### PR TITLE
feat: deliver inline design vibe coding workspace

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,103 @@
+# BurnGuard Design System
+
+## Product stance
+
+BurnGuard is a local-first design workspace, not a generic AI chat shell. The
+canvas is the primary surface; chat, inspection, edits, comments, and undo are
+supporting tools that should keep the user's visual context intact. The
+interface should feel precise, quiet, and reversible.
+
+The visual direction combines premium utilitarian minimalism with Linear-like
+workspace precision. The existing blue brand accent remains the action color;
+neutral surfaces carry hierarchy so a selected artifact is more important than
+the chrome around it.
+
+## Tokens
+
+### Color
+
+- `background`: `#ffffff`
+- `foreground`: `#17191a`
+- `muted`: `#f1f3f5`
+- `muted-foreground`: `#757b80`
+- `border`: `#dce4ea`
+- `accent`: `#004fff`
+- `accent-soft`: `#ecf4ff`
+- `success`: `#00ce78`
+- `warning`: `#fca63d`
+- `danger`: `#ff524c`
+- `canvas-ink`: `#111111`
+
+Use semantic Tailwind tokens instead of new one-off colors. Accent is reserved
+for the next meaningful action, selection focus, and keyboard focus rings.
+Danger is reserved for destructive or unrecoverable states.
+
+### Type
+
+- UI: the existing system sans stack, with `font-sans` and normal sentence
+  case for user-facing copy.
+- Artifact metadata and selectors: `font-mono`, compact, and scannable.
+- Labels: 10–12px uppercase only for secondary section labels; never use
+  uppercase for primary actions or instructions.
+- Body line-height: at least 1.45. Do not use tracking-tight for body copy.
+
+### Shape and spacing
+
+- 1px borders use `border-border`.
+- Functional controls use 6–8px radii; badges may use full rounding.
+- Use the existing 4px spacing scale. Keep panel gutters at 12–16px.
+- Keep the canvas free of decorative cards; use one clear work surface and
+  one contextual inspector.
+
+## Component anatomy
+
+- **CanvasTopBar**: mode controls, refresh, and file-level undo. Each action
+  has an accessible name and a disabled state when unavailable.
+- **SelectorOverlay**: hover and selected bounds. Selection must preserve
+  element identity, computed styles, and an authoring anchor when one exists.
+- **SelectorReadOnlyPanel**: selected identity and computed/token context. When
+  the authoring anchor is available, it exposes the next inline action without
+  forcing the user to reselect the element in another mode.
+- **TweaksPanel**: focused, editable token controls. Save is an explicit
+  checkpoint; reset and undo remain visible and reversible.
+- **CommentPanel**: contextual feedback tied to an artifact path and optional
+  slide index. Resolved comments leave the active queue.
+- **ChatPane**: intent entry and streaming state. Chat must not obscure the
+  artifact or imply a completed update before the backend event arrives.
+
+## State and interaction rules
+
+- First run: explain the canvas and the next action without blocking creation.
+- Empty: provide one clear action and avoid fake content.
+- Loading: preserve the last stable artifact while showing what is pending.
+- Error: name the failed operation, preserve the user's input, and offer retry
+  or recovery. Never fail silently.
+- Saving: disable duplicate submission and show a local checkpoint state.
+- Saved: surface the changed artifact and make undo discoverable.
+- Cancelled/interrupted: keep the last stable artifact and make retry safe.
+- Keyboard: every toolbar action and inspector control is reachable in order;
+  focus is visible with the accent ring.
+- Reduced motion: state changes remain understandable without transitions.
+
+## Motion
+
+Use short opacity/color transitions for mode changes and selection feedback.
+Avoid layout movement during streaming. Under `prefers-reduced-motion: reduce`,
+remove non-essential transitions and preserve the same visible state changes.
+
+## Responsive behavior
+
+- Desktop: chat, canvas, and the contextual inspector share the viewport
+  without nested horizontal scrolling.
+- Narrow viewport: the inspector becomes a full-width contextual section below
+  the canvas; controls remain at least 44px high where touch is plausible.
+- Long selectors and file paths truncate visually but remain available in a
+  `title` or accessible description.
+
+## Evidence expectations
+
+Every new behavior needs a focused RED -> GREEN proof and a real app scenario.
+Visual review covers desktop and narrow viewport screenshots, keyboard focus,
+empty/loading/error/recovery states, and reduced motion. Generated artifacts
+must remain understandable on disk and reversible through the existing file
+patch and undo contracts.

--- a/doc/03-backend-adapters.md
+++ b/doc/03-backend-adapters.md
@@ -123,25 +123,23 @@ The Codex adapter is intentionally minimal today.
 Current command shape:
 
 ```text
-codex -p {prompt}
+codex exec --json --skip-git-repo-check --sandbox workspace-write -
 ```
 
 Behavior:
-- stdout is streamed directly as `chat.delta`
+- prompt text is piped through stdin so it is not exposed in process listings
+- stdout JSONL is normalized into chat, tool, file-change, usage, and completion events
 - stderr is consumed in parallel and traced
-- at process exit the adapter emits `chat.message_end`
-- then it emits `status.idle` based on the exit code
+- completed file-change paths are normalized against the project boundary
+- the adapter emits one `chat.message_end` and terminal `status.idle` sequence
 
 ### 6.2 Limitations
 
 The current Codex path does **not** provide:
-- structured tool events
-- structured file change events
-- token usage extraction
 - cancellation
 - replayable backend session identity
 
-It is effectively a raw text backend with shared session persistence around it.
+It remains a per-turn subprocess backend with shared session persistence around it.
 
 ## 7. Broker and Persistence
 

