### PR TITLE
BG-04: enforce realpath-safe file boundaries

### DIFF
--- a/.omo/ulw-loop/evidence/bg-04/green-backend.txt
+++ b/.omo/ulw-loop/evidence/bg-04/green-backend.txt
@@ -1,0 +1,318 @@
+$ cd packages/backend && bun test
+bun test v1.3.13 (bf2e2cec)
+
+tests\bootstrap-sample-filter.test.ts:
+(pass) isSampleSourcePathAllowed > allows the source root
+(pass) isSampleSourcePathAllowed > allows top-level sample DS files and folders
+(pass) isSampleSourcePathAllowed > blocks the uploads folder and everything inside it
+(pass) isSampleSourcePathAllowed > uses path-segment matching, not substring matching
+(pass) isSampleSourcePathAllowed > normalises Windows backslash separators
+
+tests\broker.test.ts:
+(pass) EventBroker > delivers events to all subscribers of a session
+[broker] sync listener for session s1 threw: warn: boom
+      at <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\broker.test.ts:26:17)
+      at publish (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\src\services\broker.ts:27:24)
+      at <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\broker.test.ts:31:48)
+
+(pass) EventBroker > isolates a throwing listener so siblings still receive the event
+[broker] async listener for session s1 threw: warn: async boom
+      at <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\broker.test.ts:39:17)
+      at publish (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\src\services\broker.ts:27:24)
+      at <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\broker.test.ts:43:48)
+
+(pass) EventBroker > survives an async listener that rejects [16.00ms]
+(pass) EventBroker > snapshots the listener set so unsubscribe-during-publish does not skip siblings
+(pass) EventBroker > unsubscribe stops further deliveries and cleans the empty set
+(pass) EventBroker > publishes to unrelated sessions do not cross over
+
+tests\checkpoints.test.ts:
+(pass) checkpoint path boundary > rejects a traversing turnId before touching project storage
+(pass) checkpoint snapshot / restore round-trip > snapshot excludes .meta and .attachments [62.00ms]
+(pass) checkpoint snapshot / restore round-trip > restore rewinds the project tree to the snapshot contents [94.00ms]
+(pass) checkpoint snapshot / restore round-trip > restore leaves .attachments and .meta untouched [78.00ms]
+(pass) checkpoint snapshot / restore round-trip > restore against a missing snapshot returns null [31.00ms]
+
+tests\claude-code-parser.test.ts:
+(pass) parseStreamLine — input shape tolerance > blank, non-JSON, and non-object lines yield zero events
+(pass) parseStreamLine — input shape tolerance > unknown top-level type is silently skipped (forward-compat)
+(pass) parseStreamLine — assistant content blocks > text block becomes a single chat.delta with the text payload
+(pass) parseStreamLine — assistant content blocks > empty text content is dropped (no zero-length deltas)
+(pass) parseStreamLine — assistant content blocks > thinking block becomes chat.thinking
+(pass) parseStreamLine — assistant content blocks > tool_use registers the tool name and emits tool.started
+(pass) parseStreamLine — assistant content blocks > multiple content blocks emit in order
+(pass) parseStreamLine — tool_result correlation > looks up the tool name from a prior tool_use
+(pass) parseStreamLine — tool_result correlation > falls back to 'tool' when no prior tool_use was seen
+(pass) parseStreamLine — tool_result correlation > is_error: true flips ok=false but still emits tool.finished
+(pass) parseStreamLine — file.changed emission > Write tool result emits file.changed with action=created and a project-relative path
+(pass) parseStreamLine — file.changed emission > Edit tool result uses action=edited
+(pass) parseStreamLine — file.changed emission > file.changed is suppressed when the path resolves outside the project tree
+(pass) parseStreamLine — file.changed emission > file.changed is suppressed when tool_result is_error
+(pass) parseStreamLine — result line > emits usage.delta + chat.message_end + status.idle on success [16.00ms]
+(pass) parseStreamLine — result line > flips status.idle to stopReason=error when subtype is an error
+(pass) parseStreamLine — result line > non-numeric usage values fall back to 0
+
+tests\codex-parser.test.ts:
+(pass) parseCodexLine — structured path > tool_start becomes tool.started and registers the tool name
+(pass) parseCodexLine — structured path > tool_result looks up the registered tool name when the line omits it
+(pass) parseCodexLine — structured path > tool_result respects is_error / ok:false as failure signals
+(pass) parseCodexLine — structured path > file_change maps to file.changed with a normalized action
+(pass) parseCodexLine — structured path > usage maps through and preserves cached when present [15.00ms]
+(pass) parseCodexLine — structured path > done normalizes stopReason and falls back to end_turn
+(pass) parseCodexLine — structured path > text / message map to chat.delta
+(pass) parseCodexLine — structured path > thinking maps to chat.thinking
+(pass) parseCodexLine — structured path > error maps to status.error with recoverable default true
+(pass) parseCodexLine — raw-mode fallthrough > non-JSON text falls through to chat.delta byte-for-byte
+(pass) parseCodexLine — raw-mode fallthrough > JSON with an unknown type also falls through
+(pass) parseCodexLine — raw-mode fallthrough > JSON without a type field falls through
+(pass) parseCodexLine — raw-mode fallthrough > malformed JSON falls through instead of throwing
+(pass) parseCodexLine — raw-mode fallthrough > empty / whitespace-only lines are dropped
+
+tests\design-system-extract.test.ts:
+(pass) inferSourceType > treats git-style URLs as github source
+(pass) inferSourceType > treats regular web pages as website source
+(pass) inferUploadKind > detects supported upload kinds by file extension
+(pass) inferUploadKind > falls back to content type when extension is ambiguous
+(pass) extractCssCustomProperties > extracts custom properties from css blocks
+(pass) design system token css editing > updates existing custom properties and appends missing ones inside :root
+(pass) design system token css editing > creates a :root block when custom properties are written to an empty file
+(pass) design system token css editing > ensures token css imports local font faces exactly once
+(pass) design system token css editing > preserves @charset before inserting font imports
+(pass) extractCssStyleSignals > extracts colors, font sizes, spacing, radii, and shadows from plain css declarations
+(pass) extractHtmlComponentSamples > extracts representative text samples for common component buckets [47.00ms]
+(pass) contentTypeForDesignSystemFile > maps common preview file extensions
+(pass) isUnsafeImportHostname > blocks localhost and private network literals
+(pass) isUnsafeImportHostname > allows public hostnames and public ip literals
+(pass) normalizeUploadStringList > trims + collapses whitespace and dedupes by normalized value
+(pass) normalizeUploadStringList > skips non-strings and respects the cap
+(pass) normalizeUploadStringList > returns [] when the input is not an array
+(pass) normalizeUploadPages > coerces the common good-shape input
+(pass) normalizeUploadPages > assigns sequential indices when missing / non-numeric
+(pass) normalizeUploadPages > caps at MAX_UPLOAD_UI_KIT_PAGES (8)
+(pass) normalizeUploadPages > drops non-object entries and non-array inputs
+(pass) readUploadManifest > parses + normalizes a valid pptx manifest [31.00ms]
+(pass) readUploadManifest > throws when the file is missing
+(pass) readUploadManifest > throws on invalid JSON + invalid kind [63.00ms]
+(pass) readUploadManifest > defensively defaults missing array fields to [] [31.00ms]
+
+tests\examples-tab-filter.test.ts:
+(pass) isExampleProject > admits the seeded prototype tutorial
+(pass) isExampleProject > admits the seeded slide-deck tutorial
+(pass) isExampleProject > admits all four prompt-sample projects regardless of typed surface
+(pass) isExampleProject > admits placeholder template fixtures (from_template)
+(pass) isExampleProject > rejects regular user projects, even ones with brand-y names
+(pass) isExampleProject > rejects names that merely contain the tag string mid-sentence
+
+tests\export-gc.test.ts:
+(pass) pruneOldExports > removes succeeded jobs older than the retention window [15.00ms]
+(pass) pruneOldExports > skips and warns about an output_path outside the exports root
+(pass) pruneOldExports > dryRun reports the work but does not unlink or delete anything
+(pass) pruneOldExports > missing files still drop the DB row so dead download URLs do not linger
+(pass) pruneOldExports > respects a custom retention window
+(pass) pruneOldExports > never asks for failed / pending / running jobs (listStale filters) [16.00ms]
+
+tests\export-handoff.test.ts:
+(pass) buildHandoffSpec > wraps extracted pages with project + design-system metadata
+(pass) buildHandoffSpec > null-tolerant design-system metadata
+(pass) buildHandoffSpec > generated_at defaults to now when omitted [15.00ms]
+(pass) copyProjectIntoBundle > mirrors the entire project tree into source/, minus .meta and .attachments [94.00ms]
+(pass) copyProjectIntoBundle > works when source has zero entries (empty project) [16.00ms]
+(pass) EXTRACT_HANDOFF_FN > is an IIFE-compatible function source that references the required API
+
+tests\export-naming.test.ts:
+(pass) formatExtension / formatMime > PDF maps to application/pdf and .pdf
+(pass) formatExtension / formatMime > PPTX maps to the PowerPoint MIME and .pptx
+(pass) formatExtension / formatMime > html_zip and handoff both map to .zip / application/zip
+(pass) slugifyProjectName > turns spaces into hyphens and preserves case-insensitive readability
+(pass) slugifyProjectName > strips path and reserved Windows characters
+(pass) slugifyProjectName > collapses runs of whitespace and dashes into a single dash
+(pass) slugifyProjectName > preserves Unicode (Korean / Japanese / accented) project names
+(pass) slugifyProjectName > falls back to 'export' when nothing slug-worthy survives
+(pass) slugifyProjectName > truncates absurdly long names to a sane length
+(pass) buildDownloadFilename > composes <slug>-<tag>-<date>.<ext> for each format
+(pass) buildDownloadFilename > uses the creation timestamp when completed_at is missing
+(pass) buildDownloadFilename > falls back to 'export' when project name is missing
+(pass) buildContentDisposition > emits both ASCII filename and RFC 5987 filename* parameters
+(pass) buildContentDisposition > scrubs non-ASCII from the legacy filename and percent-encodes filename*
+(pass) buildContentDisposition > removes inner double-quotes from the ASCII filename to keep the header valid
+
+tests\export-options.test.ts:
+(pass) pdfDimensionsForPaper > a4 maps to the named A4 format with no explicit dimensions
+(pass) pdfDimensionsForPaper > letter maps to the named Letter format
+(pass) pdfDimensionsForPaper > widescreen-16x9 emits explicit width/height instead of a named format
+(pass) pptxLayoutForSize > 16x9 is the 10in × 5.625in widescreen default
+(pass) pptxLayoutForSize > 4x3 is the 10in × 7.5in classic PowerPoint layout
+(pass) pptxLayoutForSize > layout names are unique so PptxGenJS does not collide between exports
+
+tests\export-pdf.test.ts:
+(pass) PDF_PRINT_CSS > overrides single-slide gate and hides the nav
+(pass) PDF_PRINT_CSS > breaks a page between slides except after the last
+(pass) PDF_PRINT_CSS > does not declare an @page rule (page size is driven by the paper option)
+
+tests\export-pptx.test.ts:
+(pass) writePptx > emits one slide per extract with editable text entries [125.00ms]
+(pass) writePptx > handles an empty extract without throwing [62.00ms]
+(pass) writePptx > skips text boxes whose computed dimensions are zero or negative [47.00ms]
+(pass) EXTRACT_SLIDES_FN > is a valid JS function expression starting with () =>
+
+tests\exports.test.ts:
+(pass) export path boundary > rejects an entrypoint outside the staged project [31.00ms]
+(pass) tutorial HTML contracts > prototype tutorial is a standalone page with editable anchors
+(pass) tutorial HTML contracts > deck tutorial exposes at least 3 [data-slide] sections with editable text
+(pass) tutorial HTML contracts > tutorial names carry the reserved prefix so seedTutorialsOnce can match
+[exports.test] skipping PDF smoke — set BG_EXPORT_SMOKE=1 to run
+(pass) deck export smoke (chromium-gated) > PDF: renderDeckToPdf produces a non-empty .pdf
+[exports.test] skipping PPTX smoke — set BG_EXPORT_SMOKE=1 to run
+(pass) deck export smoke (chromium-gated) > PPTX: renderDeckToPptx produces a non-empty .pptx
+
+tests\figma-client.test.ts:
+(pass) parseFigmaUrl > extracts the file key from /file/<key>/<title> URLs [16.00ms]
+(pass) parseFigmaUrl > accepts the newer /design/<key>/<title> URL form
+(pass) parseFigmaUrl > accepts the prototype /proto/<key> URL form
+(pass) parseFigmaUrl > treats a bare alphanumeric token as an already-extracted key
+(pass) parseFigmaUrl > rejects non-figma hosts
+(pass) parseFigmaUrl > rejects URLs with no file segment
+(pass) parseFigmaUrl > rejects empty input
+(pass) slugifyStyleName > kebabs nested style names with slashes
+(pass) slugifyStyleName > collapses runs of separators and trims edges
+(pass) slugifyStyleName > strips non-alphanumeric runs
+(pass) pickFirstFillHex > converts the first visible solid SOLID paint to a 6-digit hex
+(pass) pickFirstFillHex > skips invisible fills
+(pass) pickFirstFillHex > ignores non-SOLID paints (gradients, images, etc.)
+(pass) pickFirstFillHex > returns null on missing or empty fills
+(pass) extractFigmaTokens > turns FILL styles into --color-<slug> entries
+(pass) extractFigmaTokens > turns TEXT styles into typography entries and unique font-family list
+(pass) extractFigmaTokens > ignores EFFECT / GRID style types at MVP
+(pass) extractFigmaTokens > skips styles whose node was not resolved (defensive)
+
+tests\file-change-broker.test.ts:
+(pass) file-change-broker dedupe > path emits when nothing has been noted
+(pass) file-change-broker dedupe > path suppressed after a note, unchanged by unrelated paths
+(pass) file-change-broker dedupe > note normalises Windows-style separators to POSIX
+(pass) file-change-broker dedupe > different projects do not cross-contaminate
+
+tests\file-patch.test.ts:
+(pass) applyHtmlNodePatch > rewrites text of the targeted node only
+(pass) applyHtmlNodePatch > escapes HTML special characters in text
+(pass) applyHtmlNodePatch > escapes quotes too so a future caller cannot inject into an attribute
+(pass) applyHtmlNodePatch > blocks the classic xss payload via raw event handler injection
+(pass) applyHtmlNodePatch > sets, updates, and removes attributes [16.00ms]
+(pass) applyHtmlNodePatch > silently ignores edits to the data-bg-node-id anchor
+(pass) applyHtmlNodePatch > throws FilePatchError(node_not_found) when the anchor is missing
+(pass) applyHtmlNodePatch > no-op when neither text nor attributes are provided
+(pass) applyHtmlNodePatch > styles: adds inline style to a bare element
+(pass) applyHtmlNodePatch > styles: merges into existing style without losing siblings
+(pass) applyHtmlNodePatch > styles: null removes a property; removing all drops the attribute
+(pass) applyHtmlNodePatch > styles: coexist with attributes patch in the same call
+(pass) parseInlineStyle / serializeInlineStyle > round-trips key/value pairs
+(pass) parseInlineStyle / serializeInlineStyle > parse tolerates trailing semicolons and whitespace
+(pass) parseInlineStyle / serializeInlineStyle > parse ignores declarations without a colon
+(pass) parseInlineStyle / serializeInlineStyle > serialize empty map yields empty string
+(pass) parseInlineStyle / serializeInlineStyle > does not split on `;` inside parens — url(), linear-gradient()
+(pass) parseInlineStyle / serializeInlineStyle > does not split on `,` inside parens — gradient stops, var() fallbacks
+(pass) parseInlineStyle / serializeInlineStyle > respects single-quoted and double-quoted strings inside values
+(pass) parseInlineStyle / serializeInlineStyle > nested parens do not corrupt depth tracking
+(pass) file undo store > getFileUndoState returns can_undo:false on an unseen file
+(pass) file undo store > the test-only reset helper is idempotent
+
+tests\path-boundary.test.ts:
+(pass) resolveWithin > resolves a contained existing path
+(pass) resolveWithin > rejects parent traversal [16.00ms]
+(pass) resolveWithin > rejects an absolute path segment
+(pass) resolveWithin > rejects backslash traversal on Windows [16.00ms]
+(pass) resolveWithin > allows a not-yet-existing leaf below an existing root
+(pass) resolveWithin > rejects an escape through a junction or symlink [15.00ms]
+(pass) assertSafeName > returns a safe single path component
+(pass) assertSafeName > rejects unsafe component ""
+(pass) assertSafeName > rejects unsafe component ".."
+(pass) assertSafeName > rejects unsafe component "../victim"
+(pass) assertSafeName > rejects unsafe component "..\\victim"
+(pass) assertSafeName > rejects unsafe component "C:relative"
+(pass) assertSafeName > rejects unsafe component "NUL"
+
+tests\prompt-builder.test.ts:
+(pass) buildPrompt > emits project + delivery + request sections for prototype [15.00ms]
+(pass) buildPrompt > injects prototype skill for prototype projects
+(pass) buildPrompt > injects slide deck skill for slide_deck projects
+(pass) buildPrompt > compact mode references stable context instead of inlining full skills
+(pass) buildPrompt > injects deck structure summary when entrypoint is a real deck.html [141.00ms]
+(pass) buildPrompt > injects prototype structure summary when entrypoint is a real index.html
+(pass) buildPrompt > skips structure summary gracefully when the entrypoint file does not exist yet
+(pass) buildPrompt > serializes open comments with slide scope for deck pins
+(pass) buildPrompt > omits attachments section when there are none [16.00ms]
+(pass) buildPrompt > lists attachments verbatim
+(pass) buildPrompt > inlines compact summaries for pptx/pdf attachments and points Read to extracted text [15.00ms]
+
+tests\prompt-sample-lookup.test.ts:
+(pass) getPromptSampleBySlug > returns every shipped prompt-sample slug [16.00ms]
+(pass) getPromptSampleBySlug > returns null for an unknown slug
+
+tests\python-health.test.ts:
+(pass) parsePythonVersion > extracts the first non-empty line verbatim
+(pass) parsePythonVersion > returns null on an empty probe
+(pass) parsePythonVersion > falls back to the raw first line even for unusual output
+(pass) parsePypdfVersion > accepts standard dotted versions
+(pass) parsePypdfVersion > rejects non-version output
+
+tests\request-authority.test.ts:
+(pass) request authority > allows public health only on the configured authority [31.00ms]
+(pass) request authority > rejects absent, wrong, and previous-launch capabilities without mutation
+(pass) request authority > rejects hostile origins and simple browser mutations without side effects
+(pass) request authority > allows an authorized same-origin mutation [16.00ms]
+(pass) request authority > allows private GET and SSE channels through a launch-scoped cookie
+(pass) request authority > bootstraps only the packaged app or explicit Vite authority
+(pass) request authority > accepts a browser same-origin bootstrap without an Origin header
+(pass) request authority > answers only trusted preflights
+(pass) request authority > guards the real route tree before routing [31.00ms]
+
+tests\seeded-project-html.test.ts:
+(pass) SEEDED_PROJECT_HTML > covers every non-archived fixture project
+(pass) SEEDED_PROJECT_HTML > does not waste bytes on archived fixtures
+(pass) SEEDED_PROJECT_HTML > decks include the deck-stage runtime script tag
+(pass) SEEDED_PROJECT_HTML > non-deck artifacts do not falsely declare deck structure
+(pass) SEEDED_PROJECT_HTML > every artifact starts with a doctype and a viewport meta [15.00ms]
+(pass) SEEDED_PROJECT_HTML > every artifact carries a brand statement that it is a sample
+
+tests\structure-extractor.test.ts:
+(pass) summarizeDeckHtml > renders slide map with id, classes, layout, and snippet [16.00ms]
+(pass) summarizeDeckHtml > includes style block stats and CSS variable list
+(pass) summarizeDeckHtml > returns null when the file is missing
+(pass) summarizeDeckHtml > flags empty / non-conforming deck instead of crashing [16.00ms]
+(pass) summarizeDeckHtml > output stays compact for a deck with many slides [62.00ms]
+(pass) summarizePrototypeHtml > lists data-section landmarks with text snippets
+(pass) summarizePrototypeHtml > falls back to semantic landmarks when data-section is absent [16.00ms]
+
+tests\tool-decision-channel.test.ts:
+(pass) tool-decision channel contract > decisions submitted before onDecision registers are queued, then drained in order [15.00ms]
+(pass) tool-decision channel contract > decisions submitted after register go straight through
+(pass) tool-decision channel contract > unsubscribe clears the handler so the next submit queues again
+(pass) tool-decision channel contract > throwing handler requeues the decision for the next registrant
+
+tests\upload-component-detect.test.ts:
+(pass) detectComponentSamples — English > detects CTA buttons from misc lines
+(pass) detectComponentSamples — English > detects form labels
+(pass) detectComponentSamples — English > detects status badges
+(pass) detectComponentSamples — Korean > matches Korean CTA verbs [16.00ms]
+(pass) detectComponentSamples — Korean > matches Korean form labels
+(pass) detectComponentSamples — Korean > matches Korean status words
+(pass) detectComponentSamples — shape guarantees > dedupes + caps each bucket at 6
+(pass) detectComponentSamples — shape guarantees > empty input returns empty buckets
+(pass) detectComponentSamples — shape guarantees > table hint picks up tab-delimited + quarter tags
+
+tests\upload-extract-smoke.test.ts:
+[upload-extract.smoke] skipping — set BG_UPLOAD_SMOKE=1 to run
+(pass) upload extractor end-to-end (BG_UPLOAD_SMOKE=1) > parses a generated pptx through the Python extractor
+(pass) upload extractor end-to-end (BG_UPLOAD_SMOKE=1) > flags invalid-kind manifests produced by a regressed extractor
+
+tests\zip.test.ts:
+(pass) zipDirectory > packs every file into a real, JSZip-readable .zip [109.00ms]
+(pass) zipDirectory > uses forward-slash separators in zip entry paths on every platform [47.00ms]
+(pass) zipDirectory > an empty source directory still yields a valid empty .zip [47.00ms]
+(pass) zipDirectory > does not include the source directory itself as a path prefix [31.00ms]
+
+ 240 pass
+ 0 fail
+ 637 expect() calls
+Ran 240 tests across 28 files. [4.18s]
+
+EXIT_CODE=0

--- a/.omo/ulw-loop/evidence/bg-04/red.txt
+++ b/.omo/ulw-loop/evidence/bg-04/red.txt
@@ -1,0 +1,17 @@
+$ cd packages/backend && bun test tests/path-boundary.test.ts
+bun test v1.3.13 (bf2e2cec)
+
+tests\path-boundary.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+error: Cannot find module '../src/security/path-boundary' from 'C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\path-boundary.test.ts'
+-------------------------------
+
+
+ 0 pass
+ 1 fail
+ 1 error
+Ran 1 test across 1 file. [118.00ms]
+
+EXIT_CODE=1

--- a/.omo/ulw-loop/evidence/bg-04/slice2/green.txt
+++ b/.omo/ulw-loop/evidence/bg-04/slice2/green.txt
@@ -1,0 +1,330 @@
+bun test v1.3.13 (bf2e2cec)
+
+tests\bootstrap-sample-filter.test.ts:
+(pass) isSampleSourcePathAllowed > allows the source root
+(pass) isSampleSourcePathAllowed > allows top-level sample DS files and folders
+(pass) isSampleSourcePathAllowed > blocks the uploads folder and everything inside it
+(pass) isSampleSourcePathAllowed > uses path-segment matching, not substring matching
+(pass) isSampleSourcePathAllowed > normalises Windows backslash separators
+
+tests\broker.test.ts:
+(pass) EventBroker > delivers events to all subscribers of a session [16.00ms]
+[broker] sync listener for session s1 threw: warn: boom
+      at <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\broker.test.ts:26:17)
+      at publish (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\src\services\broker.ts:27:24)
+      at <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\broker.test.ts:31:48)
+
+(pass) EventBroker > isolates a throwing listener so siblings still receive the event
+[broker] async listener for session s1 threw: warn: async boom
+      at <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\broker.test.ts:39:17)
+      at publish (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\src\services\broker.ts:27:24)
+      at <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\broker.test.ts:43:48)
+
+(pass) EventBroker > survives an async listener that rejects [16.00ms]
+(pass) EventBroker > snapshots the listener set so unsubscribe-during-publish does not skip siblings
+(pass) EventBroker > unsubscribe stops further deliveries and cleans the empty set
+(pass) EventBroker > publishes to unrelated sessions do not cross over
+
+tests\checkpoints.test.ts:
+(pass) checkpoint path boundary > rejects a traversing turnId before touching project storage
+(pass) checkpoint snapshot / restore round-trip > snapshot excludes .meta and .attachments [78.00ms]
+(pass) checkpoint snapshot / restore round-trip > restore rewinds the project tree to the snapshot contents [63.00ms]
+(pass) checkpoint snapshot / restore round-trip > restore leaves .attachments and .meta untouched [62.00ms]
+(pass) checkpoint snapshot / restore round-trip > restore against a missing snapshot returns null [16.00ms]
+
+tests\claude-code-parser.test.ts:
+(pass) parseStreamLine — input shape tolerance > blank, non-JSON, and non-object lines yield zero events
+(pass) parseStreamLine — input shape tolerance > unknown top-level type is silently skipped (forward-compat)
+(pass) parseStreamLine — assistant content blocks > text block becomes a single chat.delta with the text payload
+(pass) parseStreamLine — assistant content blocks > empty text content is dropped (no zero-length deltas)
+(pass) parseStreamLine — assistant content blocks > thinking block becomes chat.thinking
+(pass) parseStreamLine — assistant content blocks > tool_use registers the tool name and emits tool.started
+(pass) parseStreamLine — assistant content blocks > multiple content blocks emit in order
+(pass) parseStreamLine — tool_result correlation > looks up the tool name from a prior tool_use
+(pass) parseStreamLine — tool_result correlation > falls back to 'tool' when no prior tool_use was seen
+(pass) parseStreamLine — tool_result correlation > is_error: true flips ok=false but still emits tool.finished
+(pass) parseStreamLine — file.changed emission > Write tool result emits file.changed with action=created and a project-relative path
+(pass) parseStreamLine — file.changed emission > Edit tool result uses action=edited
+(pass) parseStreamLine — file.changed emission > file.changed is suppressed when the path resolves outside the project tree [15.00ms]
+(pass) parseStreamLine — file.changed emission > file.changed is suppressed when tool_result is_error
+(pass) parseStreamLine — result line > emits usage.delta + chat.message_end + status.idle on success
+(pass) parseStreamLine — result line > flips status.idle to stopReason=error when subtype is an error
+(pass) parseStreamLine — result line > non-numeric usage values fall back to 0
+
+tests\codex-parser.test.ts:
+(pass) parseCodexLine — structured path > tool_start becomes tool.started and registers the tool name
+(pass) parseCodexLine — structured path > tool_result looks up the registered tool name when the line omits it
+(pass) parseCodexLine — structured path > tool_result respects is_error / ok:false as failure signals
+(pass) parseCodexLine — structured path > file_change maps to file.changed with a normalized action
+(pass) parseCodexLine — structured path > usage maps through and preserves cached when present [16.00ms]
+(pass) parseCodexLine — structured path > done normalizes stopReason and falls back to end_turn
+(pass) parseCodexLine — structured path > text / message map to chat.delta
+(pass) parseCodexLine — structured path > thinking maps to chat.thinking
+(pass) parseCodexLine — structured path > error maps to status.error with recoverable default true
+(pass) parseCodexLine — raw-mode fallthrough > non-JSON text falls through to chat.delta byte-for-byte
+(pass) parseCodexLine — raw-mode fallthrough > JSON with an unknown type also falls through
+(pass) parseCodexLine — raw-mode fallthrough > JSON without a type field falls through
+(pass) parseCodexLine — raw-mode fallthrough > malformed JSON falls through instead of throwing
+(pass) parseCodexLine — raw-mode fallthrough > empty / whitespace-only lines are dropped
+
+tests\design-system-extract.test.ts:
+(pass) inferSourceType > treats git-style URLs as github source
+(pass) inferSourceType > treats regular web pages as website source
+(pass) inferUploadKind > detects supported upload kinds by file extension
+(pass) inferUploadKind > falls back to content type when extension is ambiguous
+(pass) extractCssCustomProperties > extracts custom properties from css blocks
+(pass) design system token css editing > updates existing custom properties and appends missing ones inside :root
+(pass) design system token css editing > creates a :root block when custom properties are written to an empty file
+(pass) design system token css editing > ensures token css imports local font faces exactly once
+(pass) design system token css editing > preserves @charset before inserting font imports
+(pass) extractCssStyleSignals > extracts colors, font sizes, spacing, radii, and shadows from plain css declarations
+(pass) extractHtmlComponentSamples > extracts representative text samples for common component buckets [32.00ms]
+(pass) contentTypeForDesignSystemFile > maps common preview file extensions
+(pass) isUnsafeImportHostname > blocks localhost and private network literals
+(pass) isUnsafeImportHostname > allows public hostnames and public ip literals
+(pass) normalizeUploadStringList > trims + collapses whitespace and dedupes by normalized value
+(pass) normalizeUploadStringList > skips non-strings and respects the cap
+(pass) normalizeUploadStringList > returns [] when the input is not an array
+(pass) normalizeUploadPages > coerces the common good-shape input
+(pass) normalizeUploadPages > assigns sequential indices when missing / non-numeric
+(pass) normalizeUploadPages > caps at MAX_UPLOAD_UI_KIT_PAGES (8)
+(pass) normalizeUploadPages > drops non-object entries and non-array inputs
+(pass) readUploadManifest > parses + normalizes a valid pptx manifest [31.00ms]
+(pass) readUploadManifest > throws when the file is missing
+(pass) readUploadManifest > throws on invalid JSON + invalid kind [31.00ms]
+(pass) readUploadManifest > defensively defaults missing array fields to [] [16.00ms]
+
+tests\examples-tab-filter.test.ts:
+(pass) isExampleProject > admits the seeded prototype tutorial
+(pass) isExampleProject > admits the seeded slide-deck tutorial
+(pass) isExampleProject > admits all four prompt-sample projects regardless of typed surface
+(pass) isExampleProject > admits placeholder template fixtures (from_template)
+(pass) isExampleProject > rejects regular user projects, even ones with brand-y names
+(pass) isExampleProject > rejects names that merely contain the tag string mid-sentence
+
+tests\export-gc.test.ts:
+(pass) pruneOldExports > removes succeeded jobs older than the retention window [16.00ms]
+(pass) pruneOldExports > skips and warns about an output_path outside the exports root
+(pass) pruneOldExports > dryRun reports the work but does not unlink or delete anything
+(pass) pruneOldExports > missing files still drop the DB row so dead download URLs do not linger
+(pass) pruneOldExports > respects a custom retention window
+(pass) pruneOldExports > never asks for failed / pending / running jobs (listStale filters)
+
+tests\export-handoff.test.ts:
+(pass) buildHandoffSpec > wraps extracted pages with project + design-system metadata [15.00ms]
+(pass) buildHandoffSpec > null-tolerant design-system metadata
+(pass) buildHandoffSpec > generated_at defaults to now when omitted
+(pass) copyProjectIntoBundle > mirrors the entire project tree into source/, minus .meta and .attachments [63.00ms]
+(pass) copyProjectIntoBundle > works when source has zero entries (empty project) [16.00ms]
+(pass) EXTRACT_HANDOFF_FN > is an IIFE-compatible function source that references the required API
+
+tests\export-naming.test.ts:
+(pass) formatExtension / formatMime > PDF maps to application/pdf and .pdf
+(pass) formatExtension / formatMime > PPTX maps to the PowerPoint MIME and .pptx
+(pass) formatExtension / formatMime > html_zip and handoff both map to .zip / application/zip
+(pass) slugifyProjectName > turns spaces into hyphens and preserves case-insensitive readability
+(pass) slugifyProjectName > strips path and reserved Windows characters
+(pass) slugifyProjectName > collapses runs of whitespace and dashes into a single dash
+(pass) slugifyProjectName > preserves Unicode (Korean / Japanese / accented) project names
+(pass) slugifyProjectName > falls back to 'export' when nothing slug-worthy survives
+(pass) slugifyProjectName > truncates absurdly long names to a sane length
+(pass) buildDownloadFilename > composes <slug>-<tag>-<date>.<ext> for each format
+(pass) buildDownloadFilename > uses the creation timestamp when completed_at is missing
+(pass) buildDownloadFilename > falls back to 'export' when project name is missing
+(pass) buildContentDisposition > emits both ASCII filename and RFC 5987 filename* parameters
+(pass) buildContentDisposition > scrubs non-ASCII from the legacy filename and percent-encodes filename*
+(pass) buildContentDisposition > removes inner double-quotes from the ASCII filename to keep the header valid
+
+tests\export-options.test.ts:
+(pass) pdfDimensionsForPaper > a4 maps to the named A4 format with no explicit dimensions
+(pass) pdfDimensionsForPaper > letter maps to the named Letter format
+(pass) pdfDimensionsForPaper > widescreen-16x9 emits explicit width/height instead of a named format
+(pass) pptxLayoutForSize > 16x9 is the 10in × 5.625in widescreen default
+(pass) pptxLayoutForSize > 4x3 is the 10in × 7.5in classic PowerPoint layout
+(pass) pptxLayoutForSize > layout names are unique so PptxGenJS does not collide between exports
+
+tests\export-pdf.test.ts:
+(pass) PDF_PRINT_CSS > overrides single-slide gate and hides the nav
+(pass) PDF_PRINT_CSS > breaks a page between slides except after the last
+(pass) PDF_PRINT_CSS > does not declare an @page rule (page size is driven by the paper option)
+
+tests\export-pptx.test.ts:
+(pass) writePptx > emits one slide per extract with editable text entries [79.00ms]
+(pass) writePptx > handles an empty extract without throwing [31.00ms]
+(pass) writePptx > skips text boxes whose computed dimensions are zero or negative [47.00ms]
+(pass) EXTRACT_SLIDES_FN > is a valid JS function expression starting with () =>
+
+tests\exports.test.ts:
+(pass) export path boundary > rejects an entrypoint outside the staged project [32.00ms]
+(pass) tutorial HTML contracts > prototype tutorial is a standalone page with editable anchors
+(pass) tutorial HTML contracts > deck tutorial exposes at least 3 [data-slide] sections with editable text
+(pass) tutorial HTML contracts > tutorial names carry the reserved prefix so seedTutorialsOnce can match
+[exports.test] skipping PDF smoke — set BG_EXPORT_SMOKE=1 to run
+(pass) deck export smoke (chromium-gated) > PDF: renderDeckToPdf produces a non-empty .pdf
+[exports.test] skipping PPTX smoke — set BG_EXPORT_SMOKE=1 to run
+(pass) deck export smoke (chromium-gated) > PPTX: renderDeckToPptx produces a non-empty .pptx
+
+tests\figma-client.test.ts:
+(pass) parseFigmaUrl > extracts the file key from /file/<key>/<title> URLs
+(pass) parseFigmaUrl > accepts the newer /design/<key>/<title> URL form
+(pass) parseFigmaUrl > accepts the prototype /proto/<key> URL form
+(pass) parseFigmaUrl > treats a bare alphanumeric token as an already-extracted key
+(pass) parseFigmaUrl > rejects non-figma hosts
+(pass) parseFigmaUrl > rejects URLs with no file segment
+(pass) parseFigmaUrl > rejects empty input
+(pass) slugifyStyleName > kebabs nested style names with slashes
+(pass) slugifyStyleName > collapses runs of separators and trims edges
+(pass) slugifyStyleName > strips non-alphanumeric runs
+(pass) pickFirstFillHex > converts the first visible solid SOLID paint to a 6-digit hex
+(pass) pickFirstFillHex > skips invisible fills
+(pass) pickFirstFillHex > ignores non-SOLID paints (gradients, images, etc.)
+(pass) pickFirstFillHex > returns null on missing or empty fills
+(pass) extractFigmaTokens > turns FILL styles into --color-<slug> entries
+(pass) extractFigmaTokens > turns TEXT styles into typography entries and unique font-family list
+(pass) extractFigmaTokens > ignores EFFECT / GRID style types at MVP
+(pass) extractFigmaTokens > skips styles whose node was not resolved (defensive)
+
+tests\file-change-broker.test.ts:
+(pass) file-change-broker dedupe > path emits when nothing has been noted [16.00ms]
+(pass) file-change-broker dedupe > path suppressed after a note, unchanged by unrelated paths
+(pass) file-change-broker dedupe > note normalises Windows-style separators to POSIX
+(pass) file-change-broker dedupe > different projects do not cross-contaminate
+
+tests\file-patch.test.ts:
+(pass) applyHtmlNodePatch > rewrites text of the targeted node only
+(pass) applyHtmlNodePatch > escapes HTML special characters in text
+(pass) applyHtmlNodePatch > escapes quotes too so a future caller cannot inject into an attribute
+(pass) applyHtmlNodePatch > blocks the classic xss payload via raw event handler injection
+(pass) applyHtmlNodePatch > sets, updates, and removes attributes [15.00ms]
+(pass) applyHtmlNodePatch > silently ignores edits to the data-bg-node-id anchor
+(pass) applyHtmlNodePatch > throws FilePatchError(node_not_found) when the anchor is missing
+(pass) applyHtmlNodePatch > no-op when neither text nor attributes are provided
+(pass) applyHtmlNodePatch > styles: adds inline style to a bare element
+(pass) applyHtmlNodePatch > styles: merges into existing style without losing siblings
+(pass) applyHtmlNodePatch > styles: null removes a property; removing all drops the attribute
+(pass) applyHtmlNodePatch > styles: coexist with attributes patch in the same call
+(pass) parseInlineStyle / serializeInlineStyle > round-trips key/value pairs
+(pass) parseInlineStyle / serializeInlineStyle > parse tolerates trailing semicolons and whitespace
+(pass) parseInlineStyle / serializeInlineStyle > parse ignores declarations without a colon
+(pass) parseInlineStyle / serializeInlineStyle > serialize empty map yields empty string
+(pass) parseInlineStyle / serializeInlineStyle > does not split on `;` inside parens — url(), linear-gradient()
+(pass) parseInlineStyle / serializeInlineStyle > does not split on `,` inside parens — gradient stops, var() fallbacks
+(pass) parseInlineStyle / serializeInlineStyle > respects single-quoted and double-quoted strings inside values
+(pass) parseInlineStyle / serializeInlineStyle > nested parens do not corrupt depth tracking
+(pass) file undo store > getFileUndoState returns can_undo:false on an unseen file
+(pass) file undo store > the test-only reset helper is idempotent
+
+tests\path-boundary.test.ts:
+(pass) resolveWithin > resolves a contained existing path
+(pass) resolveWithin > rejects parent traversal
+(pass) resolveWithin > rejects an absolute path segment
+(pass) resolveWithin > rejects backslash traversal on Windows [16.00ms]
+(pass) resolveWithin > allows a not-yet-existing leaf below an existing root
+(pass) resolveWithin > rejects an escape through a junction or symlink
+(pass) assertSafeName > returns a safe single path component
+(pass) assertSafeName > rejects unsafe component ""
+(pass) assertSafeName > rejects unsafe component ".."
+(pass) assertSafeName > rejects unsafe component "../victim"
+(pass) assertSafeName > rejects unsafe component "..\\victim"
+(pass) assertSafeName > rejects unsafe component "C:relative"
+(pass) assertSafeName > rejects unsafe component "NUL"
+
+tests\prompt-builder.test.ts:
+(pass) buildPrompt > emits project + delivery + request sections for prototype
+(pass) buildPrompt > injects prototype skill for prototype projects
+(pass) buildPrompt > injects slide deck skill for slide_deck projects [16.00ms]
+(pass) buildPrompt > compact mode references stable context instead of inlining full skills
+(pass) buildPrompt > injects deck structure summary when entrypoint is a real deck.html [62.00ms]
+(pass) buildPrompt > injects prototype structure summary when entrypoint is a real index.html [32.00ms]
+(pass) buildPrompt > skips structure summary gracefully when the entrypoint file does not exist yet
+(pass) buildPrompt > serializes open comments with slide scope for deck pins
+(pass) buildPrompt > omits attachments section when there are none
+(pass) buildPrompt > lists attachments verbatim
+(pass) buildPrompt > inlines compact summaries for pptx/pdf attachments and points Read to extracted text [31.00ms]
+
+tests\prompt-sample-lookup.test.ts:
+(pass) getPromptSampleBySlug > returns every shipped prompt-sample slug
+(pass) getPromptSampleBySlug > returns null for an unknown slug
+
+tests\python-health.test.ts:
+(pass) parsePythonVersion > extracts the first non-empty line verbatim
+(pass) parsePythonVersion > returns null on an empty probe
+(pass) parsePythonVersion > falls back to the raw first line even for unusual output
+(pass) parsePypdfVersion > accepts standard dotted versions
+(pass) parsePypdfVersion > rejects non-version output
+
+tests\request-authority.test.ts:
+(pass) request authority > allows public health only on the configured authority [16.00ms]
+(pass) request authority > rejects absent, wrong, and previous-launch capabilities without mutation
+(pass) request authority > rejects hostile origins and simple browser mutations without side effects
+(pass) request authority > allows an authorized same-origin mutation
+(pass) request authority > allows private GET and SSE channels through a launch-scoped cookie
+(pass) request authority > bootstraps only the packaged app or explicit Vite authority
+(pass) request authority > accepts a browser same-origin bootstrap without an Origin header
+(pass) request authority > answers only trusted preflights
+(pass) request authority > guards the real route tree before routing
+
+tests\seeded-project-html.test.ts:
+(pass) SEEDED_PROJECT_HTML > covers every non-archived fixture project [15.00ms]
+(pass) SEEDED_PROJECT_HTML > does not waste bytes on archived fixtures
+(pass) SEEDED_PROJECT_HTML > decks include the deck-stage runtime script tag
+(pass) SEEDED_PROJECT_HTML > non-deck artifacts do not falsely declare deck structure
+(pass) SEEDED_PROJECT_HTML > every artifact starts with a doctype and a viewport meta
+(pass) SEEDED_PROJECT_HTML > every artifact carries a brand statement that it is a sample
+
+tests\serve-path-boundary.test.ts:
+(pass) project file and draw services > reject traversal, backslash traversal, absolute paths, and junction escapes [46.00ms]
+(pass) project file and draw services > rejects draw junction escapes while allowing missing leaves through a symlinked project root [32.00ms]
+(pass) project file and draw services > does not index a symlink whose target leaves the project [31.00ms]
+(pass) file patch service > does not patch HTML through a junction outside the project [16.00ms]
+(pass) file patch service > revalidates containment before undoing a prior patch [31.00ms]
+[fs] 404 resolve failed: projectId=bg04-project-11612-6 relPath="linked/secret.txt"
+(pass) serve and deletion routes > rejects project file and draw junction escapes at HTTP sinks [47.00ms]
+(pass) serve and deletion routes > does not serve an export output_path outside the managed exports root [31.00ms]
+(pass) serve and deletion routes > does not recursively delete a project path outside the managed projects root [16.00ms]
+(pass) serve and deletion routes > does not recursively delete a design-system path outside the managed systems root [15.00ms]
+(pass) serve and deletion routes > does not serve a design-system file through an escaping junction [16.00ms]
+(pass) serve and deletion routes > does not serve a static asset through an escaping junction [15.00ms]
+(pass) attachments service > rejects a symlinked .attachments directory before writing any upload [16.00ms]
+
+tests\structure-extractor.test.ts:
+(pass) summarizeDeckHtml > renders slide map with id, classes, layout, and snippet [15.00ms]
+(pass) summarizeDeckHtml > includes style block stats and CSS variable list
+(pass) summarizeDeckHtml > returns null when the file is missing
+(pass) summarizeDeckHtml > flags empty / non-conforming deck instead of crashing
+(pass) summarizeDeckHtml > output stays compact for a deck with many slides [47.00ms]
+(pass) summarizePrototypeHtml > lists data-section landmarks with text snippets
+(pass) summarizePrototypeHtml > falls back to semantic landmarks when data-section is absent [16.00ms]
+
+tests\tool-decision-channel.test.ts:
+(pass) tool-decision channel contract > decisions submitted before onDecision registers are queued, then drained in order
+(pass) tool-decision channel contract > decisions submitted after register go straight through
+(pass) tool-decision channel contract > unsubscribe clears the handler so the next submit queues again
+(pass) tool-decision channel contract > throwing handler requeues the decision for the next registrant
+
+tests\upload-component-detect.test.ts:
+(pass) detectComponentSamples — English > detects CTA buttons from misc lines
+(pass) detectComponentSamples — English > detects form labels
+(pass) detectComponentSamples — English > detects status badges
+(pass) detectComponentSamples — Korean > matches Korean CTA verbs
+(pass) detectComponentSamples — Korean > matches Korean form labels
+(pass) detectComponentSamples — Korean > matches Korean status words
+(pass) detectComponentSamples — shape guarantees > dedupes + caps each bucket at 6
+(pass) detectComponentSamples — shape guarantees > empty input returns empty buckets
+(pass) detectComponentSamples — shape guarantees > table hint picks up tab-delimited + quarter tags
+
+tests\upload-extract-smoke.test.ts:
+[upload-extract.smoke] skipping — set BG_UPLOAD_SMOKE=1 to run
+(pass) upload extractor end-to-end (BG_UPLOAD_SMOKE=1) > parses a generated pptx through the Python extractor
+(pass) upload extractor end-to-end (BG_UPLOAD_SMOKE=1) > flags invalid-kind manifests produced by a regressed extractor
+
+tests\zip.test.ts:
+(pass) zipDirectory > packs every file into a real, JSZip-readable .zip [78.00ms]
+(pass) zipDirectory > uses forward-slash separators in zip entry paths on every platform [31.00ms]
+(pass) zipDirectory > an empty source directory still yields a valid empty .zip [32.00ms]
+(pass) zipDirectory > does not include the source directory itself as a path prefix [15.00ms]
+
+ 252 pass
+ 0 fail
+ 660 expect() calls
+Ran 252 tests across 29 files. [3.78s]