--- a/packages/backend/src/adapters/codex/event-mapping.ts
+++ b/packages/backend/src/adapters/codex/event-mapping.ts
@@ -1,0 +1,163 @@
+import path from "node:path";
+import { ulid } from "ulid";
+import type { NormalizedEvent } from "@bg/shared";
+import { resolveWithin } from "../../security/path-boundary";
+import type { CodexParserContext } from "./parser";
+
+export function mapCodexEnvelope(
+  obj: Record<string, unknown>,
+  ctx: CodexParserContext,
+): NormalizedEvent[] | null {
+  const type = asString(obj.type);
+  if (!type) return null;
+
+  switch (type) {
+    case "thread.started":
+      return [];
+    case "turn.started":
+      return [{ id: ulid(), ts: Date.now(), type: "status.running" }];
+    case "item.started":
+      return mapItem(obj.item, ctx, false);
+    case "item.completed":
+      return mapItem(obj.item, ctx, true);
+    case "turn.completed":
+      return mapTurnCompleted(obj.usage, ctx);
+    default:
+      return null;
+  }
+}
+
+function mapItem(
+  value: unknown,
+  ctx: CodexParserContext,
+  completed: boolean,
+): NormalizedEvent[] {
+  if (!isRecord(value)) return [];
+  const itemType = asString(value.type);
+  const itemId = asString(value.id) ?? ulid();
+  if (itemType === "agent_message" && completed) {
+    const text = asString(value.text);
+    return text
+      ? [{ id: ulid(), ts: Date.now(), type: "chat.delta", turnId: ctx.turnId, text }]
+      : [];
+  }
+  if (itemType === "error" && completed) {
+    return [{
+      id: ulid(),
+      ts: Date.now(),
+      type: "chat.delta",
+      turnId: ctx.turnId,
+      text: asString(value.message) ?? "Codex reported an error",
+    }];
+  }
+  if (itemType === "command_execution") {
+    if (!completed) {
+      return [{
+        id: ulid(),
+        ts: Date.now(),
+        type: "tool.started",
+        turnId: ctx.turnId,
+        toolCallId: itemId,
+        tool: itemType,
+        input: { command: asString(value.command) ?? "" },
+      }];
+    }
+    return [{
+      id: ulid(),
+      ts: Date.now(),
+      type: "tool.finished",
+      turnId: ctx.turnId,
+      toolCallId: itemId,
+      tool: itemType,
+      ok: asString(value.status) === "completed",
+      output: {
+        aggregated_output: value.aggregated_output ?? "",
+        exit_code: value.exit_code ?? null,
+      },
+    }];
+  }
+  if (itemType === "file_change" && completed) {
+    return mapFileChanges(value.changes, ctx);
+  }
+  return [];
+}
+
+function mapTurnCompleted(
+  value: unknown,
+  ctx: CodexParserContext,
+): NormalizedEvent[] {
+  const usage = isRecord(value) ? value : {};
+  const input = asNumber(usage.input_tokens) ?? 0;
+  const output = asNumber(usage.output_tokens) ?? 0;
+  const cached = asNumber(usage.cached_input_tokens);
+  return [
+    {
+      id: ulid(),
+      ts: Date.now(),
+      type: "usage.delta",
+      input,
+      output,
+      ...(cached != null ? { cached } : {}),
+    },
+    { id: ulid(), ts: Date.now(), type: "chat.message_end", turnId: ctx.turnId },
+    { id: ulid(), ts: Date.now(), type: "status.idle", stopReason: "end_turn" },
+  ];
+}
+
+function mapFileChanges(
+  value: unknown,
+  ctx: CodexParserContext,
+): NormalizedEvent[] {
+  if (!Array.isArray(value)) return [];
+  const events: NormalizedEvent[] = [];
+  for (const change of value) {
+    if (!isRecord(change)) continue;
+    const rawPath = asString(change.path);
+    if (!rawPath || !ctx.projectDir) continue;
+    const filePath = normalizeProjectPath(rawPath, ctx.projectDir);
+    if (!filePath) continue;
+    const kind = asString(change.kind);
+    events.push({
+      id: ulid(),
+      ts: Date.now(),
+      type: "file.changed",
+      turnId: ctx.turnId,
+      action: kind === "add" ? "created" : kind === "delete" ? "deleted" : "edited",
+      path: filePath,
+    });
+  }
+  return events;
+}
+
+function normalizeProjectPath(rawPath: string, projectDir: string): string | null {
+  const candidate = path.isAbsolute(rawPath)
+    ? rawPath
+    : path.resolve(projectDir, rawPath);
+  const relative = path.relative(projectDir, candidate);
+  if (
+    !relative ||
+    relative === ".." ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    return null;
+  }
+  try {
+    resolveWithin(projectDir, ...relative.split(path.sep));
+    return relative.split(path.sep).join("/");
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}

--- a/packages/backend/src/adapters/codex/index.ts
+++ b/packages/backend/src/adapters/codex/index.ts
@@ -2,6 +2,18 @@ import { ulid } from "ulid";
 import type { AdapterRunInput, AdapterRunResult } from "../types";
 import { parseCodexLine, type CodexParserContext } from "./parser";
 
+export function buildCodexCommand(binaryPath: string): string[] {
+  return [
+    binaryPath,
+    "exec",
+    "--json",
+    "--skip-git-repo-check",
+    "--sandbox",
+    "workspace-write",
+    "-",
+  ];
+}
+
 /**
  * Codex adapter — streams stdout through `parseCodexLine`.
  *
@@ -17,10 +29,12 @@ export async function runCodexTurn(
 ): Promise<AdapterRunResult> {
   const ctx: CodexParserContext = {
     turnId: input.turnId,
+    projectDir: input.projectDir,
     toolNames: new Map(),
   };
 
   let sawIdle = false;
+  let sawMessageEnd = false;
 
   // Same story as claude-code: register the sink for future mode
   // upgrades where decisions can be piped into the running CLI.
@@ -33,12 +47,9 @@ export async function runCodexTurn(
   });
 
   const proc = Bun.spawn({
-    // FIXME(codex): prompt is passed as a positional CLI arg — visible
-    // in `ps` listings. Move to stdin once the Codex CLI documents a
-    // stdin-reading mode (claude-code uses `claude -p` + stdin pipe).
-    cmd: [input.binaryPath, "-p", input.prompt],
+    cmd: buildCodexCommand(input.binaryPath),
     cwd: input.projectDir,
-    stdin: "ignore",
+    stdin: new Blob([input.prompt]),
     stdout: "pipe",
     stderr: "pipe",
     signal: input.signal,
@@ -66,6 +77,7 @@ export async function runCodexTurn(
         }
         for (const event of events) {
           if (event.type === "status.idle") sawIdle = true;
+          if (event.type === "chat.message_end") sawMessageEnd = true;
           await input.onEvent(event);
         }
       }),
@@ -81,12 +93,14 @@ export async function runCodexTurn(
     unsubscribeDecision?.();
   }
 
-  await input.onEvent({
-    id: ulid(),
-    ts: Date.now(),
-    type: "chat.message_end",
-    turnId: input.turnId,
-  });
+  if (!sawMessageEnd) {
+    await input.onEvent({
+      id: ulid(),
+      ts: Date.now(),
+      type: "chat.message_end",
+      turnId: input.turnId,
+    });
+  }
 
   if (!sawIdle) {
     // The CLI exited without emitting a structured `done` line — emit

--- a/packages/backend/src/adapters/codex/parser.ts
+++ b/packages/backend/src/adapters/codex/parser.ts
@@ -1,8 +1,10 @@
 import { ulid } from "ulid";
 import type { NormalizedEvent } from "@bg/shared";
+import { mapCodexEnvelope } from "./event-mapping";
 
 export interface CodexParserContext {
   turnId: string;
+  projectDir?: string;
   /** Correlates a tool_result line to the tool name set at tool_start. */
   toolNames: Map<string, string>;
 }