--- a/.omo/ulw-loop/evidence/bg-04/slice2/red.txt
+++ b/.omo/ulw-loop/evidence/bg-04/slice2/red.txt
@@ -1,0 +1,214 @@
+bun test v1.3.13 (bf2e2cec)
+
+tests\serve-path-boundary.test.ts:
+154 |       "../secret.txt",
+155 |       "..\\secret.txt",
+156 |       path.join(outside, "secret.txt"),
+157 |       "linked/secret.txt",
+158 |     ]) {
+159 |       expect(await resolveProjectFile(projectId, hostile)).toBeNull();
+                                                                 ^
+error: expect(received).toBeNull()
+
+Received: {
+  project: {
+    id: "bg04-project-28624-1",
+    name: "bg04-project-28624-1",
+    type: "prototype",
+    design_system_id: null,
+    design_system_name: null,
+    thumbnail_path: null,
+    updated_at: 1786675283373,
+    archived_at: null,
+    dir_path: "C:\\Users\\lg\\AppData\\Local\\Temp\\bg04-project-qKhyPo",
+    entrypoint: "index.html",
+    backend_id: "claude-code",
+    options_json: null,
+  },
+  relPath: "linked/secret.txt",
+  absolutePath: "C:\\Users\\lg\\AppData\\Local\\Temp\\bg04-project-qKhyPo\\linked\\secret.txt",
+}
+
+      at <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\serve-path-boundary.test.ts:159:60)
+(fail) project file and draw services > reject traversal, backslash traversal, absolute paths, and junction escapes [32.00ms]
+168 |     const outside = await temp("bg04-draw-outside-");
+169 |     await mkdir(path.join(realProject, ".meta", "draws"), { recursive: true });
+170 |     await makeDirLink(outside, path.join(realProject, ".meta", "draws", "linked"));
+171 |     const projectId = insertProject(projectLink);
+172 | 
+173 |     expect(await resolveDrawFile(projectId, "linked/note")).toBeNull();
+                                                                  ^
+error: expect(received).toBeNull()
+
+Received: {
+  project: {
+    id: "bg04-project-28624-2",
+    name: "bg04-project-28624-2",
+    type: "prototype",
+    design_system_id: null,
+    design_system_name: null,
+    thumbnail_path: null,
+    updated_at: 1786675283415,
+    archived_at: null,
+    dir_path: "C:\\Users\\lg\\AppData\\Local\\Temp\\bg04-project-link-a7I0AM\\project",
+    entrypoint: "index.html",
+    backend_id: "claude-code",
+    options_json: null,
+  },
+  relPath: "linked/note",
+  absolutePath: "C:\\Users\\lg\\AppData\\Local\\Temp\\bg04-project-link-a7I0AM\\project\\.meta\\draws\\linked\\note.svg",
+  parentDir: "C:\\Users\\lg\\AppData\\Local\\Temp\\bg04-project-link-a7I0AM\\project\\.meta\\draws\\linked",
+}
+
+      at <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\serve-path-boundary.test.ts:173:61)
+(fail) project file and draw services > rejects draw junction escapes while allowing missing leaves through a symlinked project root [31.00ms]
+181 |     await writeFile(path.join(outside, "secret.txt"), "secret", "utf8");
+182 |     await makeDirLink(outside, path.join(root, "linked"));
+183 |     const projectId = insertProject(root);
+184 | 
+185 |     const files = await indexProjectFiles(projectId);
+186 |     expect(files?.some((file) => file.rel_path.startsWith("linked"))).toBe(false);
+                                                                            ^
+error: expect(received).toBe(expected)
+
+Expected: false
+Received: true
+
+      at <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\serve-path-boundary.test.ts:186:71)
+(fail) project file and draw services > does not index a symlink whose target leaves the project [15.00ms]
+201 |     await expect(
+202 |       patchHtmlNode(projectId, "linked/page.html", {
+203 |         node_bg_id: "title",
+204 |         text: "pwned",
+205 |       }),
+206 |     ).rejects.toMatchObject({ code: "file_not_found" } satisfies Partial<FilePatchError>);
+                    ^
+error: 
+
+Expected promise that rejects
+Received promise that resolved: Promise { <resolved> }
+
+      at <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\serve-path-boundary.test.ts:206:15)
+(fail) file patch service > does not patch HTML through a junction outside the project [47.00ms]
+222 |       text: "inside patch",
+223 |     });
+224 |     await rm(link, { recursive: true, force: true });
+225 |     await makeDirLink(outside, link);
+226 | 
+227 |     expect(await undoLastFilePatch(projectId, "linked/page.html")).toBeNull();
+                                                                         ^
+error: expect(received).toBeNull()
+
+Received: {
+  absolutePath: "C:\\Users\\lg\\AppData\\Local\\Temp\\bg04-undo-project-kv4qho\\linked\\page.html",
+  updatedAt: 1786675283523,
+}
+
+      at <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\serve-path-boundary.test.ts:227:68)
+(fail) file patch service > revalidates containment before undoing a prior patch [32.00ms]
+[fs] 200 serving: C:\Users\lg\AppData\Local\Temp\bg04-route-project-8ldzSm\linked\secret.txt
+239 |     await mkdir(path.join(root, ".meta", "draws"), { recursive: true });
+240 |     await makeDirLink(outside, path.join(root, ".meta", "draws", "linked"));
+241 |     const projectId = insertProject(root);
+242 |     const app = createApp();
+243 | 
+244 |     expect((await app.request(`/api/projects/${projectId}/fs/linked/secret.txt`)).status).toBe(404);
+                                                                                                ^
+error: expect(received).toBe(expected)
+
+Expected: 404
+Received: 200
+
+      at <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\serve-path-boundary.test.ts:244:91)
+(fail) serve and deletion routes > rejects project file and draw junction escapes at HTTP sinks [31.00ms]
+260 |     await writeFile(outsideFile, "secret", "utf8");
+261 |     const projectId = insertProject(root);
+262 |     const exportId = insertExport(projectId, outsideFile);
+263 | 
+264 |     const response = await createApp().request(`/api/exports/${exportId}/download`);
+265 |     expect(response.status).toBe(404);
+                                  ^
+error: expect(received).toBe(expected)
+
+Expected: 404
+Received: 200
+
+      at <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\serve-path-boundary.test.ts:265:29)
+(fail) serve and deletion routes > does not serve an export output_path outside the managed exports root [47.00ms]
+270 |     await writeFile(path.join(outside, "victim.txt"), "keep", "utf8");
+271 |     const projectId = insertProject(outside);
+272 | 
+273 |     const response = await createApp().request(`/api/projects/${projectId}`, { method: "DELETE" });
+274 |     expect(response.status).toBe(204);
+275 |     expect(await readFile(path.join(outside, "victim.txt"), "utf8")).toBe("keep");
+                       ^
+ENOENT: no such file or directory, open 'C:\Users\lg\AppData\Local\Temp\bg04-delete-project-Xcuf1H\victim.txt'
+    path: "C:\\Users\\lg\\AppData\\Local\\Temp\\bg04-delete-project-Xcuf1H\\victim.txt",
+ syscall: "open",
+   errno: -2,
+    code: "ENOENT"
+
+      at async <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\serve-path-boundary.test.ts:275:18)
+(fail) serve and deletion routes > does not recursively delete a project path outside the managed projects root [15.00ms]
+280 |     await writeFile(path.join(outside, "victim.txt"), "keep", "utf8");
+281 |     const systemId = insertSystem(outside);
+282 | 
+283 |     const response = await createApp().request(`/api/design-systems/${systemId}`, { method: "DELETE" });
+284 |     expect(response.status).toBe(200);
+285 |     expect(await readFile(path.join(outside, "victim.txt"), "utf8")).toBe("keep");
+                       ^
+ENOENT: no such file or directory, open 'C:\Users\lg\AppData\Local\Temp\bg04-delete-system-QnrQuP\victim.txt'
+    path: "C:\\Users\\lg\\AppData\\Local\\Temp\\bg04-delete-system-QnrQuP\\victim.txt",
+ syscall: "open",
+   errno: -2,
+    code: "ENOENT"
+
+      at async <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\serve-path-boundary.test.ts:285:18)
+(fail) serve and deletion routes > does not recursively delete a design-system path outside the managed systems root [16.00ms]
+291 |     await writeFile(path.join(outside, "secret.css"), "secret", "utf8");
+292 |     await makeDirLink(outside, path.join(root, "linked"));
+293 |     const systemId = insertSystem(root);
+294 | 
+295 |     const response = await createApp().request(`/api/design-systems/${systemId}/files/linked/secret.css`);
+296 |     expect(response.status).toBe(404);
+                                  ^
+error: expect(received).toBe(expected)
+
+Expected: 404
+Received: 200
+
+      at <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\serve-path-boundary.test.ts:296:29)
+(fail) serve and deletion routes > does not serve a design-system file through an escaping junction [16.00ms]
+303 |     const link = path.join(import.meta.dir, "..", "..", "frontend", "dist", "assets", linkName);
+304 |     await makeDirLink(outside, link);
+305 |     distLinks.push(link);
+306 | 
+307 |     const response = await createApp().request(`/assets/${linkName}/secret.txt`);
+308 |     expect(response.status).toBe(404);
+                                  ^
+error: expect(received).toBe(expected)
+
+Expected: 404
+Received: 200
+
+      at <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\serve-path-boundary.test.ts:308:29)
+(fail) serve and deletion routes > does not serve a static asset through an escaping junction [15.00ms]
+317 |     const projectId = insertProject(root);
+318 |     const sessionId = insertSession(projectId);
+319 | 
+320 |     await expect(
+321 |       saveSessionAttachments(sessionId, [new File(["secret"], "../../secret.txt", { type: "text/plain" })]),
+322 |     ).rejects.toBeInstanceOf(PathBoundaryError);
+                    ^
+error: 
+
+Expected promise that rejects
+Received promise that resolved: Promise { <resolved> }
+
+      at <anonymous> (C:\Users\lg\Documents\Claude\Projects\BurnGuard\packages\backend\tests\serve-path-boundary.test.ts:322:15)
+(fail) attachments service > rejects a symlinked .attachments directory before writing any upload [31.00ms]
+
+ 0 pass
+ 12 fail
+ 15 expect() calls
+Ran 12 tests across 1 file. [1.87s]