@@ -36,7 +38,9 @@ export function parseCodexLine(
     try {
       const parsed = JSON.parse(trimmed) as unknown;
       if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-        const mapped = mapStructured(parsed as Record<string, unknown>, ctx);
+        const record = parsed as Record<string, unknown>;
+        const mapped =
+          mapCodexEnvelope(record, ctx) ?? mapStructured(record, ctx);
         if (mapped) return mapped;
       }
     } catch {

--- a/packages/backend/src/lib/port.ts
+++ b/packages/backend/src/lib/port.ts
@@ -1,5 +1,13 @@
 import { createServer } from "node:net";
 
+type PortProbeServer = ReturnType<typeof createServer> & {
+  once(
+    event: "error" | "listening",
+    listener: (...args: unknown[]) => void,
+  ): PortProbeServer;
+  close(callback?: (error?: Error) => void): void;
+};
+
 export async function pickPort(start = 14070, end = 14170): Promise<number> {
   for (let p = start; p <= end; p++) {
     if (await isFree(p)) return p;
@@ -9,7 +17,7 @@ export async function pickPort(start = 14070, end = 14170): Promise<number> {
 
 function isFree(port: number): Promise<boolean> {
   return new Promise((resolve) => {
-    const srv = createServer();
+    const srv = createServer() as unknown as PortProbeServer;
     srv.once("error", () => resolve(false));
     srv.once("listening", () => srv.close(() => resolve(true)));
     srv.listen(port, "127.0.0.1");

--- a/packages/backend/src/routes/artifacts.ts
+++ b/packages/backend/src/routes/artifacts.ts
@@ -83,6 +83,29 @@ artifactRoutes.post("/api/projects/:id/refresh", async (c) => {
   return c.json(ok(artifacts satisfies ArtifactSummary));
 });
 
+// Hono matches routes in declaration order. Keep the specific undo-info
+// route before the generic file route so its suffix is not treated as part
+// of the relative file path.
+artifactRoutes.get("/api/projects/:id/fs/*/undo-info", async (c) => {
+  const projectId = c.req.param("id");
+  const project = await getProjectDetail(projectId);
+  if (!project) {
+    return c.json(
+      fail("project_not_found", "Project not found", { projectId }),
+      404,
+    );
+  }
+  const prefix = `/api/projects/${projectId}/fs/`;
+  const rawPath = c.req.path.replace(/\/undo-info$/, "");
+  const relPath = rawPath.startsWith(prefix)
+    ? decodeURIComponent(rawPath.slice(prefix.length))
+    : "";
+  if (!relPath) {
+    return c.json(fail("invalid_path", "File path is required"), 400);
+  }
+  return c.json(ok(getFileUndoState(projectId, relPath)));
+});
+
 artifactRoutes.get("/api/projects/:id/fs/*", async (c) => {
   const projectId = c.req.param("id");
   // Hono 4.x does not expose the wildcard match via c.req.param("*") for a
@@ -221,28 +244,7 @@ artifactRoutes.patch("/api/projects/:id/fs/*", async (c) => {
 });
 
 // Single-step file-level undo for the GUI patch path (audit fix #7).
-// GET reports whether the active file has an undo entry; POST restores
-// the pre-patch content and clears the entry.
-artifactRoutes.get("/api/projects/:id/fs/*/undo-info", async (c) => {
-  const projectId = c.req.param("id");
-  const project = await getProjectDetail(projectId);
-  if (!project) {
-    return c.json(
-      fail("project_not_found", "Project not found", { projectId }),
-      404,
-    );
-  }
-  const prefix = `/api/projects/${projectId}/fs/`;
-  const rawPath = c.req.path.replace(/\/undo-info$/, "");
-  const relPath = rawPath.startsWith(prefix)
-    ? decodeURIComponent(rawPath.slice(prefix.length))
-    : "";
-  if (!relPath) {
-    return c.json(fail("invalid_path", "File path is required"), 400);
-  }
-  return c.json(ok(getFileUndoState(projectId, relPath)));
-});
-
+// POST restores the pre-patch content and clears the entry.
 artifactRoutes.post("/api/projects/:id/fs/*/undo", async (c) => {
   const projectId = c.req.param("id");
   const project = await getProjectDetail(projectId);

--- a/packages/backend/src/security/path-boundary.ts
+++ b/packages/backend/src/security/path-boundary.ts
@@ -120,5 +120,11 @@ export function resolveWithin(root: string, ...segments: string[]): string {
     );
   }
 
+  // macOS exposes temporary directories through both `/var` and its
+  // canonical `/private/var` spelling. Preserve the public path spelling
+  // callers used while retaining the realpath-based containment check.
+  if (process.platform === "darwin" && resolved.startsWith("/private/")) {
+    return resolved.slice("/private".length);
+  }
   return resolved;
 }

--- a/packages/backend/src/services/files.ts
+++ b/packages/backend/src/services/files.ts
@@ -173,6 +173,9 @@ async function walk(rootDir: string, currentDir: string, output: FileInfo[]) {
     const relPath = path
       .relative(rootDir, path.join(currentDir, entry.name))
       .replaceAll("\\", "/");
+    if (isTransientFilePath(relPath)) {
+      continue;
+    }
     let absolute: string;
     try {
       absolute = resolveWithin(rootDir, relPath);
@@ -200,6 +203,11 @@ async function walk(rootDir: string, currentDir: string, output: FileInfo[]) {
       updated_at: stats.mtimeMs,
     });
   }
+}
+
+export function isTransientFilePath(relPath: string): boolean {
+  const baseName = path.posix.basename(relPath);
+  return /^\..+\.\d+\.\d+\.tmp$/.test(baseName);
 }
 
 function categorize(relPath: string): FileInfo["category"] {

--- a/packages/backend/src/services/watchers.ts
+++ b/packages/backend/src/services/watchers.ts
@@ -10,7 +10,7 @@ import {
   publishFileChangeFromWatcher,
   shouldEmitFileChange,
 } from "./file-change-broker";
-import { indexProjectFiles } from "./files";
+import { indexProjectFiles, isTransientFilePath } from "./files";
 import { appendSessionTrace } from "./trace";
 
 const IGNORED_TOP_LEVEL = new Set([".meta", ".attachments"]);
@@ -19,6 +19,10 @@ const watchers = new Map<string, FSWatcher>();
 const pendingReindex = new Map<string, Timer>();
 const pendingEmit = new Map<string, Timer>();
 const sessionIdCache = new Map<string, string>();
+
+type ErrorAwareWatcher = FSWatcher & {
+  on(event: "error", listener: (error: Error) => void): ErrorAwareWatcher;
+};
 
 export async function ensureProjectWatcher(projectId: string) {
   if (watchers.has(projectId)) {
@@ -36,7 +40,7 @@ export async function ensureProjectWatcher(projectId: string) {
   // real watcher below; on failure we delete it so a retry can run.
   watchers.set(projectId, RESERVED_WATCHER);
 
-  let watcher: FSWatcher;
+  let watcher: ErrorAwareWatcher;
   try {
     await indexProjectFiles(projectId);
 
@@ -50,7 +54,7 @@ export async function ensureProjectWatcher(projectId: string) {
         if (shouldSkipPath(relPath)) return;
         scheduleEmit(projectId, project.dir_path, relPath);
       },
-    );
+    ) as ErrorAwareWatcher;
   } catch (err) {
     watchers.delete(projectId);
     throw err;
@@ -116,9 +120,9 @@ export async function ensureAllProjectWatchers() {
   await Promise.all(projectIds.map((projectId) => ensureProjectWatcher(projectId)));
 }
 
-function shouldSkipPath(relPath: string): boolean {
+export function shouldSkipPath(relPath: string): boolean {
   const top = relPath.split("/")[0];
-  return IGNORED_TOP_LEVEL.has(top);
+  return IGNORED_TOP_LEVEL.has(top) || isTransientFilePath(relPath);
 }
 
 function scheduleReindex(projectId: string) {

--- a/packages/backend/tests/codex-parser.test.ts
+++ b/packages/backend/tests/codex-parser.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import path from "node:path";
 import {
   parseCodexLine,
   type CodexParserContext,
@@ -138,6 +139,89 @@ describe("parseCodexLine — structured path", () => {
       expect(e.message).toBe("boom");
       expect(e.recoverable).toBe(true);
     }
+  });
+
+  test("Codex item.completed agent messages become readable chat deltas", () => {
+    const c = ctx();
+    const [event] = parseCodexLine(
+      JSON.stringify({
+        type: "item.completed",
+        item: { type: "agent_message", text: "Changed only the headline." },
+      }),
+      c,
+    );
+    expect(event.type).toBe("chat.delta");
+    if (event.type === "chat.delta") {
+      expect(event.text).toBe("Changed only the headline.");
+    }
+  });
+
+  test("Codex recoverable item errors remain visible without poisoning a successful turn", () => {
+    const c = ctx();
+    const [event] = parseCodexLine(
+      JSON.stringify({
+        type: "item.completed",
+        item: { type: "error", message: "Skills were trimmed for this turn." },
+      }),
+      c,
+    );
+    expect(event.type).toBe("chat.delta");
+    if (event.type === "chat.delta") {
+      expect(event.text).toBe("Skills were trimmed for this turn.");
+    }
+  });
+
+  test("Codex turn.completed emits usage and one terminal status sequence", () => {
+    const c = ctx();
+    const events = parseCodexLine(
+      JSON.stringify({
+        type: "turn.completed",
+        usage: { input_tokens: 12, cached_input_tokens: 5, output_tokens: 7 },
+      }),
+      c,
+    );
+    expect(events.map((event) => event.type)).toEqual([
+      "usage.delta",
+      "chat.message_end",
+      "status.idle",
+    ]);
+    const usage = events[0];
+    if (usage.type === "usage.delta") {
+      expect(usage.input).toBe(12);
+      expect(usage.output).toBe(7);
+      expect(usage.cached).toBe(5);
+    }
+  });
+
+  test("Codex file changes stay project-relative and reject outside paths", () => {
+    const c = { ...ctx(), projectDir: process.cwd() };
+    const [inside] = parseCodexLine(
+      JSON.stringify({
+        type: "item.completed",
+        item: {
+          type: "file_change",
+          changes: [{ path: path.join(process.cwd(), "index.html"), kind: "update" }],
+          status: "completed",
+        },
+      }),
+      c,
+    );
+    expect(inside.type).toBe("file.changed");
+    if (inside.type === "file.changed") expect(inside.path).toBe("index.html");
+
+    expect(
+      parseCodexLine(
+        JSON.stringify({
+          type: "item.completed",
+          item: {
+            type: "file_change",
+            changes: [{ path: "/tmp/outside.html", kind: "update" }],
+            status: "completed",
+          },
+        }),
+        c,
+      ),
+    ).toHaveLength(0);
   });
 });
 

--- a/packages/backend/tests/codex-runner.test.ts
+++ b/packages/backend/tests/codex-runner.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { buildCodexCommand } from "../src/adapters/codex";
+
+describe("buildCodexCommand", () => {
+  test("uses Codex exec with JSON events and stdin prompt input", () => {
+    expect(buildCodexCommand("/opt/homebrew/bin/codex")).toEqual([
+      "/opt/homebrew/bin/codex",
+      "exec",
+      "--json",
+      "--skip-git-repo-check",
+      "--sandbox",
+      "workspace-write",
+      "-",
+    ]);
+  });
+});

--- a/packages/backend/tests/watchers.test.ts
+++ b/packages/backend/tests/watchers.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { isTransientFilePath } from "../src/services/files";
+import * as watchers from "../src/services/watchers";
+
+describe("project watcher path filtering", () => {
+  test("ignores atomic-write temporary artifacts", () => {
+    const shouldSkipPath = (
+      watchers as typeof watchers & {
+        shouldSkipPath?: (relPath: string) => boolean;
+      }
+    ).shouldSkipPath;
+
+    expect(typeof shouldSkipPath).toBe("function");
+    if (!shouldSkipPath) return;
+
+    expect(shouldSkipPath(".index.html.123.456.tmp")).toBe(true);
+    expect(shouldSkipPath("index.html")).toBe(false);
+    expect(isTransientFilePath(".index.html.123.456.tmp")).toBe(true);
+    expect(isTransientFilePath("nested/index.html")).toBe(false);
+  });
+});

--- a/packages/frontend/src/components/canvas/SelectorOverlay.tsx
+++ b/packages/frontend/src/components/canvas/SelectorOverlay.tsx
@@ -79,6 +79,8 @@ export default function SelectorOverlay({
       setSelectedKey(hit.selector);
       onSelect({
         nodeId: hit.selector,
+        bgId: hit.bgId,
+        tag: hit.tag,
         rect: {
           x: hit.rect.left,
           y: hit.rect.top,
@@ -86,6 +88,7 @@ export default function SelectorOverlay({
           h: hit.rect.height,
         },
         computed: hit.computed,
+        inline: hit.inline,
         file: activeRelPath ?? "",
       });
     });

--- a/packages/frontend/src/components/canvas/frame-bridge.ts
+++ b/packages/frontend/src/components/canvas/frame-bridge.ts
@@ -34,9 +34,11 @@ export interface FrameRect {
 export interface FrameSelectHit {
   rect: FrameRect | null;
   selector: string | null;
+  bgId: string | null;
   tag: string | null;
   text: string | null;
   computed: Record<string, string>;
+  inline: Record<string, string>;
 }
 
 export interface FrameCommentHit {
@@ -462,12 +464,18 @@ const BRIDGE_SCRIPT = String.raw`(function () {
 
     if (data.action === "hit-select") {
       var selectNode = resolveTargetAtPoint(payload.x, payload.y);
-      response = selectNode ? {
-        rect: toRect(selectNode),
-        selector: selectorOf(selectNode),
-        tag: String(selectNode.tagName || "").toLowerCase(),
-        text: String(selectNode.textContent || ""),
-        computed: readComputed(selectNode)
+      var selectAnchor = selectNode && selectNode.closest
+        ? selectNode.closest("[data-bg-node-id]")
+        : null;
+      var inspectNode = selectAnchor || selectNode;
+      response = inspectNode ? {
+        rect: toRect(inspectNode),
+        selector: selectorOf(inspectNode),
+        bgId: selectAnchor ? selectAnchor.getAttribute("data-bg-node-id") : null,
+        tag: String(inspectNode.tagName || "").toLowerCase(),
+        text: String(inspectNode.textContent || ""),
+        computed: readComputed(inspectNode),
+        inline: readInline(inspectNode)
       } : null;
     } else if (data.action === "hit-comment") {
       var commentNode = resolveTargetAtPoint(payload.x, payload.y);

--- a/packages/frontend/src/components/chat/ChatPane.tsx
+++ b/packages/frontend/src/components/chat/ChatPane.tsx
@@ -65,7 +65,7 @@ export default function ChatPane({
   const sessionRunning = session.status === "running";
 
   return (
-    <aside className="w-[360px] shrink-0 border-r border-border bg-background flex flex-col min-h-0">
+    <aside className="w-[360px] shrink-0 border-r border-border bg-background flex flex-col min-h-0 overflow-hidden max-[900px]:w-full max-[900px]:h-[300px] max-[900px]:border-r-0 max-[900px]:border-b">
       <div className="flex items-stretch gap-1 px-3 pt-2 border-b border-border">
         <ChatTab
           id="chat"

--- a/packages/frontend/src/components/export/ExportMenu.tsx
+++ b/packages/frontend/src/components/export/ExportMenu.tsx
@@ -167,7 +167,12 @@ export default function ExportMenu({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="sm" className="gap-1.5">
+        <Button
+          variant="outline"
+          size="sm"
+          className="gap-1.5 max-[900px]:w-8 max-[900px]:justify-center max-[900px]:gap-0 max-[900px]:px-0 max-[900px]:text-[0px]"
+          aria-label="Export"
+        >
           <Download className="h-3.5 w-3.5" /> Export
         </Button>
       </DropdownMenuTrigger>

--- a/packages/frontend/src/components/modes/ModePanel.tsx
+++ b/packages/frontend/src/components/modes/ModePanel.tsx
@@ -12,6 +12,7 @@ import DrawPanel from "./DrawPanel";
 import EditPanel from "./EditPanel";
 import SelectorReadOnlyPanel from "./SelectorReadOnlyPanel";
 import TweaksPanel from "./TweaksPanel";
+import type { TweakChangePreview } from "./TweaksPanel";
 
 /**
  * Right-side mode pane. Renders nothing when no mode is active so the canvas
@@ -21,6 +22,7 @@ import TweaksPanel from "./TweaksPanel";
 export default function ModePanel({
   mode,
   selection,
+  onPromoteToTweaks,
   comments,
   activeRelPath,
   activeSlideIdx,
@@ -37,6 +39,7 @@ export default function ModePanel({
   onApplyTweak,
   onResetTweaks,
   onClearTweaks,
+  tweakReview,
   drawTool,
   drawColor,
   drawStrokeWidth,
@@ -50,6 +53,7 @@ export default function ModePanel({
 }: {
   mode: CanvasMode | null;
   selection: SelectedNode | null;
+  onPromoteToTweaks: () => void;
   comments: Comment[];
   activeRelPath: string | null;
   activeSlideIdx: number | null;
@@ -69,6 +73,7 @@ export default function ModePanel({
   onApplyTweak: (patch: Partial<Record<TweaksStyleKey, string | null>>) => void;
   onResetTweaks: () => void;
   onClearTweaks: () => void;
+  tweakReview: TweakChangePreview | null;
   drawTool: DrawTool;
   drawColor: string;
   drawStrokeWidth: number;
@@ -83,8 +88,13 @@ export default function ModePanel({
   if (!mode) return null;
 
   return (
-    <aside className="w-[320px] shrink-0 border-l border-border bg-background flex flex-col min-h-0">
-      {mode === "select" && <SelectorReadOnlyPanel selection={selection} />}
+    <aside className="w-[320px] shrink-0 border-l border-border bg-background flex flex-col min-h-0 overflow-hidden max-[900px]:w-full max-[900px]:max-h-[48vh] max-[900px]:border-l-0 max-[900px]:border-t">
+      {mode === "select" && (
+        <SelectorReadOnlyPanel
+          selection={selection}
+          onPromoteToTweaks={onPromoteToTweaks}
+        />
+      )}
       {mode === "tweaks" && (
         <TweaksPanel
           target={tweaksTarget}
@@ -92,6 +102,7 @@ export default function ModePanel({
           onApply={onApplyTweak}
           onResetAll={onResetTweaks}
           onClear={onClearTweaks}
+          review={tweakReview}
         />
       )}
       {mode === "comment" && (

--- a/packages/frontend/src/components/modes/SelectorReadOnlyPanel.tsx
+++ b/packages/frontend/src/components/modes/SelectorReadOnlyPanel.tsx
@@ -1,9 +1,16 @@
 import type { SelectedNode } from "@/types/project";
+import {
+  TWEAKS_STYLE_KEYS,
+  type TweaksStyleKey,
+  type TweaksTarget,
+} from "@/components/canvas/TweaksLayer";
 
 export default function SelectorReadOnlyPanel({
   selection,
+  onPromoteToTweaks,
 }: {
   selection: SelectedNode | null;
+  onPromoteToTweaks: () => void;
 }) {
   if (!selection) {
     return (
@@ -15,7 +22,7 @@ export default function SelectorReadOnlyPanel({
           Click an element in the canvas to inspect its computed styles.
         </p>
         <p className="mt-3 text-[10px] text-muted-foreground leading-relaxed">
-          Read-only in Phase 1. Editable CSS fields ship in Phase 3 (Tweaks).
+          Select an authored element to carry its context into inline Tweaks.
         </p>
       </div>
     );
@@ -73,10 +80,44 @@ export default function SelectorReadOnlyPanel({
       ))}
 
       <p className="text-[10px] text-muted-foreground px-1 mt-3 leading-relaxed">
-        Read-only in Phase 1. Editable CSS fields ship in Phase 3 (Tweaks).
+        Computed values come from the live canvas. Inline changes are saved as
+        reversible file patches.
       </p>
+      {selection.bgId && (
+        <button
+          type="button"
+          onClick={onPromoteToTweaks}
+          className="mx-1 mt-3 w-[calc(100%-0.5rem)] rounded-md bg-accent px-3 py-2 text-xs font-medium text-accent-foreground transition-colors hover:bg-accent/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          Open in Tweaks
+        </button>
+      )}
     </div>
   );
+}
+
+export function selectedNodeToTweaksTarget(
+  selection: SelectedNode | null,
+): TweaksTarget | null {
+  if (!selection?.bgId) return null;
+
+  const computed: Partial<Record<TweaksStyleKey, string>> = {};
+  const inline: Partial<Record<TweaksStyleKey, string>> = {};
+  for (const key of TWEAKS_STYLE_KEYS) {
+    if (selection.computed[key] !== undefined) {
+      computed[key] = selection.computed[key];
+    }
+    if (selection.inline[key] !== undefined) {
+      inline[key] = selection.inline[key];
+    }
+  }
+
+  return {
+    bg_id: selection.bgId,
+    tag: selection.tag ?? "div",
+    computed,
+    inline,
+  };
 }
 
 function Row({ k, v, last }: { k: string; v: string; last: boolean }) {

--- a/packages/frontend/src/components/modes/TweaksPanel.tsx
+++ b/packages/frontend/src/components/modes/TweaksPanel.tsx
@@ -6,6 +6,7 @@ import {
 } from "react";
 import { cn } from "@/lib/utils";
 import {
+  TWEAKS_STYLE_KEYS,
   type TweaksStyleKey,
   type TweaksTarget,
 } from "@/components/canvas/TweaksLayer";
@@ -19,6 +20,28 @@ import {
 } from "./tweaks-utils";
 
 type ApplyFn = (patch: Partial<Record<TweaksStyleKey, string | null>>) => void;
+
+export interface TweakChangePreview {
+  property: TweaksStyleKey;
+  from: string;
+  to: string;
+}
+
+export function buildTweakChangePreview(
+  target: TweaksTarget,
+  patch: Partial<Record<TweaksStyleKey, string | null>>,
+): TweakChangePreview | null {
+  for (const property of TWEAKS_STYLE_KEYS) {
+    const next = patch[property];
+    if (next === undefined) continue;
+    return {
+      property,
+      from: target.inline[property] ?? target.computed[property] ?? "unset",
+      to: next ?? "unset",
+    };
+  }
+  return null;
+}
 
 const FONT_WEIGHTS: Array<{ value: string; label: string }> = [
   { value: "300", label: "Light (300)" },
@@ -59,12 +82,14 @@ export default function TweaksPanel({
   onApply,
   onResetAll,
   onClear,
+  review,
 }: {
   target: TweaksTarget | null;
   saving: boolean;
   onApply: ApplyFn;
   onResetAll: () => void;
   onClear: () => void;
+  review: TweakChangePreview | null;
 }) {
   if (!target) {
     return (
@@ -112,6 +137,26 @@ export default function TweaksPanel({
           data-bg-node-id="{target.bg_id}"
         </div>
       </div>
+      {review && (
+        <section
+          aria-label="Last inline patch"
+          className="border-b border-border bg-muted/30 px-3 py-2"
+        >
+          <SectionHeader>Last patch</SectionHeader>
+          <pre className="mt-1.5 overflow-x-auto rounded border border-border bg-background px-2 py-1.5 font-mono text-[10px] leading-relaxed">
+            <span className="text-muted-foreground">
+              - {review.property}: {review.from}
+            </span>
+            {"\n"}
+            <span className="text-foreground">
+              + {review.property}: {review.to}
+            </span>
+          </pre>
+          <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
+            Saved as a reversible inline style override.
+          </p>
+        </section>
+      )}
 
       <section className="border-b border-border px-3 py-2">
         <SectionHeader>Typography</SectionHeader>

--- a/packages/frontend/src/components/project/ProjectTopBar.tsx
+++ b/packages/frontend/src/components/project/ProjectTopBar.tsx
@@ -18,8 +18,8 @@ export default function ProjectTopBar({
 }) {
   const displayName = stripInternalProjectTag(project.name);
   return (
-    <header className="h-12 border-b border-border bg-background flex items-stretch shrink-0">
-      <div className="flex items-center gap-3 px-4 shrink-0 border-r border-border">
+    <header className="h-12 border-b border-border bg-background flex items-stretch shrink-0 overflow-hidden">
+      <div className="flex items-center gap-3 px-4 shrink-0 border-r border-border max-[900px]:gap-2 max-[900px]:px-2">
         <Link
           to="/"
           className="text-muted-foreground hover:text-foreground"
@@ -29,7 +29,7 @@ export default function ProjectTopBar({
         </Link>
         <div className="flex items-center min-w-0">
           <div
-            className="text-sm font-medium w-[180px] truncate"
+            className="text-sm font-medium w-[180px] truncate max-[900px]:w-[96px]"
             title={displayName}
           >
             {displayName}
@@ -37,11 +37,11 @@ export default function ProjectTopBar({
         </div>
       </div>
       <div className="flex-1 min-w-0 overflow-x-auto">{tabsSlot}</div>
-      <div className="px-3 flex items-center gap-2 shrink-0">
+      <div className="px-3 flex items-center gap-2 shrink-0 max-[900px]:px-2 max-[900px]:gap-1">
         <Button
           variant="ghost"
           size="sm"
-          className="gap-1.5"
+          className="gap-1.5 max-[900px]:w-8 max-[900px]:justify-center max-[900px]:gap-0 max-[900px]:px-0 max-[900px]:text-[0px]"
           onClick={onPresent}
           disabled={!canPresent || !onPresent}
           title={

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -113,3 +113,14 @@
   background-color: rgb(var(--muted-foreground) / 0.5);
   background-clip: padding-box;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/packages/frontend/src/types/project.ts
+++ b/packages/frontend/src/types/project.ts
@@ -15,8 +15,11 @@ export type SessionInfoLocal = SessionInfo;
 /** UI state only — not a backend concept. */
 export interface SelectedNode {
   nodeId: string;
+  bgId?: string | null;
+  tag?: string | null;
   rect: { x: number; y: number; w: number; h: number };
   computed: Record<string, string>;
+  inline: Record<string, string>;
   file: string;
 }
 

--- a/packages/frontend/src/views/ProjectView.tsx
+++ b/packages/frontend/src/views/ProjectView.tsx
@@ -61,6 +61,11 @@ import type {
 import { getProjectDraws, putProjectDraws } from "@/api/draws";
 import PresentOverlay from "@/components/present/PresentOverlay";
 import ModePanel from "@/components/modes/ModePanel";
+import { selectedNodeToTweaksTarget } from "@/components/modes/SelectorReadOnlyPanel";
+import {
+  buildTweakChangePreview,
+  type TweakChangePreview,
+} from "@/components/modes/TweaksPanel";
 import type { CanvasMode } from "@/components/modes/types";
 import ArtifactTabs from "@/components/project/ArtifactTabs";
 import ProjectTopBar from "@/components/project/ProjectTopBar";
@@ -114,6 +119,9 @@ export default function ProjectView() {
   const [activeSlideIdx, setActiveSlideIdx] = useState<number | null>(null);
   const [editTarget, setEditTarget] = useState<EditTarget | null>(null);
   const [tweaksTarget, setTweaksTarget] = useState<TweaksTarget | null>(null);
+  const [tweakReview, setTweakReview] = useState<TweakChangePreview | null>(
+    null,
+  );
   const tweaksUndoRef = useRef<TweaksUndoFrame[]>([]);
   const tweaksRedoRef = useRef<TweaksUndoFrame[]>([]);
   const [presentOpen, setPresentOpen] = useState(false);
@@ -704,6 +712,10 @@ export default function ProjectView() {
           queryKey: ["project", id, "artifacts"],
         }),
       ]);
+      setSelection(null);
+      setTweaksTarget(null);
+      setTweakReview(null);
+      setMode(null);
       setRefreshTick((value) => value + 1);
       pushToast({ title: "Last save undone", tone: "success" });
     },
@@ -775,7 +787,7 @@ export default function ProjectView() {
           />
         }
       />
-      <div className="flex min-h-0 flex-1">
+      <div className="flex min-h-0 flex-1 overflow-hidden max-[900px]:flex-col max-[900px]:overflow-y-auto">
         <ChatPane
           events={events}
           session={session}
@@ -846,7 +858,10 @@ export default function ProjectView() {
               src={canvasSrc}
               frameKey={`${canvasSrc ?? "entrypoint"}:${refreshTick}`}
               onModeChange={setMode}
-              onSelect={setSelection}
+              onSelect={(next) => {
+                setSelection(next);
+                if (!next) setTweakReview(null);
+              }}
               onRefresh={() => {
                 if (!id) return;
                 refreshMutation.mutate();
@@ -894,6 +909,12 @@ export default function ProjectView() {
             <ModePanel
               mode={mode}
               selection={selection}
+              onPromoteToTweaks={() => {
+                const target = selectedNodeToTweaksTarget(selection);
+                if (!target) return;
+                setTweaksTarget(target);
+                setMode("tweaks");
+              }}
               comments={comments}
               activeRelPath={activeRelPath}
               activeSlideIdx={activeSlideIdx}
@@ -925,9 +946,11 @@ export default function ProjectView() {
               }}
               onClearEdit={() => setEditTarget(null)}
               tweaksTarget={tweaksTarget}
+              tweakReview={tweakReview}
               tweaksSaving={tweaksMutation.isPending}
               onApplyTweak={(patch) => {
                 if (!activeRelPath || !tweaksTarget) return;
+                setTweakReview(buildTweakChangePreview(tweaksTarget, patch));
                 const frame = buildTweaksUndoFrame(
                   tweaksTarget,
                   activeRelPath,
@@ -964,7 +987,10 @@ export default function ProjectView() {
                   },
                 });
               }}
-              onClearTweaks={() => setTweaksTarget(null)}
+              onClearTweaks={() => {
+                setTweaksTarget(null);
+                setTweakReview(null);
+              }}
               drawTool={drawTool}
               drawColor={drawColor}
               drawStrokeWidth={drawStrokeWidth}

--- a/packages/frontend/tests/selection-bridge.test.ts
+++ b/packages/frontend/tests/selection-bridge.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import * as selectorPanel from "../src/components/modes/SelectorReadOnlyPanel";
+import type { SelectedNode } from "../src/types/project";
+
+describe("selected canvas node to inline tweaks bridge", () => {
+  test("preserves the authoring anchor and computed token context", () => {
+    const selectedNode = {
+      nodeId: '[data-bg-node-id="hero"]',
+      bgId: "hero",
+      tag: "button",
+      rect: { x: 12, y: 24, w: 160, h: 44 },
+      computed: {
+        "font-size": "14px",
+        color: "rgb(23, 25, 26)",
+      },
+      inline: {
+        color: "#17191a",
+      },
+      file: "index.html",
+    } as SelectedNode;
+    const bridge = (
+      selectorPanel as typeof selectorPanel & {
+        selectedNodeToTweaksTarget?: (
+          node: SelectedNode | null,
+        ) => unknown;
+      }
+    ).selectedNodeToTweaksTarget;
+
+    expect(typeof bridge).toBe("function");
+    if (!bridge) return;
+
+    expect(bridge(selectedNode)).toEqual({
+      bg_id: "hero",
+      tag: "button",
+      computed: selectedNode.computed,
+      inline: selectedNode.inline,
+    });
+    expect(bridge({ ...selectedNode, bgId: undefined })).toBeNull();
+  });
+});

--- a/packages/frontend/tests/tweak-review.test.ts
+++ b/packages/frontend/tests/tweak-review.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import * as tweaksPanel from "../src/components/modes/TweaksPanel";
+import type {
+  TweaksStyleKey,
+  TweaksTarget,
+} from "../src/components/canvas/TweaksLayer";
+
+describe("inline tweak review", () => {
+  test("summarizes the source value and the proposed patch", () => {
+    const target: TweaksTarget = {
+      bg_id: "hero",
+      tag: "h1",
+      computed: { "font-size": "48px" },
+      inline: { "font-size": "48px" },
+    };
+    const buildPreview = (
+      tweaksPanel as typeof tweaksPanel & {
+        buildTweakChangePreview?: (
+          target: TweaksTarget,
+          patch: Partial<Record<TweaksStyleKey, string | null>>,
+        ) => unknown;
+      }
+    ).buildTweakChangePreview;
+
+    expect(typeof buildPreview).toBe("function");
+    if (!buildPreview) return;
+
+    expect(buildPreview(target, { "font-size": "52px" })).toEqual({
+      property: "font-size",
+      from: "48px",
+      to: "52px",
+    });
+  });
+});

--- a/scripts/build-binary.ts
+++ b/scripts/build-binary.ts
@@ -35,14 +35,15 @@ async function main() {
   console.log(`[build] target: bun-windows-x64`);
 
   const start = Date.now();
-  // --external electron: playwright-core imports electron in an
-  // optional loader we never hit (we only drive headless chromium).
-  // Without the flag bun fails to resolve the module at compile.
+  // --external electron/chromium-bidi: playwright-core imports both in
+  // optional loaders we never hit (we only drive headless chromium).
+  // Without the flags bun fails to resolve those optional modules at compile.
   await $`bun build ${ENTRY} \
     --compile \
     --target=bun-windows-x64 \
     --minify \
     --external electron \
+    --external chromium-bidi \
     --outfile ${OUT}`.cwd(ROOT);
 
   const elapsed = ((Date.now() - start) / 1000).toFixed(1);


### PR DESCRIPTION
## Summary
- Deliver the existing inline design vibe coding workspace to `main` without expanding scope.
- Keep selection context, reversible tweaks, comments, readable patch review, responsive layout, and checkpoint/recovery behavior in the canvas.
- Stream Codex JSONL events through stdin with structured chat/tool/file/usage/completion mapping and project-boundary enforcement.
- Include the related design and backend adapter documentation plus focused frontend/backend regression tests.

## Validation
- `bun --config=/dev/null test packages/backend/tests/codex-parser.test.ts packages/backend/tests/codex-runner.test.ts packages/backend/tests/path-boundary.test.ts packages/backend/tests/file-patch.test.ts packages/backend/tests/serve-path-boundary.test.ts` — 66 passed.
- `bun --config=/dev/null test packages/backend/tests` — 275 passed.
- `bun run typecheck` — passed.
- `bun run build` — passed.
- `bun pm untrusted` — 0 untrusted dependencies.
- `git diff --check` — passed.
- Real-app browser QA was completed on the delivered product loop before this clean squash.

## Security and scope notes
- `bun audit --audit-level high` reports three pre-existing high advisories in unchanged dependencies (`image-size` through `pptxgenjs`, and `vite`).
- The repository default test config enables an 80% coverage threshold; all tests pass, while the default command reports the pre-existing 59.26% aggregate coverage result.
- This clean delivery commit intentionally excludes generated `.omo/evidence`, `init-deep`, `senpi-task`, loop state/quality artifacts, and secrets.
- Merge and auto-merge are intentionally not enabled.