--- a/.omo/ulw-loop/evidence/bg-04/slice2/typecheck.txt
+++ b/.omo/ulw-loop/evidence/bg-04/slice2/typecheck.txt
@@ -1,0 +1,1 @@
+$ tsc --build

--- a/.omo/ulw-loop/evidence/bg-04/typecheck.txt
+++ b/.omo/ulw-loop/evidence/bg-04/typecheck.txt
@@ -1,0 +1,4 @@
+$ bun run typecheck
+$ tsc --build
+
+EXIT_CODE=0

--- a/packages/backend/src/lib/paths.ts
+++ b/packages/backend/src/lib/paths.ts
@@ -1,5 +1,6 @@
 import os from "node:os";
 import path from "node:path";
+import { PathBoundaryError, resolveWithin } from "../security/path-boundary";
 
 export const appRootDir = path.join(os.homedir(), ".burnguard");
 export const configFilePath = path.join(appRootDir, "config.json");
@@ -9,6 +10,15 @@ export const projectsDir = path.join(dataDir, "projects");
 export const cacheDir = path.join(appRootDir, "cache");
 export const logsDir = path.join(appRootDir, "logs");
 export const exportsDir = path.join(cacheDir, "exports");
+
+/** Resolves a DB-sourced absolute path against its managed storage root. */
+export function resolveManagedPath(root: string, target: string): string {
+  const relative = path.relative(root, target);
+  if (!relative) {
+    throw new PathBoundaryError("outside_root", "Managed storage root is not a record path");
+  }
+  return resolveWithin(root, relative);
+}
 
 export function resolveRepoRoot(fromDir = import.meta.dir): string {
   return path.resolve(fromDir, "../../../..");

--- a/packages/backend/src/routes/artifacts.ts
+++ b/packages/backend/src/routes/artifacts.ts
@@ -27,6 +27,7 @@ import {
 } from "../services/file-patch";
 import { getExportJob, listProjectExports } from "../db/exports";
 import { getProjectDetail } from "../db/seed";
+import { exportsDir, resolveManagedPath } from "../lib/paths";
 
 function ok<T>(data: T): ApiSuccess<T> {
   return { data };
@@ -470,6 +471,17 @@ artifactRoutes.get("/api/exports/:id/download", async (c) => {
     return c.json(fail("export_not_ready", "Export is not ready for download", { id }), 409);
   }
 
+  let outputPath: string;
+  try {
+    outputPath = resolveManagedPath(exportsDir, job.output_path);
+    const info = await stat(outputPath);
+    if (!info.isFile()) {
+      return c.json(fail("export_not_found", "Export output file not found", { id }), 404);
+    }
+  } catch {
+    return c.json(fail("export_not_found", "Export output file not found", { id }), 404);
+  }
+
   // Friendly user-facing filename (project-slug-format-date.ext) and
   // the correct MIME type per format. Both fixes from the export audit:
   // the previous response always claimed application/zip, even for PDF
@@ -481,7 +493,7 @@ artifactRoutes.get("/api/exports/:id/download", async (c) => {
   });
   c.header("Content-Disposition", buildContentDisposition(filename));
   c.header("Content-Type", formatMime(job.format));
-  return new Response(Bun.file(job.output_path), {
+  return new Response(Bun.file(outputPath), {
     headers: c.res.headers,
   });
 });

--- a/packages/backend/src/routes/project.ts
+++ b/packages/backend/src/routes/project.ts
@@ -5,6 +5,7 @@ import { closeProjectWatcher } from "../services/watchers";
 import type { ApiErrorBody, ApiSuccess, ProjectDetail, SessionInfo } from "@bg/shared";
 import { getDb } from "../db/client";
 import { projectsTable } from "../db/schema";
+import { projectsDir, resolveManagedPath } from "../lib/paths";
 import {
   getLatestProjectSession,
   getProjectDetail,
@@ -65,9 +66,14 @@ projectRoutes.delete("/api/projects/:id", async (c) => {
   // freshly created project that re-uses the same id starts clean.
   closeProjectWatcher(id);
 
-  // Remove the filesystem directory (ignore errors so the DB row still
-  // gets cleaned up even if a file handle is held or the dir is gone).
-  await rm(project.dir_path, { recursive: true, force: true }).catch(() => {});
+  // Remove only managed project storage. Ignore filesystem errors so the DB
+  // row still gets cleaned up if a file handle is held or the dir is gone.
+  try {
+    const projectDir = resolveManagedPath(projectsDir, project.dir_path);
+    await rm(projectDir, { recursive: true, force: true });
+  } catch {
+    // Keep the route's existing best-effort deletion behavior.
+  }
 
   // ON DELETE CASCADE on sessions/events/attachments/files/comments/tweaks/exports
   // removes the rest.

--- a/packages/backend/src/routes/system.ts
+++ b/packages/backend/src/routes/system.ts
@@ -1,4 +1,4 @@
-import { rm } from "node:fs/promises";
+import { rm, stat } from "node:fs/promises";
 import { Hono } from "hono";
 import type {
   ApiErrorBody,
@@ -26,10 +26,11 @@ import {
   extractDesignSystemFromSource,
   extractDesignSystemFromUpload,
   readDesignSystemTokens,
-  resolveDesignSystemFile,
   uploadDesignSystemFont,
   upsertDesignSystemColorToken,
 } from "../services/design-system-extract";
+import { resolveManagedPath, systemsDir } from "../lib/paths";
+import { assertSafeName, resolveWithin } from "../security/path-boundary";
 
 function ok<T>(data: T): ApiSuccess<T> {
   return { data };
@@ -321,10 +322,13 @@ systemRoutes.delete("/api/design-systems/:id", async (c) => {
   }
 
   await deleteDesignSystemRecord(id);
-  await rm(existing.dir_path, { recursive: true, force: true }).catch(() => {
-    // The DB row is already gone; failing to delete the directory
-    // leaves stale bytes on disk but keeps the UI consistent.
-  });
+  try {
+    const systemDir = resolveManagedPath(systemsDir, existing.dir_path);
+    await rm(systemDir, { recursive: true, force: true });
+  } catch {
+    // The DB row is already gone; an unsafe path or failed deletion leaves
+    // stale bytes on disk but keeps the UI consistent.
+  }
   return c.json(ok({ id, deleted: true } satisfies DeleteDesignSystemResponse));
 });
 
@@ -335,7 +339,19 @@ systemRoutes.get("/api/design-systems/:id/files/*", async (c) => {
   const relPath = rawPath.startsWith(prefix)
     ? decodeURIComponent(rawPath.slice(prefix.length))
     : "";
-  const absolutePath = await resolveDesignSystemFile(id, relPath);
+  const detail = await getDesignSystemDetail(id);
+  let absolutePath: string | null = null;
+  if (detail) {
+    try {
+      const segments = relPath.replaceAll("\\", "/").split("/").map(assertSafeName);
+      const candidate = resolveWithin(detail.dir_path, ...segments);
+      const info = await stat(candidate);
+      if (info.isFile()) absolutePath = candidate;
+    } catch {
+      // Preserve this endpoint's file-not-found response for invalid paths,
+      // escaping links, and inaccessible or missing files.
+    }
+  }
   if (!absolutePath) {
     return c.json(
       fail("design_system_file_not_found", "Design system file not found", {

--- a/packages/backend/src/security/path-boundary.ts
+++ b/packages/backend/src/security/path-boundary.ts
@@ -1,0 +1,124 @@
+import { realpathSync } from "node:fs";
+import path from "node:path";
+
+export type PathBoundaryErrorCode = "invalid_name" | "outside_root" | "invalid_path";
+
+export class PathBoundaryError extends Error {
+  readonly code: PathBoundaryErrorCode;
+
+  constructor(code: PathBoundaryErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "PathBoundaryError";
+    this.code = code;
+  }
+}
+
+const WINDOWS_RESERVED_NAME = /^(?:con|prn|aux|nul|clock\$|com[1-9]|lpt[1-9])(?:\.|$)/i;
+const WINDOWS_INVALID_CHARACTER = /[<>:"/\\|?*]/;
+
+function hasControlCharacter(value: string): boolean {
+  return Array.from(value).some((character) => character.charCodeAt(0) <= 31);
+}
+
+/** Validates a value that will be used as exactly one path component. */
+export function assertSafeName(name: string): string {
+  if (
+    name.length === 0 ||
+    name === "." ||
+    name === ".." ||
+    path.isAbsolute(name) ||
+    path.win32.isAbsolute(name) ||
+    /^[A-Za-z]:/.test(name) ||
+    WINDOWS_INVALID_CHARACTER.test(name) ||
+    hasControlCharacter(name) ||
+    /[ .]$/.test(name) ||
+    WINDOWS_RESERVED_NAME.test(name)
+  ) {
+    throw new PathBoundaryError(
+      "invalid_name",
+      `Unsafe path component: ${JSON.stringify(name)}`,
+    );
+  }
+  return name;
+}
+
+function resolveExistingPrefix(candidate: string): string {
+  let current = candidate;
+  const missing: string[] = [];
+
+  for (;;) {
+    try {
+      return path.resolve(realpathSync(current), ...missing);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && code !== "ENOTDIR") {
+        throw new PathBoundaryError(
+          "invalid_path",
+          `Could not resolve path: ${candidate}`,
+          { cause: error },
+        );
+      }
+
+      const parent = path.dirname(current);
+      if (parent === current) {
+        throw new PathBoundaryError(
+          "invalid_path",
+          `Path has no existing ancestor: ${candidate}`,
+          { cause: error },
+        );
+      }
+      missing.unshift(path.basename(current));
+      current = parent;
+    }
+  }
+}
+
+/**
+ * Resolves a path through junctions/symlinks, including paths whose final
+ * components do not exist yet, and verifies that it remains below `root`.
+ */
+export function resolveWithin(root: string, ...segments: string[]): string {
+  for (const segment of segments) {
+    if (
+      path.isAbsolute(segment) ||
+      path.win32.isAbsolute(segment) ||
+      /^[A-Za-z]:/.test(segment)
+    ) {
+      throw new PathBoundaryError(
+        "outside_root",
+        `Absolute path segment is not allowed: ${segment}`,
+      );
+    }
+  }
+
+  let realRoot: string;
+  try {
+    realRoot = realpathSync(root);
+  } catch (error) {
+    throw new PathBoundaryError(
+      "invalid_path",
+      `Could not resolve boundary root: ${root}`,
+      { cause: error },
+    );
+  }
+
+  const candidate = path.resolve(root, ...segments);
+  const resolved = resolveExistingPrefix(candidate);
+  const comparisonRoot = process.platform === "win32" ? realRoot.toLowerCase() : realRoot;
+  const comparisonResolved =
+    process.platform === "win32" ? resolved.toLowerCase() : resolved;
+  const relative = path.relative(comparisonRoot, comparisonResolved);
+
+  if (
+    relative === ".." ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    throw new PathBoundaryError(
+      "outside_root",
+      `Resolved path is outside boundary root: ${resolved}`,
+    );
+  }
+
+  return resolved;
+}

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -16,6 +16,7 @@ import {
   createRequestAuthority,
   type RequestAuthorityOptions,
 } from "./security/request-authority";
+import { PathBoundaryError, resolveWithin } from "./security/path-boundary";
 
 export function createApp(authority?: RequestAuthorityOptions): Hono {
   const app = new Hono();
@@ -42,16 +43,21 @@ export function createApp(authority?: RequestAuthorityOptions): Hono {
     const assetPath = rawPath.startsWith(prefix)
       ? decodeURIComponent(rawPath.slice(prefix.length))
       : "";
-    if (!distDir || !assetPath || assetPath.includes("..")) {
+    if (!distDir || !assetPath) {
       return c.notFound();
     }
 
-    const absolutePath = path.join(distDir, "assets", assetPath);
-    if (!existsSync(absolutePath)) {
-      return c.notFound();
+    try {
+      const assetsDir = resolveWithin(distDir, "assets");
+      const absolutePath = resolveWithin(assetsDir, assetPath);
+      if (!existsSync(absolutePath)) {
+        return c.notFound();
+      }
+      return new Response(Bun.file(absolutePath));
+    } catch (error) {
+      if (error instanceof PathBoundaryError) return c.notFound();
+      throw error;
     }
-
-    return new Response(Bun.file(absolutePath));
   });
 
   app.get("*", async (c) => {

--- a/packages/backend/src/services/attachments.ts
+++ b/packages/backend/src/services/attachments.ts
@@ -1,9 +1,9 @@
 import { createHash } from "node:crypto";
 import { mkdir, rm, writeFile } from "node:fs/promises";
-import path from "node:path";
 import { ulid } from "ulid";
 import { insertAttachment } from "../db/attachments";
 import { getSessionProject } from "../db/events";
+import { assertSafeName, resolveWithin } from "../security/path-boundary";
 import {
   inferUploadKind,
   readUploadManifest,
@@ -25,7 +25,7 @@ export async function saveSessionAttachments(sessionId: string, files: File[]) {
     throw new Error(`attachment_limit_exceeded:${MAX_ATTACHMENT_COUNT}`);
   }
 
-  const attachmentsDir = path.join(context.project_dir, ".attachments");
+  const attachmentsDir = resolveWithin(context.project_dir, ".attachments");
   await mkdir(attachmentsDir, { recursive: true });
 
   const records: string[] = [];
@@ -43,15 +43,28 @@ export async function saveSessionAttachments(sessionId: string, files: File[]) {
     }
 
     const base = sanitize(file.name || "attachment");
-    const storedName = `${ulid()}-${base}`;
-    const absolutePath = path.join(attachmentsDir, storedName);
+    const storedName = assertSafeName(`${ulid()}-${base}`);
+    const absolutePath = resolveWithin(
+      context.project_dir,
+      ".attachments",
+      storedName,
+    );
     const buffer = Buffer.from(await file.arrayBuffer());
     const sha256 = createHash("sha256").update(buffer).digest("hex");
 
     await writeFile(absolutePath, buffer);
     const uploadKind = inferUploadKind(file.name || storedName, file.type);
     if (uploadKind) {
-      const manifestPath = attachmentSummaryPath(absolutePath);
+      const manifestPath = resolveWithin(
+        context.project_dir,
+        ".attachments",
+        assertSafeName(`${storedName}.summary.json`),
+      );
+      const extractedTextPath = resolveWithin(
+        context.project_dir,
+        ".attachments",
+        assertSafeName(`${storedName}.extracted.md`),
+      );
       try {
         await runPythonUploadExtractor({
           sourcePath: absolutePath,
@@ -59,16 +72,14 @@ export async function saveSessionAttachments(sessionId: string, files: File[]) {
         });
         const manifest = await readUploadManifest(manifestPath);
         await writeFile(
-          attachmentExtractedTextPath(absolutePath),
+          extractedTextPath,
           renderAttachmentExtract(manifest, file.name || storedName),
           "utf8",
         );
       } catch (error) {
         await rm(absolutePath, { force: true }).catch(() => {});
         await rm(manifestPath, { force: true }).catch(() => {});
-        await rm(attachmentExtractedTextPath(absolutePath), {
-          force: true,
-        }).catch(() => {});
+        await rm(extractedTextPath, { force: true }).catch(() => {});
         const message = error instanceof Error ? error.message : String(error);
         throw new Error(
           `attachment_extract_failed:${file.name || storedName}:${message}`,

--- a/packages/backend/src/services/checkpoints.ts
+++ b/packages/backend/src/services/checkpoints.ts
@@ -2,12 +2,19 @@ import { cp, mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { CheckpointRef } from "@bg/shared";
 import { getProjectDetail } from "../db/seed";
+import { assertSafeName, resolveWithin } from "../security/path-boundary";
 import { listIndexedProjectFiles } from "./files";
 
 const EXCLUDED_DIR_NAMES = new Set([".meta", ".attachments"]);
 
 function snapshotDir(projectDir: string, turnId: string): string {
-  return path.join(projectDir, ".meta", "checkpoints", "snapshots", turnId);
+  return resolveWithin(
+    projectDir,
+    ".meta",
+    "checkpoints",
+    "snapshots",
+    assertSafeName(turnId),
+  );
 }
 
 /**
@@ -21,6 +28,7 @@ export async function writePreTurnSnapshot(
   projectId: string,
   turnId: string,
 ): Promise<CheckpointRef | null> {
+  assertSafeName(turnId);
   const project = await getProjectDetail(projectId);
   if (!project) return null;
 
@@ -53,6 +61,7 @@ export async function hasSnapshot(
   projectId: string,
   turnId: string,
 ): Promise<boolean> {
+  assertSafeName(turnId);
   const project = await getProjectDetail(projectId);
   if (!project) return false;
   const dest = snapshotDir(project.dir_path, turnId);
@@ -82,6 +91,7 @@ export async function restoreFromSnapshot(
   projectId: string,
   turnId: string,
 ): Promise<RestoreResult | null> {
+  assertSafeName(turnId);
   const project = await getProjectDetail(projectId);
   if (!project) return null;
 
@@ -127,14 +137,20 @@ export async function writeTurnCheckpoint(
   projectId: string,
   turnId: string,
 ): Promise<CheckpointRef | null> {
+  const safeTurnId = assertSafeName(turnId);
   const project = await getProjectDetail(projectId);
   if (!project) {
     return null;
   }
 
   const files = await listIndexedProjectFiles(projectId);
-  const checkpointDir = path.join(project.dir_path, ".meta", "checkpoints");
-  const checkpointPath = path.join(checkpointDir, `${turnId}.json`);
+  const checkpointDir = resolveWithin(project.dir_path, ".meta", "checkpoints");
+  const checkpointPath = resolveWithin(
+    project.dir_path,
+    ".meta",
+    "checkpoints",
+    `${safeTurnId}.json`,
+  );
   const createdAt = Date.now();
 
   await mkdir(checkpointDir, { recursive: true });

--- a/packages/backend/src/services/export-gc.ts
+++ b/packages/backend/src/services/export-gc.ts
@@ -15,11 +15,14 @@
  * sessions can opt into a periodic timer later if needed.
  */
 import { stat, unlink } from "node:fs/promises";
+import path from "node:path";
 import type { ExportJob } from "@bg/shared";
 import {
   deleteExportJob,
   listStaleSucceededExports,
 } from "../db/exports";
+import { exportsDir } from "../lib/paths";
+import { resolveWithin } from "../security/path-boundary";
 
 export const DEFAULT_EXPORT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
@@ -39,6 +42,8 @@ export interface PruneResult {
   removedFiles: string[];
   /** Jobs whose output_path was already missing — DB row still pruned. */
   missingFiles: string[];
+  /** Unsafe output paths that were deliberately not touched. */
+  warnings: string[];
 }
 
 /**
@@ -51,6 +56,7 @@ export interface PruneDeps {
   deleteJob?: (id: string) => Promise<void>;
   statFile?: (path: string) => Promise<{ size: number }>;
   unlinkFile?: (path: string) => Promise<void>;
+  exportsRoot?: string;
 }
 
 export async function pruneOldExports(
@@ -66,6 +72,7 @@ export async function pruneOldExports(
       return { size: info.size };
     });
   const unlinkFile = deps.unlinkFile ?? unlink;
+  const exportsRoot = deps.exportsRoot ?? exportsDir;
 
   const retention = options.retentionMs ?? DEFAULT_EXPORT_RETENTION_MS;
   const now = options.now ?? Date.now();
@@ -77,21 +84,34 @@ export async function pruneOldExports(
     removedBytes: 0,
     removedFiles: [],
     missingFiles: [],
+    warnings: [],
   };
 
   for (const job of stale) {
     if (job.output_path) {
+      let safeOutputPath: string | null = null;
       try {
-        const info = await statFile(job.output_path);
-        if (!options.dryRun) {
-          await unlinkFile(job.output_path);
+        const relativeOutputPath = path.relative(exportsRoot, job.output_path);
+        safeOutputPath = resolveWithin(exportsRoot, relativeOutputPath);
+      } catch (error) {
+        result.warnings.push(
+          `Skipped unsafe output_path for export ${job.id}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+
+      if (safeOutputPath) {
+        try {
+          const info = await statFile(safeOutputPath);
+          if (!options.dryRun) {
+            await unlinkFile(safeOutputPath);
+          }
+          result.removedBytes += info.size;
+          result.removedFiles.push(job.output_path);
+        } catch {
+          // File already gone — still drop the DB row so it doesn't
+          // forever advertise a non-existent download URL.
+          result.missingFiles.push(job.output_path);
         }
-        result.removedBytes += info.size;
-        result.removedFiles.push(job.output_path);
-      } catch {
-        // File already gone — still drop the DB row so it doesn't
-        // forever advertise a non-existent download URL.
-        result.missingFiles.push(job.output_path);
       }
     }
     if (!options.dryRun) {

--- a/packages/backend/src/services/exports.ts
+++ b/packages/backend/src/services/exports.ts
@@ -6,6 +6,7 @@ import { createExportJob, getExportJob, updateExportJob } from "../db/exports";
 import { getProjectDetail } from "../db/seed";
 import { exportsDir } from "../lib/paths";
 import { DECK_STAGE_JS } from "../runtime/deck-stage";
+import { assertSafeName, resolveWithin } from "../security/path-boundary";
 import { renderDeckToPdf } from "./export-pdf";
 import { renderDeckToPptx } from "./export-pptx";
 import { renderHandoffBundle } from "./export-handoff";
@@ -65,12 +66,17 @@ async function runExport(jobId: string, options: ExportOptions = {}) {
     await mkdir(exportsDir, { recursive: true });
     const ext =
       job.format === "pdf" ? "pdf" : job.format === "pptx" ? "pptx" : "zip";
-    const outputPath = path.join(exportsDir, `${project.id}-${job.id}.${ext}`);
+    const safeProjectId = assertSafeName(project.id);
+    const safeJobId = assertSafeName(job.id);
+    const outputPath = resolveWithin(
+      exportsDir,
+      `${safeProjectId}-${safeJobId}.${ext}`,
+    );
     await rm(outputPath, { force: true });
     const stagingDir = await mkdtemp(path.join(os.tmpdir(), "burnguard-export-"));
 
     try {
-      const projectStageDir = path.join(stagingDir, project.id);
+      const projectStageDir = path.join(stagingDir, safeProjectId);
       await cp(project.dir_path, projectStageDir, { recursive: true });
 
       if (project.type === "slide_deck") {
@@ -106,7 +112,7 @@ async function runExport(jobId: string, options: ExportOptions = {}) {
           project.design_system_id,
           project.dir_path,
         );
-        const bundleDir = path.join(stagingDir, `${project.id}-handoff`);
+        const bundleDir = path.join(stagingDir, `${safeProjectId}-handoff`);
         await mkdir(bundleDir, { recursive: true });
         await renderHandoffBundle({
           // Full project mirror — renderHandoffBundle copies it into
@@ -181,12 +187,14 @@ async function resolveHandoffTokens(
   };
 }
 
-async function prepareSlideDeckExport(projectDir: string, entrypoint: string) {
+export async function prepareSlideDeckExport(
+  projectDir: string,
+  entrypoint: string,
+) {
+  const entrypointPath = resolveWithin(projectDir, entrypoint);
   const runtimeDir = path.join(projectDir, "runtime");
   await mkdir(runtimeDir, { recursive: true });
   await writeFile(path.join(runtimeDir, "deck-stage.js"), DECK_STAGE_JS, "utf8");
-
-  const entrypointPath = path.join(projectDir, entrypoint);
   const relativeRuntimePath = path
     .relative(path.dirname(entrypointPath), path.join(runtimeDir, "deck-stage.js"))
     .replaceAll("\\", "/");

--- a/packages/backend/src/services/files.ts
+++ b/packages/backend/src/services/files.ts
@@ -3,6 +3,11 @@ import path from "node:path";
 import type { ArtifactSummary, FileInfo } from "@bg/shared";
 import { listProjectFiles as listProjectFilesFromDb, replaceProjectFiles } from "../db/files";
 import { getProjectDetail } from "../db/seed";
+import {
+  PathBoundaryError,
+  assertSafeName,
+  resolveWithin,
+} from "../security/path-boundary";
 
 const IGNORED_DIRS = new Set([
   ".attachments",
@@ -101,17 +106,16 @@ export async function resolveProjectFile(projectId: string, relPath: string) {
     return null;
   }
 
-  const absolute = path.resolve(project.dir_path, normalized);
-  const root = path.resolve(project.dir_path);
-  if (!absolute.startsWith(root)) {
-    return null;
+  try {
+    return {
+      project,
+      relPath: normalized,
+      absolutePath: resolveWithin(project.dir_path, normalized),
+    };
+  } catch (error) {
+    if (error instanceof PathBoundaryError) return null;
+    throw error;
   }
-
-  return {
-    project,
-    relPath: normalized,
-    absolutePath: absolute,
-  };
 }
 
 /**
@@ -133,23 +137,29 @@ export async function resolveDrawFile(projectId: string, relPath: string) {
     return null;
   }
 
-  const drawsRoot = path.resolve(project.dir_path, ".meta", "draws");
-  const svgPath = path.resolve(drawsRoot, `${normalized}.svg`);
-  if (!svgPath.startsWith(drawsRoot)) {
-    return null;
+  try {
+    const svgPath = resolveWithin(
+      project.dir_path,
+      ".meta",
+      "draws",
+      `${normalized}.svg`,
+    );
+    return {
+      project,
+      relPath: normalized,
+      absolutePath: svgPath,
+      parentDir: path.dirname(svgPath),
+    };
+  } catch (error) {
+    if (error instanceof PathBoundaryError) return null;
+    throw error;
   }
-
-  return {
-    project,
-    relPath: normalized,
-    absolutePath: svgPath,
-    parentDir: path.dirname(svgPath),
-  };
 }
 
 async function scanProjectDir(projectDir: string) {
   const output: FileInfo[] = [];
-  await walk(projectDir, projectDir, output);
+  const rootDir = resolveWithin(projectDir);
+  await walk(rootDir, rootDir, output);
   return output.sort((a, b) => a.rel_path.localeCompare(b.rel_path));
 }
 
@@ -160,8 +170,16 @@ async function walk(rootDir: string, currentDir: string, output: FileInfo[]) {
       continue;
     }
 
-    const absolute = path.join(currentDir, entry.name);
-    const relPath = path.relative(rootDir, absolute).replaceAll("\\", "/");
+    const relPath = path
+      .relative(rootDir, path.join(currentDir, entry.name))
+      .replaceAll("\\", "/");
+    let absolute: string;
+    try {
+      absolute = resolveWithin(rootDir, relPath);
+    } catch (error) {
+      if (error instanceof PathBoundaryError) continue;
+      throw error;
+    }
     const stats = await stat(absolute);
 
     if (entry.isDirectory()) {
@@ -215,10 +233,15 @@ function categorize(relPath: string): FileInfo["category"] {
 }
 
 function normalizeRelativePath(relPath: string) {
-  const normalized = relPath.replaceAll("\\", "/").replace(/^\/+/, "");
-  if (!normalized || normalized.includes("..")) {
-    return null;
+  try {
+    return relPath
+      .replaceAll("\\", "/")
+      .split("/")
+      .map(assertSafeName)
+      .join("/");
+  } catch (error) {
+    if (error instanceof PathBoundaryError) return null;
+    throw error;
   }
-  return normalized;
 }
 

--- a/packages/backend/tests/checkpoints.test.ts
+++ b/packages/backend/tests/checkpoints.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { writePreTurnSnapshot } from "../src/services/checkpoints";
 
 /**
  * Checkpoint / restore round-trip test. The production helpers live in
@@ -67,6 +68,14 @@ function restoreSnapshot(projectDir: string, turnId: string) {
   }
   return { restoredAt: Date.now() };
 }
+
+describe("checkpoint path boundary", () => {
+  test("rejects a traversing turnId before touching project storage", async () => {
+    await expect(
+      writePreTurnSnapshot("project-does-not-matter", "../../victim"),
+    ).rejects.toThrow("Unsafe path component");
+  });
+});
 
 describe("checkpoint snapshot / restore round-trip", () => {
   let projectDir: string;

--- a/packages/backend/tests/export-gc.test.ts
+++ b/packages/backend/tests/export-gc.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import type { ExportJob } from "@bg/shared";
 import {
   DEFAULT_EXPORT_RETENTION_MS,
@@ -6,6 +9,15 @@ import {
 } from "../src/services/export-gc";
 
 const NOW = Date.UTC(2026, 3, 25); // 2026-04-25 00:00 UTC
+const EXPORTS_ROOT = mkdtempSync(path.join(tmpdir(), "bg-export-gc-"));
+
+function exportPath(name: string): string {
+  return path.join(EXPORTS_ROOT, name);
+}
+
+afterAll(() => {
+  rmSync(EXPORTS_ROOT, { recursive: true, force: true });
+});
 
 function makeJob(overrides: Partial<ExportJob>): ExportJob {
   return {
@@ -13,7 +25,7 @@ function makeJob(overrides: Partial<ExportJob>): ExportJob {
     project_id: "proj-1",
     format: "html_zip",
     status: "succeeded",
-    output_path: "/exports/job-1.zip",
+    output_path: exportPath("job-1.zip"),
     error_message: null,
     size_bytes: 1024,
     created_at: NOW - DEFAULT_EXPORT_RETENTION_MS - 86400_000, // 8 days ago
@@ -31,6 +43,7 @@ interface FakeDeps {
 
 function makeDeps(state: FakeDeps) {
   return {
+    exportsRoot: EXPORTS_ROOT,
     listStale: async (cutoffMs: number) =>
       state.jobs.filter(
         (j) =>
@@ -55,14 +68,16 @@ function makeDeps(state: FakeDeps) {
 
 describe("pruneOldExports", () => {
   test("removes succeeded jobs older than the retention window", async () => {
+    const old1 = exportPath("old-1.zip");
+    const old2 = exportPath("old-2.zip");
     const state: FakeDeps = {
       jobs: [
-        makeJob({ id: "old-1", output_path: "/exports/old-1.zip" }),
-        makeJob({ id: "old-2", output_path: "/exports/old-2.zip" }),
+        makeJob({ id: "old-1", output_path: old1 }),
+        makeJob({ id: "old-2", output_path: old2 }),
       ],
       fileSizes: new Map([
-        ["/exports/old-1.zip", 2048],
-        ["/exports/old-2.zip", 4096],
+        [old1, 2048],
+        [old2, 4096],
       ]),
       deletedIds: [],
       unlinkedPaths: [],
@@ -70,22 +85,37 @@ describe("pruneOldExports", () => {
     const result = await pruneOldExports({ now: NOW }, makeDeps(state));
     expect(result.removedJobs).toBe(2);
     expect(result.removedBytes).toBe(2048 + 4096);
-    expect(result.removedFiles).toEqual([
-      "/exports/old-1.zip",
-      "/exports/old-2.zip",
-    ]);
+    expect(result.removedFiles).toEqual([old1, old2]);
     expect(result.missingFiles).toEqual([]);
+    expect(result.warnings).toEqual([]);
     expect(state.deletedIds).toEqual(["old-1", "old-2"]);
-    expect(state.unlinkedPaths).toEqual([
-      "/exports/old-1.zip",
-      "/exports/old-2.zip",
-    ]);
+    expect(state.unlinkedPaths).toEqual([old1, old2]);
+  });
+
+  test("skips and warns about an output_path outside the exports root", async () => {
+    const outsidePath = path.join(path.dirname(EXPORTS_ROOT), "victim.zip");
+    const state: FakeDeps = {
+      jobs: [makeJob({ id: "hostile", output_path: outsidePath })],
+      fileSizes: new Map([[outsidePath, 4096]]),
+      deletedIds: [],
+      unlinkedPaths: [],
+    };
+
+    const result = await pruneOldExports({ now: NOW }, makeDeps(state));
+
+    expect(state.unlinkedPaths).toEqual([]);
+    expect(result.removedFiles).toEqual([]);
+    expect(result.missingFiles).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("Skipped unsafe output_path");
+    expect(state.deletedIds).toEqual(["hostile"]);
   });
 
   test("dryRun reports the work but does not unlink or delete anything", async () => {
+    const old1 = exportPath("old-1.zip");
     const state: FakeDeps = {
-      jobs: [makeJob({ id: "old-1", output_path: "/exports/old-1.zip" })],
-      fileSizes: new Map([["/exports/old-1.zip", 2048]]),
+      jobs: [makeJob({ id: "old-1", output_path: old1 })],
+      fileSizes: new Map([[old1, 2048]]),
       deletedIds: [],
       unlinkedPaths: [],
     };
@@ -100,8 +130,9 @@ describe("pruneOldExports", () => {
   });
 
   test("missing files still drop the DB row so dead download URLs do not linger", async () => {
+    const missing = exportPath("missing.zip");
     const state: FakeDeps = {
-      jobs: [makeJob({ id: "old-1", output_path: "/exports/missing.zip" })],
+      jobs: [makeJob({ id: "old-1", output_path: missing })],
       fileSizes: new Map(), // no file exists
       deletedIds: [],
       unlinkedPaths: [],
@@ -110,7 +141,7 @@ describe("pruneOldExports", () => {
     expect(result.removedJobs).toBe(1);
     expect(result.removedBytes).toBe(0);
     expect(result.removedFiles).toEqual([]);
-    expect(result.missingFiles).toEqual(["/exports/missing.zip"]);
+    expect(result.missingFiles).toEqual([missing]);
     // DB row still pruned even though no file was on disk.
     expect(state.deletedIds).toEqual(["old-1"]);
     // No unlink attempted because stat failed first.
@@ -120,22 +151,24 @@ describe("pruneOldExports", () => {
   test("respects a custom retention window", async () => {
     // Set retention to 1 hour. A 2-hour-old succeeded job is stale;
     // a 30-minute-old job is fresh.
+    const twoHoursOld = exportPath("two-hours-old.zip");
+    const halfHourOld = exportPath("half-hour-old.zip");
     const state: FakeDeps = {
       jobs: [
         makeJob({
           id: "two-hours-old",
           completed_at: NOW - 2 * 60 * 60 * 1000,
-          output_path: "/exports/two-hours-old.zip",
+          output_path: twoHoursOld,
         }),
         makeJob({
           id: "half-hour-old",
           completed_at: NOW - 30 * 60 * 1000,
-          output_path: "/exports/half-hour-old.zip",
+          output_path: halfHourOld,
         }),
       ],
       fileSizes: new Map([
-        ["/exports/two-hours-old.zip", 1024],
-        ["/exports/half-hour-old.zip", 1024],
+        [twoHoursOld, 1024],
+        [halfHourOld, 1024],
       ]),
       deletedIds: [],
       unlinkedPaths: [],
@@ -153,13 +186,14 @@ describe("pruneOldExports", () => {
     // assert here that pruneOldExports doesn't try to second-guess
     // the query — feeding in a mixed list, only the succeeded one
     // should be processed.
+    const defaultPath = exportPath("job-1.zip");
     const state: FakeDeps = {
       jobs: [
         makeJob({ id: "succeeded-old", status: "succeeded" }),
         makeJob({ id: "failed-old", status: "failed" }),
         makeJob({ id: "running-old", status: "running" }),
       ],
-      fileSizes: new Map([["/exports/job-1.zip", 1024]]),
+      fileSizes: new Map([[defaultPath, 1024]]),
       deletedIds: [],
       unlinkedPaths: [],
     };

--- a/packages/backend/tests/exports.test.ts
+++ b/packages/backend/tests/exports.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, test } from "bun:test";
-import { mkdtemp, rm, stat, writeFile, mkdir } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { chromium, type LaunchOptions } from "playwright-core";
@@ -12,6 +12,26 @@ import {
 import { DECK_STAGE_JS } from "../src/runtime/deck-stage";
 import { PdfExportError, renderDeckToPdf } from "../src/services/export-pdf";
 import { PptxExportError, renderDeckToPptx } from "../src/services/export-pptx";
+import { prepareSlideDeckExport } from "../src/services/exports";
+
+describe("export path boundary", () => {
+  test("rejects an entrypoint outside the staged project", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "bg-export-boundary-"));
+    const projectDir = path.join(tempRoot, "staging", "project");
+    const outsidePath = path.join(tempRoot, "outside.html");
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(outsidePath, "outside-original", "utf8");
+
+    try {
+      await expect(
+        prepareSlideDeckExport(projectDir, "../../outside.html"),
+      ).rejects.toThrow("outside boundary root");
+      expect(await readFile(outsidePath, "utf8")).toBe("outside-original");
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("tutorial HTML contracts", () => {
   test("prototype tutorial is a standalone page with editable anchors", () => {

--- a/packages/backend/tests/path-boundary.test.ts
+++ b/packages/backend/tests/path-boundary.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  PathBoundaryError,
+  assertSafeName,
+  resolveWithin,
+} from "../src/security/path-boundary";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("resolveWithin", () => {
+  test("resolves a contained existing path", () => {
+    const root = makeTempDir("bg-path-root-");
+    const child = path.join(root, "child");
+    mkdirSync(child);
+
+    expect(resolveWithin(root, "child")).toBe(child);
+  });
+
+  test("rejects parent traversal", () => {
+    const root = makeTempDir("bg-path-root-");
+    expect(() => resolveWithin(root, "..", "victim.txt")).toThrow(
+      PathBoundaryError,
+    );
+  });
+
+  test("rejects an absolute path segment", () => {
+    const root = makeTempDir("bg-path-root-");
+    const outside = makeTempDir("bg-path-outside-");
+    expect(() => resolveWithin(root, outside)).toThrow(PathBoundaryError);
+  });
+
+  test("rejects backslash traversal on Windows", () => {
+    if (process.platform !== "win32") return;
+    const root = makeTempDir("bg-path-root-");
+    expect(() => resolveWithin(root, "..\\victim.txt")).toThrow(
+      PathBoundaryError,
+    );
+  });
+
+  test("allows a not-yet-existing leaf below an existing root", () => {
+    const root = makeTempDir("bg-path-root-");
+    expect(resolveWithin(root, "new", "artifact.zip")).toBe(
+      path.join(root, "new", "artifact.zip"),
+    );
+  });
+
+  test("rejects an escape through a junction or symlink", () => {
+    const root = makeTempDir("bg-path-root-");
+    const outside = makeTempDir("bg-path-outside-");
+    const link = path.join(root, "linked");
+    symlinkSync(outside, link, process.platform === "win32" ? "junction" : "dir");
+
+    expect(() => resolveWithin(root, "linked", "victim.txt")).toThrow(
+      PathBoundaryError,
+    );
+  });
+});
+
+describe("assertSafeName", () => {
+  test("returns a safe single path component", () => {
+    expect(assertSafeName("project-01_abc")).toBe("project-01_abc");
+  });
+
+  test.each(["", "..", "../victim", "..\\victim", "C:relative", "NUL"])(
+    "rejects unsafe component %p",
+    (name) => {
+      expect(() => assertSafeName(name)).toThrow(PathBoundaryError);
+    },
+  );
+});

--- a/packages/backend/tests/serve-path-boundary.test.ts
+++ b/packages/backend/tests/serve-path-boundary.test.ts
@@ -1,0 +1,325 @@
+import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { runMigrations } from "../src/db/migrate";
+import { getSqlite } from "../src/db/client";
+import { exportsDir, projectsDir, systemsDir } from "../src/lib/paths";
+import { PathBoundaryError } from "../src/security/path-boundary";
+import { createApp } from "../src/server";
+import { saveSessionAttachments } from "../src/services/attachments";
+import {
+  indexProjectFiles,
+  resolveDrawFile,
+  resolveProjectFile,
+} from "../src/services/files";
+import {
+  __resetFilePatchUndoStoreForTests,
+  FilePatchError,
+  patchHtmlNode,
+  undoLastFilePatch,
+} from "../src/services/file-patch";
+
+const tempDirs: string[] = [];
+const projectIds: string[] = [];
+const sessionIds: string[] = [];
+const systemIds: string[] = [];
+const exportIds: string[] = [];
+const distLinks: string[] = [];
+let sequence = 0;
+
+function id(prefix: string): string {
+  sequence += 1;
+  return `bg04-${prefix}-${process.pid}-${sequence}`;
+}
+
+async function temp(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function insertProject(dirPath: string): string {
+  const projectId = id("project");
+  const now = Date.now();
+  getSqlite()
+    .prepare(
+      `INSERT INTO projects
+       (id, name, type, design_system_id, dir_path, entrypoint, backend_id, created_at, updated_at)
+       VALUES (?, ?, 'prototype', NULL, ?, 'index.html', 'claude-code', ?, ?)`,
+    )
+    .run(projectId, projectId, dirPath, now, now);
+  projectIds.push(projectId);
+  return projectId;
+}
+
+function insertSession(projectId: string): string {
+  const sessionId = id("session");
+  const now = Date.now();
+  getSqlite()
+    .prepare(
+      `INSERT INTO sessions
+       (id, project_id, backend_id, status, usage_input_tokens, usage_output_tokens,
+        usage_cache_read, usage_cache_write, created_at, updated_at, last_active_at)
+       VALUES (?, ?, 'claude-code', 'idle', 0, 0, 0, 0, ?, ?, ?)`,
+    )
+    .run(sessionId, projectId, now, now, now);
+  sessionIds.push(sessionId);
+  return sessionId;
+}
+
+function insertSystem(dirPath: string): string {
+  const systemId = id("system");
+  const now = Date.now();
+  getSqlite()
+    .prepare(
+      `INSERT INTO design_systems
+       (id, name, status, source_type, is_template, dir_path, created_at, updated_at)
+       VALUES (?, ?, 'draft', 'manual', 0, ?, ?, ?)`,
+    )
+    .run(systemId, systemId, dirPath, now, now);
+  systemIds.push(systemId);
+  return systemId;
+}
+
+function insertExport(projectId: string, outputPath: string): string {
+  const exportId = id("export");
+  const now = Date.now();
+  getSqlite()
+    .prepare(
+      `INSERT INTO exports
+       (id, project_id, format, status, output_path, size_bytes, created_at, completed_at)
+       VALUES (?, ?, 'html_zip', 'succeeded', ?, 6, ?, ?)`,
+    )
+    .run(exportId, projectId, outputPath, now, now);
+  exportIds.push(exportId);
+  return exportId;
+}
+
+async function makeDirLink(target: string, link: string): Promise<void> {
+  await symlink(target, link, process.platform === "win32" ? "junction" : "dir");
+}
+
+beforeAll(async () => {
+  await runMigrations();
+  await Promise.all([
+    mkdir(projectsDir, { recursive: true }),
+    mkdir(systemsDir, { recursive: true }),
+    mkdir(exportsDir, { recursive: true }),
+  ]);
+});
+
+afterEach(async () => {
+  __resetFilePatchUndoStoreForTests();
+  const db = getSqlite();
+  for (const exportId of exportIds.splice(0)) {
+    db.prepare("DELETE FROM exports WHERE id = ?").run(exportId);
+  }
+  for (const sessionId of sessionIds.splice(0)) {
+    db.prepare("DELETE FROM attachments WHERE session_id = ?").run(sessionId);
+    db.prepare("DELETE FROM sessions WHERE id = ?").run(sessionId);
+  }
+  for (const projectId of projectIds.splice(0)) {
+    db.prepare("DELETE FROM files WHERE project_id = ?").run(projectId);
+    db.prepare("DELETE FROM projects WHERE id = ?").run(projectId);
+  }
+  for (const systemId of systemIds.splice(0)) {
+    db.prepare("DELETE FROM design_systems WHERE id = ?").run(systemId);
+  }
+  for (const link of distLinks.splice(0)) {
+    await rm(link, { recursive: true, force: true });
+  }
+  for (const dir of tempDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("project file and draw services", () => {
+  test("reject traversal, backslash traversal, absolute paths, and junction escapes", async () => {
+    const root = await temp("bg04-project-");
+    const outside = await temp("bg04-outside-");
+    await writeFile(path.join(outside, "secret.txt"), "secret", "utf8");
+    await makeDirLink(outside, path.join(root, "linked"));
+    const projectId = insertProject(root);
+
+    for (const hostile of [
+      "../secret.txt",
+      "..\\secret.txt",
+      path.join(outside, "secret.txt"),
+      "linked/secret.txt",
+    ]) {
+      expect(await resolveProjectFile(projectId, hostile)).toBeNull();
+    }
+  });
+
+  test("rejects draw junction escapes while allowing missing leaves through a symlinked project root", async () => {
+    const realProject = await temp("bg04-real-project-");
+    const projectLinkParent = await temp("bg04-project-link-");
+    const projectLink = path.join(projectLinkParent, "project");
+    await makeDirLink(realProject, projectLink);
+    const outside = await temp("bg04-draw-outside-");
+    await mkdir(path.join(realProject, ".meta", "draws"), { recursive: true });
+    await makeDirLink(outside, path.join(realProject, ".meta", "draws", "linked"));
+    const projectId = insertProject(projectLink);
+
+    expect(await resolveDrawFile(projectId, "linked/note")).toBeNull();
+    const safe = await resolveDrawFile(projectId, "new/note");
+    expect(safe?.absolutePath).toBe(path.join(realProject, ".meta", "draws", "new", "note.svg"));
+  });
+
+  test("does not index a symlink whose target leaves the project", async () => {
+    const root = await temp("bg04-index-project-");
+    const outside = await temp("bg04-index-outside-");
+    await writeFile(path.join(outside, "secret.txt"), "secret", "utf8");
+    await makeDirLink(outside, path.join(root, "linked"));
+    const projectId = insertProject(root);
+
+    const files = await indexProjectFiles(projectId);
+    expect(files?.some((file) => file.rel_path.startsWith("linked"))).toBe(false);
+  });
+});
+
+describe("file patch service", () => {
+  const html = '<h1 data-bg-node-id="title">outside</h1>';
+
+  test("does not patch HTML through a junction outside the project", async () => {
+    const root = await temp("bg04-patch-project-");
+    const outside = await temp("bg04-patch-outside-");
+    const outsideFile = path.join(outside, "page.html");
+    await writeFile(outsideFile, html, "utf8");
+    await makeDirLink(outside, path.join(root, "linked"));
+    const projectId = insertProject(root);
+
+    await expect(
+      patchHtmlNode(projectId, "linked/page.html", {
+        node_bg_id: "title",
+        text: "pwned",
+      }),
+    ).rejects.toMatchObject({ code: "file_not_found" } satisfies Partial<FilePatchError>);
+    expect(await readFile(outsideFile, "utf8")).toBe(html);
+  });
+
+  test("revalidates containment before undoing a prior patch", async () => {
+    const root = await temp("bg04-undo-project-");
+    const inside = path.join(root, "inside");
+    const outside = await temp("bg04-undo-outside-");
+    await mkdir(inside);
+    await writeFile(path.join(inside, "page.html"), html, "utf8");
+    await writeFile(path.join(outside, "page.html"), html, "utf8");
+    const link = path.join(root, "linked");
+    await makeDirLink(inside, link);
+    const projectId = insertProject(root);
+    await patchHtmlNode(projectId, "linked/page.html", {
+      node_bg_id: "title",
+      text: "inside patch",
+    });
+    await rm(link, { recursive: true, force: true });
+    await makeDirLink(outside, link);
+
+    expect(await undoLastFilePatch(projectId, "linked/page.html")).toBeNull();
+    expect(await readFile(path.join(outside, "page.html"), "utf8")).toBe(html);
+  });
+});
+
+describe("serve and deletion routes", () => {
+  test("rejects project file and draw junction escapes at HTTP sinks", async () => {
+    const root = await temp("bg04-route-project-");
+    const outside = await temp("bg04-route-outside-");
+    await writeFile(path.join(outside, "secret.txt"), "secret", "utf8");
+    await writeFile(path.join(outside, "note.svg"), "<svg>secret</svg>", "utf8");
+    await makeDirLink(outside, path.join(root, "linked"));
+    await mkdir(path.join(root, ".meta", "draws"), { recursive: true });
+    await makeDirLink(outside, path.join(root, ".meta", "draws", "linked"));
+    const projectId = insertProject(root);
+    const app = createApp();
+
+    expect((await app.request(`/api/projects/${projectId}/fs/linked/secret.txt`)).status).toBe(404);
+    expect((await app.request(`/api/projects/${projectId}/draws/linked/note`)).status).toBe(404);
+    expect(
+      (
+        await app.request(`/api/projects/${projectId}/draws/linked/new-note`, {
+          method: "PUT",
+          body: "<svg/>",
+        })
+      ).status,
+    ).toBe(400);
+  });
+
+  test("does not serve an export output_path outside the managed exports root", async () => {
+    const root = await temp("bg04-export-project-");
+    const outside = await temp("bg04-export-outside-");
+    const outsideFile = path.join(outside, "secret.zip");
+    await writeFile(outsideFile, "secret", "utf8");
+    const projectId = insertProject(root);
+    const exportId = insertExport(projectId, outsideFile);
+
+    const response = await createApp().request(`/api/exports/${exportId}/download`);
+    expect(response.status).toBe(404);
+  });
+
+  test("does not recursively delete a project path outside the managed projects root", async () => {
+    const outside = await temp("bg04-delete-project-");
+    await writeFile(path.join(outside, "victim.txt"), "keep", "utf8");
+    const projectId = insertProject(outside);
+
+    const response = await createApp().request(`/api/projects/${projectId}`, { method: "DELETE" });
+    expect(response.status).toBe(204);
+    expect(await readFile(path.join(outside, "victim.txt"), "utf8")).toBe("keep");
+  });
+
+  test("does not recursively delete a design-system path outside the managed systems root", async () => {
+    const outside = await temp("bg04-delete-system-");
+    await writeFile(path.join(outside, "victim.txt"), "keep", "utf8");
+    const systemId = insertSystem(outside);
+
+    const response = await createApp().request(`/api/design-systems/${systemId}`, { method: "DELETE" });
+    expect(response.status).toBe(200);
+    expect(await readFile(path.join(outside, "victim.txt"), "utf8")).toBe("keep");
+  });
+
+  test("does not serve a design-system file through an escaping junction", async () => {
+    const root = await temp("bg04-system-root-");
+    const outside = await temp("bg04-system-outside-");
+    await writeFile(path.join(outside, "secret.css"), "secret", "utf8");
+    await makeDirLink(outside, path.join(root, "linked"));
+    const systemId = insertSystem(root);
+
+    const response = await createApp().request(`/api/design-systems/${systemId}/files/linked/secret.css`);
+    expect(response.status).toBe(404);
+  });
+
+  test("does not serve a static asset through an escaping junction", async () => {
+    const outside = await temp("bg04-static-outside-");
+    await writeFile(path.join(outside, "secret.txt"), "secret", "utf8");
+    const linkName = id("static-link");
+    const link = path.join(import.meta.dir, "..", "..", "frontend", "dist", "assets", linkName);
+    await makeDirLink(outside, link);
+    distLinks.push(link);
+
+    const response = await createApp().request(`/assets/${linkName}/secret.txt`);
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("attachments service", () => {
+  test("rejects a symlinked .attachments directory before writing any upload", async () => {
+    const root = await temp("bg04-attachment-project-");
+    const outside = await temp("bg04-attachment-outside-");
+    await makeDirLink(outside, path.join(root, ".attachments"));
+    const projectId = insertProject(root);
+    const sessionId = insertSession(projectId);
+
+    await expect(
+      saveSessionAttachments(sessionId, [new File(["secret"], "../../secret.txt", { type: "text/plain" })]),
+    ).rejects.toBeInstanceOf(PathBoundaryError);
+    expect(await readdir(outside)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Stage outcome

BG-04 establishes a realpath/canonical-path file boundary across BurnGuard's write, delete, and serve pipelines. Junctions and symlinks can no longer redirect managed file operations outside their owning roots, while symlinked project roots and not-yet-existing leaves remain supported.

## Commits

- Slice 1: `7c5f9623fdec5ffb277de9b760142b877e3969da`
- Slice 2: `7df593ad1261a1ae0fea209db5677b9c4c936b05`

## Sink coverage

### Slice 1 - export/checkpoint sinks

- Export staging entrypoints and output creation
- Export garbage-collection deletion
- Pre-turn checkpoint snapshot and restore paths
- Shared `resolveWithin` / `assertSafeName` canonical containment primitive

### Slice 2 - serve/attachments sinks

- Project file indexing and `/fs/*` reads
- HTML patch and undo atomic-write targets
- Draw sidecar reads and writes
- Export download `output_path`
- Project and design-system recursive deletion targets
- Design-system file serving
- Frontend static asset serving
- Attachment upload, extractor input/output sidecars, and cleanup paths, including symlinked `.attachments`

## RED -> GREEN evidence

- RED: `.omo/ulw-loop/evidence/bg-04/slice2/red.txt` (`0 pass / 12 fail` against slice 1 production)
- GREEN: `.omo/ulw-loop/evidence/bg-04/slice2/green.txt` (`252 pass / 0 fail`)
- Typecheck: `.omo/ulw-loop/evidence/bg-04/slice2/typecheck.txt`

## Green commands

- `cd packages/backend && bun test`
- `bun run typecheck`
