### PR TITLE
feat: add purpose-aware briefs and reference layouts

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -53,7 +53,7 @@ Bun 모노레포이고, 워크스페이스 패키지 셋에 스크립트가 붙�
 ## 한 턴의 전체 흐름
 
 1. 채팅 창에 메시지를 보냅니다. 백엔드가 사용자 이벤트를 기록하고 프로젝트 트리를 체크포인트로 스냅샷합니다.
-2. `packages/backend/src/harness/prompt-builder.ts`가 프롬프트를 결정적으로 조립합니다. 프로젝트 정보, 프로젝트 타입 skill, 디자인 시스템 토큰, 열려 있는 코멘트 핀, 첨부 요약, 필요 시 엔트리포인트 구조 맵, 그리고 `<burnguard-research-context-v1>` 블록입니다.
+2. `packages/backend/src/harness/prompt-builder.ts`가 프롬프트를 결정적으로 조립합니다. 프로젝트 정보, 프로젝트 타입 skill, 버전이 붙은 디자인 브리프, 디자인 시스템 토큰, 열려 있는 코멘트 핀, 첨부 요약, 필요 시 reference-layout 계약과 엔트리포인트 구조 맵, 그리고 `<burnguard-research-context-v1>` 블록입니다.
 3. 어댑터(`adapters/claude-code` 또는 `adapters/codex`)가 CLI를 실행해 stdout을 스트리밍하고, 채팅 델타 / 툴 시작·종료 / 파일 변경 / 사용량 / 상태 같은 타입 이벤트로 정규화합니다.
 4. 이벤트는 SQLite에 순번과 함께 기록되고 SSE(`GET /api/sessions/:id/stream`)로 전달됩니다. 감시 중인 파일이 바뀌면 캔버스 iframe이 다시 로드됩니다.
 5. 캔버스에서 검토하고, 코멘트 핀을 찍고, GUI로 요소를 패치하고, 턴을 되돌리거나 export합니다.
@@ -75,11 +75,13 @@ Bun 모노레포이고, 워크스페이스 패키지 셋에 스크립트가 붙�
 - **공통 규칙**(`common-rules.json`, 15개 `CR-***`)은 재사용 가능하며 원장 ID를 인용합니다. 각 규칙은 `authority_class`를 선언합니다.
   - `normative_web_constraint`는 WCAG 자료를 재서술합니다. 한계 필드가 기준 레벨, 범위, 예외를 보존합니다. 그 단서를 떼어내 규칙을 더 강하게 만들면 안 됩니다.
   - `sampled_system_guidance`는 공개 디자인 시스템의 한정된 표본에서 반복되는 내용을 종합한 것입니다. 반복은 지침을 뒷받침할 뿐 보편 법칙이 아닙니다. 구체적인 간격 값, 그리드, 폰트, 색, 브레이크포인트, radius, 벤더 토큰 이름은 시스템 고유로 남습니다.
-- **목적 참조 세트**(`purpose-references.json`)는 여섯 개의 선택자 레코드입니다. `deck.pitch`, `prototype.dashboard`, `prototype.diagram`, `prototype.editorial`, `prototype.landing`, `prototype.sandbox`. purpose는 네 개 축(`project_type`, `request_intent`, `creation_mode`, `fallback`) 위의 선택자이지 새 프로젝트 타입이 아닙니다. 각 purpose는 고유 guidance, 끌어오는 공통 규칙, 인용, 신뢰도, 한계를 갖습니다. `deck.pitch`가 medium 신뢰도인 건 의도적입니다. 출처가 뒷받침하는 건 주의 집중과 접근 가능한 전달이지, 보편적인 투자 피치 서사가 아닙니다.
+- **목적 참조 세트**(`purpose-references.json`)는 열 개의 prompt 선택자 레코드입니다. `deck.company`, `deck.pitch`, `deck.report`, `deck.sales`, `deck.training`, `prototype.dashboard`, `prototype.diagram`, `prototype.editorial`, `prototype.landing`, `prototype.sandbox`. purpose는 네 개 축(`project_type`, `request_intent`, `creation_mode`, `fallback`) 위의 선택자이지 새 프로젝트 타입이 아닙니다. 각 purpose는 고유 guidance, 끌어오는 공통 규칙, 인용, 신뢰도, 한계를 갖습니다. deck 레코드는 medium 신뢰도입니다. 출처가 뒷받침하는 건 범위가 있는 전달 원칙이지 각 deck 종류의 보편 서사가 아닙니다.
 
 두 등급이 함께 적용되면 규범적 제약이 이깁니다. 표본 기반 지침은 구현 패턴을 고를 수는 있어도 규범적 제약을 약화시킬 수 없습니다. 요청이 어떤 선택자와도 맞지 않으면 공통 베이스라인(`CR-001`~`CR-005`, `CR-008`, `CR-009`)으로 폴백하고 `request_intent: "unspecified"`로 보고합니다.
 
-카탈로그 로더(`services/research-catalog.ts`)는 엄격합니다. 알 수 없는 키, 잘못된 schema version, https가 아닌 URL, 형식에 맞지 않는 ID, 정렬되지 않거나 중복된 ID, 해소되지 않는 인용, 지원되는 여섯 purpose와 정확히 일치하지 않는 집합을 모두 거부합니다.
+카탈로그 로더(`services/research-catalog.ts`)는 엄격합니다. 알 수 없는 키, 잘못된 schema version, https가 아닌 URL, 형식에 맞지 않는 ID, 정렬되지 않거나 중복된 ID, 해소되지 않는 인용, 지원되는 열 개 prompt purpose와 정확히 일치하지 않는 집합을 모두 거부합니다.
+
+영속화되는 대량 리서치 계약은 더 좁습니다. 다섯 prototype purpose와 `deck.pitch`만 허용합니다. 새로 추가된 네 deck 선택자는 prompt catalog 전용이며 영속 리서치 결과의 purpose로는 허용되지 않습니다.
 
 ### 우선순위와 오버라이드
 
@@ -106,7 +108,7 @@ Bun 모노레포이고, 워크스페이스 패키지 셋에 스크립트가 붙�
 | `max_sources` | 1 ~ 200 |
 | `max_bytes_per_source` | 1 ~ 10000000 |
 
-`purposes`는 정렬되고 중복이 없어야 하며 지원되는 여섯 purpose에서만 골라야 합니다. `mode`는 `fixture` 또는 `live`이고, `fixture_id`는 fixture 모드일 때만 존재해야 합니다. live 모드에서는 모든 출처가 `web` 또는 `repository` 종류의 `https` URL이어야 하고 자격 증명이 URL에 포함되면 안 됩니다.
+`purposes`는 정렬되고 중복이 없어야 하며 지원되는 여섯 persisted-research purpose에서만 골라야 합니다. `mode`는 `fixture` 또는 `live`이고, `fixture_id`는 fixture 모드일 때만 존재해야 합니다. live 모드에서는 모든 출처가 `web` 또는 `repository` 종류의 `https` URL이어야 하고 자격 증명이 URL에 포함되면 안 됩니다.
 
 ### 라우트
 
@@ -261,14 +263,14 @@ bun test                                           # 전체 스위트
 bun test packages/backend/tests/research-catalog.test.ts   # 카탈로그 검증기 단독
 ```
 
-리서치 관련 아홉 개 스위트(`research-catalog`, `research-contract`, `research-repository`, `research-migration`, `research-orchestrator`, `research-recovery`, `research-routes`, `research-selection`, `research-purpose-prompt`)는 60개 테스트를 실행하고 함께 통과합니다. 전체 스위트는 70개 파일, 645개 테스트입니다. `bun run build:frontend`를 먼저 돌리지 않으면 번들이 없어 정적 서빙 테스트가 실패합니다. QA 하네스 manifest 케이스는 추가로 저장소와 증거 상태에 의존하므로 작업 트리가 지저분하면 실패할 수 있습니다.
+리서치 스위트는 catalog 검증, 계약, repository, migration, orchestration, recovery, route, selection, prompt routing을 다룹니다. `bun run build:frontend`를 먼저 돌리지 않으면 번들이 없어 정적 서빙 테스트가 실패합니다. QA 하네스 manifest 케이스는 추가로 저장소, branch, 증거 상태에 의존합니다.
 
 ## 한계
 
 - **임의 HTML 리서치 파싱은 없습니다.** 라이브 리서치 출처는 문서화된 claim 형태의 구조화 JSON이어야 합니다. 웹 페이지를 긁어서 디자인 규칙을 만들지 않습니다. HTML / CSS에서 디자인 시스템을 추출하는 건 별도 계약을 가진 다른 하위 시스템입니다.
 - **리서치 UI가 없습니다.** run을 시작하거나 관찰하거나 탐색하는 화면이 없습니다. API나 QA CLI를 쓰세요.
 - **run 결과는 아직 프롬프트로 들어가지 않습니다.** 턴마다 주입되는 리서치 블록은 저장소에 포함된 카탈로그에서 만들어집니다. 영속화된 run 결과를 purpose에 맞춰 선택하는 기능(`selectResearchPromptContext`)은 구현되고 테스트되어 있지만, 프롬프트 빌더가 아직 사용하지 않습니다.
-- **카탈로그는 한정적입니다.** 출처 45개, 공통 규칙 15개, purpose 6개이고 모두 한 날짜에 수집되었습니다. 규칙에 한계가 붙어 있는 데는 이유가 있습니다. 보편 법칙처럼 쓰기 전에 읽으세요.
+- **카탈로그는 한정적입니다.** 출처 45개, 공통 규칙 15개, prompt purpose 10개, persisted-research purpose 6개이고 모두 한 날짜에 수집되었습니다. 규칙에 한계가 붙어 있는 데는 이유가 있습니다. 보편 법칙처럼 쓰기 전에 읽으세요.
 - **표본 기반 지침은 법이 아닙니다.** 표본 시스템의 수치, 그리드, 벤더 토큰 이름은 그 시스템 고유로 남습니다.
 - **PDF / PPTX export에는 Chromium이 필요합니다.** 렌더링은 `playwright-core`를 거치며 번들 Chromium을 실행하고, 안 되면 설치된 Chrome이나 Edge 채널로 폴백합니다. 셋 다 없으면 해당 export 작업은 Chromium 안내와 함께 실패합니다.
 - **PDF / PPTX 인제스트에는 Python이 필요합니다.** 해당 형식의 디자인 시스템 업로드와 채팅 첨부는 `pypdf` 기반 Python 추출기를 거칩니다.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Data on disk:
 ## End-to-end flow of one turn
 
 1. You send a message in the chat pane. The backend records the user event and snapshots the project tree as a checkpoint.
-2. `packages/backend/src/harness/prompt-builder.ts` assembles the prompt deterministically: project facts, the project-type skill, design-system tokens, open comment pins, attachment summaries, an optional structural map of the entrypoint, and a `<burnguard-research-context-v1>` block.
+2. `packages/backend/src/harness/prompt-builder.ts` assembles the prompt deterministically: project facts, the project-type skill, the versioned design brief, design-system tokens, open comment pins, attachment summaries, an optional reference-layout contract, an optional structural map of the entrypoint, and a `<burnguard-research-context-v1>` block.
 3. The adapter (`adapters/claude-code` or `adapters/codex`) spawns the CLI, streams stdout, and normalizes it into typed events: chat deltas, tool start and end, file changes, usage, status.
 4. Events are sequenced into SQLite and fanned out over SSE (`GET /api/sessions/:id/stream`). The canvas iframe reloads when watched files change.
 5. You review on canvas, drop comment pins, patch elements through the GUI, revert the turn, or export.
@@ -75,11 +75,13 @@ Two different things, deliberately kept apart.
 - **Common rules** (`common-rules.json`, 15 `CR-***` records) are reusable and cite ledger IDs. Each declares an `authority_class`:
   - `normative_web_constraint` paraphrases WCAG material. Limitations preserve criterion level, scope, and exceptions. A rule must not be strengthened by dropping those qualifications.
   - `sampled_system_guidance` synthesizes what recurs across a bounded sample of public design systems. Recurrence supports guidance, not universal law. Exact spacing values, grids, fonts, colors, breakpoints, radii, and vendor token names stay system-specific.
-- **Purpose references** (`purpose-references.json`) are six selector records: `deck.pitch`, `prototype.dashboard`, `prototype.diagram`, `prototype.editorial`, `prototype.landing`, `prototype.sandbox`. A purpose is a selector over four axes (`project_type`, `request_intent`, `creation_mode`, `fallback`), never a new project type. Each purpose lists its own guidance, the common rules it pulls in, its citations, a confidence level, and its limitations. `deck.pitch` is medium confidence on purpose: the sources support attention and accessible delivery, not a universal investor-pitch narrative.
+- **Purpose references** (`purpose-references.json`) are ten prompt selector records: `deck.company`, `deck.pitch`, `deck.report`, `deck.sales`, `deck.training`, `prototype.dashboard`, `prototype.diagram`, `prototype.editorial`, `prototype.landing`, and `prototype.sandbox`. A purpose is a selector over four axes (`project_type`, `request_intent`, `creation_mode`, `fallback`), never a new project type. Each purpose lists its own guidance, the common rules it pulls in, its citations, a confidence level, and its limitations. The deck records are medium confidence on purpose: the sources support bounded communication principles, not a universal narrative for any deck kind.
 
 Normative constraints win when both classes apply. Sampled guidance may pick an implementation pattern; it cannot weaken a normative constraint. When a request matches no selector, routing falls back to the common baseline (`CR-001` through `CR-005`, `CR-008`, `CR-009`) and reports `request_intent: "unspecified"`.
 
-The catalog loader (`services/research-catalog.ts`) is strict. It rejects unknown keys, wrong schema versions, non-https URLs, malformed IDs, unsorted or duplicated IDs, unresolved citations, and any purpose set that is not exactly the six supported IDs.
+The catalog loader (`services/research-catalog.ts`) is strict. It rejects unknown keys, wrong schema versions, non-https URLs, malformed IDs, unsorted or duplicated IDs, unresolved citations, and any purpose set that is not exactly the ten supported prompt IDs.
+
+The persisted mass-research contract remains narrower: it accepts the five prototype purposes plus `deck.pitch`. The four added deck selectors are prompt-catalog purposes only and are not accepted as persisted research-result purposes.
 
 ### Precedence and overrides
 
@@ -106,7 +108,7 @@ Beyond the shipped catalog, the backend can run a bounded research job against s
 | `max_sources` | 1 to 200 |
 | `max_bytes_per_source` | 1 to 10000000 |
 
-`purposes` must be sorted, unique, and drawn from the six supported purposes. `mode` is `fixture` or `live`, and `fixture_id` must be present exactly when the mode is `fixture`. In live mode every source must be an `https` URL of kind `web` or `repository`, with no embedded credentials.
+`purposes` must be sorted, unique, and drawn from the six persisted-research purposes. `mode` is `fixture` or `live`, and `fixture_id` must be present exactly when the mode is `fixture`. In live mode every source must be an `https` URL of kind `web` or `repository`, with no embedded credentials.
 
 ### Routes
 
@@ -261,14 +263,14 @@ bun test                                           # whole suite
 bun test packages/backend/tests/research-catalog.test.ts   # catalog validator alone
 ```
 
-The nine research suites (`research-catalog`, `research-contract`, `research-repository`, `research-migration`, `research-orchestrator`, `research-recovery`, `research-routes`, `research-selection`, `research-purpose-prompt`) run 60 tests and pass together. The full suite is 645 tests across 70 files. Run `bun run build:frontend` first, otherwise the static-serving tests fail on a missing bundle; the QA harness manifest cases additionally depend on repository and evidence preconditions and can fail in a dirty working tree.
+The research suites cover catalog validation, contracts, repositories, migrations, orchestration, recovery, routes, selection, and prompt routing. Run `bun run build:frontend` first, otherwise the static-serving tests fail on a missing bundle; the QA harness manifest cases additionally depend on repository, branch, and evidence preconditions.
 
 ## Limitations
 
 - **No arbitrary HTML research parsing.** A live research source must be structured JSON in the documented claim shape. BurnGuard will not scrape a web page for design rules. Design-system extraction from HTML and CSS is a separate subsystem with its own contract.
 - **No research UI.** There is no screen for starting, watching, or browsing research runs. Use the API or the QA CLI.
 - **Run results do not feed the prompt yet.** The per-turn research block is built from the shipped catalog. The machinery to select a persisted run result for a purpose exists and is tested (`selectResearchPromptContext`), but the prompt builder does not consume it today.
-- **The catalog is bounded.** 45 sources, 15 common rules, six purposes, all retrieved on a single date. Rules carry limitations for a reason; read them before treating one as universal.
+- **The catalog is bounded.** 45 sources, 15 common rules, ten prompt purposes, and six persisted-research purposes, all retrieved on a single date. Rules carry limitations for a reason; read them before treating one as universal.
 - **Sampled guidance is not law.** Values, grids, and vendor token names from the sampled systems stay system-specific.
 - **PDF and PPTX export need Chromium.** Rendering goes through `playwright-core`, which launches bundled Chromium and falls back to installed Chrome or Edge channels. Without one of those, those export jobs fail with a Chromium hint.
 - **PDF and PPTX ingest need Python.** Design-system uploads and chat attachments of those types go through a Python extractor with `pypdf`.

--- a/doc/02-data-model.md
+++ b/doc/02-data-model.md
@@ -109,7 +109,7 @@ CREATE TABLE projects (
   entrypoint        TEXT NOT NULL DEFAULT 'index.html',
   thumbnail_path    TEXT,
   backend_id        TEXT NOT NULL,                   -- 'claude-code' | 'codex'
-  options_json      TEXT,                            -- Type-specific (slide_deck: {useSpeakerNotes: bool})
+  options_json      TEXT,                            -- Versioned project options; see below
   archived_at       INTEGER,
   created_at        INTEGER NOT NULL,
   updated_at        INTEGER NOT NULL
@@ -118,6 +118,20 @@ CREATE TABLE projects (
 CREATE INDEX idx_projects_updated ON projects(updated_at DESC);
 CREATE INDEX idx_projects_ds ON projects(design_system_id);
 ```
+
+`options_json` stores snake-case project options. The current object may contain
+`use_speaker_notes` for slide decks, `copy_as_is` for template-based projects,
+and a versioned `design_brief` with output type, audience, objective, content
+source, locale, brand mode, visual mood, density, and output size. The HTTP
+boundary rejects unknown keys and malformed brief fields before persistence;
+readers treat malformed legacy JSON as absent options rather than injecting a
+partial brief into an agent prompt.
+
+Reference-layout context is not stored in this column. It is derived
+deterministically per turn from the request and selected attachment metadata,
+then injected as `ReferenceLayoutContextV1`. The agent is instructed to
+materialize `layout-spec.json`; immutable-underlay behavior is a prompt/runtime
+contract, not a filesystem write lock.
 
 ### 2.4 `sessions`
 

--- a/doc/04-ui-spec.md
+++ b/doc/04-ui-spec.md
@@ -16,13 +16,19 @@ Left sidebar (fixed 360 px) + main grid (rest of viewport).
 - Type tabs: Prototype / Slide deck / From template / Other (each opens the "New project" panel)
 - On tab click, a "New {type}" panel slides in:
   - `Input` Project name (required)
-  - `Select` Design system dropdown (lists published DSs only)
+  - `Select` Design system dropdown (lists published DSs only; optional for ordinary projects)
+  - Korean design brief fields: audience, objective, content source, visual mood, density, and output size
   - Type-specific toggles:
     - Slide deck: "Use speaker notes"
-    - From template: "Copy template as-is" checkbox
-  - `Button` Create (primary CTA, disabled until name is filled)
+    - From template: "Copy template as-is" checkbox and an explicit published design-system source
+  - `Button` Create (primary CTA, disabled until name, audience, objective, and any required template source are valid)
   - Caption: "Only you can see your project by default"
 - Bottom: user email/name + `Docs` link + user avatar
+
+Template creation accepts any published design system as its source because a
+real install does not seed separate template-marked rows. Draft and review
+systems never become an implicit project brand, and the UI never selects a
+system on the user's behalf.
 
 **Main grid**
 - Top tabs: `Recent` · `Your designs` · `Examples` · `Design systems`
@@ -61,7 +67,7 @@ Three panels: Chat (left 360 px) + Canvas+Tabs (flex) + Mode Panel (right 320 px
 - Active tab: underline emphasis
 
 #### ChatPane (left)
-- Top: `Chat` · `Comments` tabs (Comments becomes live in Phase 2)
+- Top: `Chat` · `Comments` tabs. Comments explains how to activate the canvas `Comment` mode and place a pin.
 - Stream area: events rendered top-down in chronological order
   - `agent.message` block: markdown rendering
   - `agent.thinking`: gray inline text, wrapped in `<pre-response-think>`, collapsible
@@ -71,10 +77,10 @@ Three panels: Chat (left 360 px) + Canvas+Tabs (flex) + Mode Panel (right 320 px
   - `usage.delta`: cumulative totals in a footer strip
 - Bottom composer:
   - Multiline textarea with placeholder "Describe what you want to create..."
-  - Top-right icons: Settings ⚙, Attach 📎, Voice 🎤 (Phase 2+)
-  - `Import` button (bring in an existing folder/file)
+  - Settings control opens the real Settings dialog
+  - `자료 첨부` opens the bounded file attachment input
   - `Send` button (primary, Enter to send)
-  - File drop zone: dashed border around composer. Text: "DROP FILES HERE — Images, docs, references, Figma links, or folders"
+  - No separate Import control; attachments use the same validated upload path
 
 #### Canvas (center)
 - Default state: blank white background + placeholder "Describe your idea to get started"

--- a/doc/07-decisions.md
+++ b/doc/07-decisions.md
@@ -229,6 +229,63 @@ Format: one entry per decision, newest at the bottom. Numbering never reused.
 
 ---
 
+## ADR-013: Project creation persists a versioned design brief
+
+**Date**: 2026-08-25
+**Status**: Accepted
+
+**Context.** Project creation previously persisted only loose type-specific
+options and could silently select the first design-system row, including a
+draft. Korean non-designers need a bounded brief that survives creation and
+reaches the agent prompt. The product also exposes a `from_template` type, but
+real installs do not seed any row with `is_template = 1`.
+
+**Decision.** Persist a parsed `DesignBriefV1` inside `projects.options_json`
+alongside snake-case type-specific options. Require an explicit user choice
+before applying a design system. Ordinary projects may use a published
+non-template system or none; `from_template` requires an explicit published
+system and treats that system as the template source, regardless of its
+`is_template` flag.
+
+**Consequences.**
+- Audience, objective, locale, brand mode, visual mood, density, content
+  source, and output size reach the prompt as machine-readable context
+- Draft and review systems cannot silently become a project's brand
+- Template creation remains usable on a default install without inventing
+  template-marked seed data
+- The brief schema must be versioned when its persisted shape changes
+
+---
+
+## ADR-014: Reference layout is a versioned advisory prompt contract
+
+**Date**: 2026-08-25
+**Status**: Accepted
+
+**Context.** A selected drawing or plan plus page requirements must preserve
+dimensions, units, orientation, scale, bleed, safe margins, aspect ratio, and
+stable anchors without mutating the source. Treating every selected image as a
+drawing would misclassify ordinary logos and screenshots, while exporter
+support is limited to specific presets and dimensions.
+
+**Decision.** Derive `ReferenceLayoutContextV1` only from explicit
+layout/reference request intent or a selected attachment whose filename
+identifies a drawing, plan, layout, sketch, or reference. Keep selected
+attachment paths inside the existing attachment boundary. Mark the reference
+as an immutable underlay in the prompt contract, preserve missing measurements
+as explicit unknowns, use normalized top-left anchors, and report exporter
+limitations without coercing custom sizes.
+
+**Consequences.**
+- Ordinary content images do not trigger `layout-spec.json` work
+- Drawing filenames still activate the contract when request text is generic
+- Repeated inputs produce byte-stable layout context
+- Immutability is advisory to the coding agent; the filesystem does not enforce
+  a write lock on attachment bytes
+- Export support remains a declared capability rather than an inferred promise
+
+---
+
 ## Template for new ADRs
 
 ```

--- a/doc/reference-layout-provenance.md
+++ b/doc/reference-layout-provenance.md
@@ -1,0 +1,156 @@
+# Reference Layout Provenance
+
+Retrieval date: **2026-08-25**
+
+This document records where BurnGuard's reference-layout ideas came from, what was actually
+inspected, how strong the evidence is, and what we are and aren't allowed to reuse. It exists so
+that later readers can tell the difference between something we observed in running code and
+something we inferred from a README screenshot.
+
+Nothing in here reproduces source, prose, assets, or prompts from the referenced projects. Only
+principles and structural observations are carried over.
+
+## Evidence Grades
+
+| Grade | Meaning |
+|---|---|
+| **E1 - executable source** | Behavior read directly from code paths in the repository at the pinned commit. Claims can be checked line by line. |
+| **E2 - README only** | Everything known comes from the repository's README and whatever it embeds. Implementation and accuracy are **unverified**: we never confirmed the described behavior exists in code. |
+
+Within E1 material, three kinds of observation are kept separate:
+
+- **Visual evidence** - screenshots. They show a rendered outcome, not the rule that produced it.
+- **Exact observed values** - computed style read back from a live DOM. These are measured numbers,
+  the strongest thing on the list.
+- **Inference** - patterns in a generated style guide. Useful as a hypothesis, nothing more. A
+  generated artifact reflects its generator's assumptions, and we did not audit that generator.
+
+## Repository Records
+
+### 1. graphic-design
+
+- **Repository URL:** https://github.com/491023434/graphic-design
+- **Commit SHA (reachable at retrieval):** `a3cf2387e8f5d0f80e5c615fb25f2e1073a0646b`
+- **Tree at that commit:** https://github.com/491023434/graphic-design/tree/a3cf2387e8f5d0f80e5c615fb25f2e1073a0646b
+- **Paths inspected:**
+  [`README.md`](https://github.com/491023434/graphic-design/blob/a3cf2387e8f5d0f80e5c615fb25f2e1073a0646b/README.md)
+  only
+- **Adopted principle:** treat a poster-style composition as a small number of named regions with a
+  dominant focal region, rather than as a free-form canvas.
+- **BurnGuard mapping (implemented):** the decomposition idea, that a reference image is broken into
+  described parts rather than treated as one opaque picture, shows up as the versioned context
+  fields in `packages/shared/src/reference-layout.ts` (`schema_version`, `layout_spec_path`,
+  `intent`, `reference`, `canvas`) and as the materialized `layout-spec.json` with stable element
+  anchors that `packages/backend/src/harness/skills/reference-layout-skill.ts` instructs the model
+  to write. Our decomposition is anchor-based, not region-based: there is no named-region vocabulary
+  in the code, and this document doesn't claim one.
+- **Evidence grade:** **E2 - README only.** Implementation and accuracy unverified.
+- **Limitations:** no code was read; the README's claims about rendering behavior could not be
+  confirmed. Any figure or ratio taken from it must be re-derived before use.
+- **License / reuse boundary:** **no license file present.** Default copyright applies, so no code,
+  text, image, or prompt may be copied. Conceptual influence only.
+
+### 2. poster-design
+
+- **Repository URL:** https://github.com/1955358104/poster-design
+- **Commit SHA (reachable at retrieval):** `c29aab04e84951502dbfa26f819b3c8de597f74b`
+- **Tree at that commit:** https://github.com/1955358104/poster-design/tree/c29aab04e84951502dbfa26f819b3c8de597f74b
+- **Paths inspected:**
+  [`README.md`](https://github.com/1955358104/poster-design/blob/c29aab04e84951502dbfa26f819b3c8de597f74b/README.md)
+  only
+- **Adopted principle:** an editable poster is a tree of typed elements over a fixed artboard, and
+  the artboard size is a first-class property rather than a viewport side effect.
+- **BurnGuard mapping (implemented):** explicit artboard sizing lives in
+  `packages/backend/src/services/reference-layout-values.ts`, which resolves named presets, literal
+  width/height with a unit, aspect ratio (tagged `explicit`, `dimensions`, or `preset`), and
+  orientation, reorienting dimensions when the two disagree. The matching capability boundary sits
+  in `packages/backend/src/services/reference-layout-export.ts`, where each target reports whether a
+  custom size survives: `preset_only`, `aspect_presets_only`, or `explicit_pixel_dimensions`. An
+  unsupported size is reported and the spec preserved; nothing is silently coerced to A4.
+- **Evidence grade:** **E2 - README only.** Implementation and accuracy unverified.
+- **Limitations:** the editor internals, coordinate system, and export path were never opened. We
+  don't know how the described model behaves under nesting or scaling.
+- **License / reuse boundary:** **no license file present.** No copying of any kind. Ideas only.
+
+### 3. ZORY-AI
+
+- **Repository URL:** https://github.com/ZORY-AI/zory-ai
+- **Commit SHA (reachable at retrieval):** `33487d9a230614a99332594e1d6f1f231a7b645a`
+- **Tree at that commit:** https://github.com/ZORY-AI/zory-ai/tree/33487d9a230614a99332594e1d6f1f231a7b645a
+- **Paths inspected:**
+  [`README.md`](https://github.com/ZORY-AI/zory-ai/blob/33487d9a230614a99332594e1d6f1f231a7b645a/README.md)
+  only
+- **Adopted principle:** a sketch or floor-plan style reference carries dimensions that are part of
+  the request, not decoration, so the drawing must be held fixed while measurements drive the
+  output.
+- **BurnGuard mapping (implemented):** `packages/backend/src/services/reference-layout.ts` marks the
+  attached reference `role: "immutable_underlay"` and tags its `evidence_boundary`, with
+  `hard_geometry` meaning the drawing's measurements bind. The geometry rules it emits are typed in
+  `packages/shared/src/reference-layout.ts` as `geometry_contract`: top-left origin, x right, y
+  down, `anchor_space: "normalized_0_1"`, `stable_anchors_required`, `preserve_aspect_ratio`.
+  **No accuracy claim.** The contract fixes a coordinate system and forbids editing the underlay. It
+  does not assert that any produced layout is dimensionally correct against the original drawing,
+  and we have measured no such thing.
+- **Evidence grade:** **E2 - README only.** Implementation and accuracy unverified.
+- **Limitations:** no model wiring, no schema, no output samples were inspected. Whether the
+  separation actually holds end to end is unknown.
+- **License / reuse boundary:** **no license file present.** Nothing may be reused verbatim,
+  including prompt text.
+
+### 4. Scrapstyle
+
+- **Repository URL:** https://github.com/user2897/Scrapstyle
+- **Commit SHA (reachable at retrieval):** `4202d00212cd0350559c0819c3addbe790645c59`
+- **Tree at that commit:** https://github.com/user2897/Scrapstyle/tree/4202d00212cd0350559c0819c3addbe790645c59
+- **Paths inspected** (immutable blob links pinned to the SHA above; search the tree link if a file
+  has since moved):
+  - [`extractor.ts`](https://github.com/user2897/Scrapstyle/blob/4202d00212cd0350559c0819c3addbe790645c59/extractor.ts)
+  - [`screenshot.ts`](https://github.com/user2897/Scrapstyle/blob/4202d00212cd0350559c0819c3addbe790645c59/screenshot.ts)
+  - [`formatter.ts`](https://github.com/user2897/Scrapstyle/blob/4202d00212cd0350559c0819c3addbe790645c59/formatter.ts)
+  - [`templates.ts`](https://github.com/user2897/Scrapstyle/blob/4202d00212cd0350559c0819c3addbe790645c59/templates.ts)
+  - [`route.ts`](https://github.com/user2897/Scrapstyle/blob/4202d00212cd0350559c0819c3addbe790645c59/route.ts)
+  - [`constants.ts`](https://github.com/user2897/Scrapstyle/blob/4202d00212cd0350559c0819c3addbe790645c59/constants.ts)
+- **Adopted principle:** derive a design system from a real page by reading computed style off a
+  live DOM, then normalize the raw values into a small token set before anyone looks at them. The
+  pipeline stays split into distinct stages: capture, extract, normalize, emit.
+- **BurnGuard mapping (implemented):** what we took is the separation of evidence strength, not the
+  scraping pipeline. `packages/backend/src/services/reference-layout-values.ts` classifies a
+  reference into `hard_geometry`, `visual_inspiration`, or `mixed`, and
+  `packages/backend/src/harness/skills/reference-layout-skill.ts` states the resulting rule: hard
+  geometry controls page bounds, scale, dimensions, and anchor placement, while visual inspiration
+  may guide composition or styling and never overrides hard geometry. This is **not** mapped to a
+  design-system import path; BurnGuard has no such import built from this repository.
+- **Evidence grade:** **E1 - executable source.** Read at the pinned commit, with the three kinds of
+  observation kept apart:
+  - screenshots produced by the capture step are **visual evidence** of a rendered result, not proof
+    of any extraction rule;
+  - computed style pulled from the live DOM gives **exact observed values**, and these are the only
+    numbers we treat as measured;
+  - recurring patterns in the emitted style guide are **inference** about intent, since a generated
+    document is downstream of choices we did not audit.
+- **Limitations:** we read the code, we did not run the pipeline against a corpus of sites. Coverage
+  on dynamic pages, shadow DOM, and lazily applied styles is unmeasured. Nothing here says the
+  extraction generalizes.
+- **License / reuse boundary:** **no license file present.** Reading it for understanding is fine;
+  copying code, structure-for-structure files, prose, or emitted templates is not. BurnGuard's
+  implementation must be written independently.
+
+## Cross-Cutting Limitations
+
+- Three of the four repositories are **E2**, so most of the material here is described behavior, not
+  observed behavior. Don't cite an E2 claim as a fact about how something works.
+- Commit SHAs were reachable on 2026-08-25. Upstream history can be rewritten or repositories made
+  private, so a later failure to fetch a SHA is expected drift, not evidence of error here.
+- No repository was forked, vendored, or mirrored into BurnGuard.
+
+## Reuse Boundary Summary
+
+| Repository | License | Copying allowed | Influence allowed |
+|---|---|---|---|
+| graphic-design | none | No | Concept only |
+| poster-design | none | No | Concept only |
+| ZORY-AI | none | No | Concept only |
+| Scrapstyle | none | No | Architecture-level principles only |
+
+All four lack a license file, so default copyright applies to all of them. The working rule is
+simple: read for ideas, write our own code, copy nothing.

--- a/doc/research.md
+++ b/doc/research.md
@@ -6,7 +6,7 @@ This catalog turns the source-grounded design review retrieved on 2026-08-25 int
 
 - `packages/backend/src/research-data/sources.json` is the provenance ledger. Each stable `S-*` record identifies its URL, retrieval date, owner or title, tags, a short paraphrase, usage boundary, confidence, and limitation.
 - `packages/backend/src/research-data/common-rules.json` contains reusable `CR-*` rules. Every rule cites ledger IDs and declares its authority class.
-- `packages/backend/src/research-data/purpose-references.json` contains the six supported reference sets. Purpose IDs are selectors, not new project types.
+- `packages/backend/src/research-data/purpose-references.json` contains the ten supported prompt reference sets. Purpose IDs are selectors, not new project types.
 
 All JSON is UTF-8, two-space indented, newline terminated, and sorted by stable ID. The focused validator rejects noncanonical serialization, duplicate or unsorted IDs, unresolved citations, incomplete provenance, and unsupported purpose IDs.
 
@@ -27,7 +27,9 @@ Purpose selection keeps four concepts separate:
 - `creation_mode` describes whether the reference set supports generated or authored output.
 - `fallback` records the generic fallback without treating it as a purpose.
 
-The catalog intentionally covers only `prototype.landing`, `prototype.dashboard`, `prototype.diagram`, `prototype.editorial`, `prototype.sandbox`, and `deck.pitch`. Editorial and sandbox remain prototype subgenres. Diagram remains request intent. Pitch guidance has medium confidence because the surviving sources support attention and accessible delivery, not a universal pitch narrative.
+The prompt catalog covers `prototype.landing`, `prototype.dashboard`, `prototype.diagram`, `prototype.editorial`, `prototype.sandbox`, `deck.company`, `deck.pitch`, `deck.report`, `deck.sales`, and `deck.training`. Editorial and sandbox remain prototype subgenres. Diagram remains request intent. Every deck purpose retains medium confidence because the sources support bounded communication principles, not a universal narrative for that deck kind.
+
+The persisted mass-research contract intentionally remains narrower. `ResearchProjectPurpose` accepts the five prototype purposes plus `deck.pitch`; the four additional deck purposes are prompt-catalog selectors only. `selectCatalogRules` can resolve all ten prompt purposes, while `selectResearchPromptContext` rejects a persisted result for a prompt-only purpose until the shared research contract is expanded deliberately.
 
 ## Applying records
 

--- a/packages/backend/src/harness/prompt-attachments.ts
+++ b/packages/backend/src/harness/prompt-attachments.ts
@@ -1,0 +1,103 @@
+import type { buildSessionContext } from "../services/context";
+import {
+  attachmentExtractedTextPath,
+  attachmentSummaryPath,
+} from "../services/attachment-paths";
+import {
+  readAttachmentSummaryFile,
+  type AttachmentSummary,
+} from "../services/attachment-summary";
+import { readOptional } from "./prompt-file-reader";
+
+type SessionContext = NonNullable<
+  Awaited<ReturnType<typeof buildSessionContext>>
+>;
+type Attachment = SessionContext["attachments"][number];
+
+const MAX_ATTACHMENT_PAGES = 4;
+
+export async function appendAttachmentContext(
+  lines: string[],
+  attachments: readonly Attachment[],
+  requestedPaths: readonly string[],
+): Promise<void> {
+  lines.push("## Attachments");
+  const selected = attachments.filter((attachment) =>
+    requestedPaths.includes(attachment.file_path),
+  );
+  for (const attachment of selected) {
+    lines.push(
+      `- ${attachment.original_name} (${attachment.mime_type}, ${attachment.size_bytes}B)`,
+    );
+    const summary = await readAttachmentSummaryFile(
+      attachmentSummaryPath(attachment.file_path),
+    );
+    if (summary) {
+      const extractedTextPath = attachmentExtractedTextPath(
+        attachment.file_path,
+      );
+      const hasExtractedText =
+        (await readOptional(extractedTextPath)) !== null;
+      lines.push(
+        `  source_path: ${attachment.file_path} (binary attachment; do not Read/Glob/Bash this file directly)`,
+      );
+      if (hasExtractedText) {
+        lines.push(
+          `  extracted_text_path: ${extractedTextPath} (safe text version for Read)`,
+        );
+      }
+      for (const summaryLine of renderAttachmentSummary(summary)) {
+        lines.push(`  ${summaryLine}`);
+      }
+    } else {
+      lines.push(`  path: ${attachment.file_path}`);
+    }
+  }
+  for (const requestedPath of requestedPaths) {
+    if (
+      !selected.some(
+        (attachment) => attachment.file_path === requestedPath,
+      )
+    ) {
+      lines.push(`- ${requestedPath}`);
+    }
+  }
+  lines.push("");
+}
+
+function renderAttachmentSummary(summary: AttachmentSummary): string[] {
+  const lines = [
+    `summary: ${summary.kind.toUpperCase()} | ${summary.page_count} page(s) | brand=${summary.brand_name ?? "unknown"}`,
+  ];
+  if (summary.fonts.length > 0) {
+    lines.push(`fonts: ${summary.fonts.slice(0, 4).join(", ")}`);
+  }
+  if (summary.colors.length > 0) {
+    lines.push(`colors: ${summary.colors.slice(0, 6).join(", ")}`);
+  }
+  if (summary.headings.length > 0) {
+    lines.push(`headings: ${summary.headings.slice(0, 3).join(" | ")}`);
+  }
+  if (summary.bodies.length > 0) {
+    lines.push(`body samples: ${summary.bodies.slice(0, 2).join(" | ")}`);
+  }
+  if (summary.pages.length > 0) {
+    lines.push("page summaries:");
+    for (const page of summary.pages.slice(0, MAX_ATTACHMENT_PAGES)) {
+      lines.push(
+        `- page ${page.index}: ${page.title} -> ${page.summary || page.text_excerpt}`,
+      );
+    }
+  }
+  if (summary.notes.length > 0) {
+    lines.push(`notes: ${summary.notes.slice(0, 2).join(" | ")}`);
+  }
+  lines.push("instruction: use this compact summary first for planning.");
+  lines.push(
+    "instruction: if an extracted_text_path is listed and you need slide/page wording, Read that file instead of the original binary file.",
+  );
+  lines.push(
+    "instruction: do not use Read, Glob, or Bash against the original .pptx/.pdf attachment path.",
+  );
+  return lines;
+}

--- a/packages/backend/src/harness/prompt-builder.ts
+++ b/packages/backend/src/harness/prompt-builder.ts
@@ -15,6 +15,7 @@ import {
 } from "./prompt-compact-skills";
 import { appendDesignBriefContext } from "./prompt-design-brief";
 import { appendDesignSystemContext } from "./prompt-design-system";
+import { appendReferenceLayoutContext } from "./prompt-reference-layout";
 import {
   summarizeDeckHtml,
   summarizePrototypeHtml,
@@ -102,6 +103,11 @@ export async function buildPrompt(
   lines.push("</burnguard-research-context-v1>");
   lines.push("");
   appendDesignBriefContext(lines, projectOptions.design_brief);
+  appendReferenceLayoutContext(lines, {
+    request: userEvent.text,
+    attachments: context.attachments,
+    requestedPaths: userEvent.attachments ?? [],
+  });
 
   // Structural summary of the entrypoint, when it's an HTML artifact we know
   // how to parse. This is the main lever against runaway prompt-cache growth:

--- a/packages/backend/src/harness/prompt-builder.ts
+++ b/packages/backend/src/harness/prompt-builder.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import type { UserEvent } from "@bg/shared/events";
 import type { buildSessionContext } from "../services/context";
+import { parseStoredProjectOptions } from "../services/project-options";
 import { buildResearchPromptContext } from "../services/research-purpose";
 import { selectPromptLearning } from "../db/learning-store";
 import { getSqlite } from "../db/sqlite-client";
@@ -12,6 +13,7 @@ import {
   COMPACT_DECK_SKILL_MD,
   COMPACT_PROTOTYPE_SKILL_MD,
 } from "./prompt-compact-skills";
+import { appendDesignBriefContext } from "./prompt-design-brief";
 import { appendDesignSystemContext } from "./prompt-design-system";
 import {
   summarizeDeckHtml,
@@ -43,6 +45,7 @@ export async function buildPrompt(
   const lines: string[] = [];
   const project = context.project;
   const contextMode = options.contextMode ?? "full";
+  const projectOptions = parseStoredProjectOptions(project.options_json);
 
   lines.push("# BurnGuard Design project session");
   lines.push("");
@@ -84,9 +87,8 @@ export async function buildPrompt(
     lines.push(`<burnguard-learning-warning code="${learning.warning}" />`);
   }
   if (project.project_type === "slide_deck") {
-    const slideDeckOptions = parseSlideDeckOptions(project.options_json);
     lines.push(
-      `- use_speaker_notes: ${slideDeckOptions.use_speaker_notes ? "true" : "false"}`,
+      `- use_speaker_notes: ${projectOptions.use_speaker_notes ? "true" : "false"}`,
     );
   }
   lines.push("");
@@ -99,6 +101,7 @@ export async function buildPrompt(
   })));
   lines.push("</burnguard-research-context-v1>");
   lines.push("");
+  appendDesignBriefContext(lines, projectOptions.design_brief);
 
   // Structural summary of the entrypoint, when it's an HTML artifact we know
   // how to parse. This is the main lever against runaway prompt-cache growth:
@@ -227,30 +230,4 @@ const DIAGRAM_REQUEST_PATTERN =
 
 function isDiagramRequest(request: string): boolean {
   return DIAGRAM_REQUEST_PATTERN.test(request);
-}
-
-function parseSlideDeckOptions(optionsJson: string | null): {
-  use_speaker_notes: boolean;
-} {
-  if (!optionsJson) {
-    return { use_speaker_notes: false };
-  }
-
-  try {
-    const parsed = JSON.parse(optionsJson);
-    if (parsed && typeof parsed === "object") {
-      return {
-        use_speaker_notes:
-          typeof (parsed as Record<string, unknown>).use_speaker_notes ===
-          "boolean"
-            ? ((parsed as Record<string, unknown>)
-                .use_speaker_notes as boolean)
-            : false,
-      };
-    }
-  } catch {
-    // Ignore malformed options and fall back to the default deck contract.
-  }
-
-  return { use_speaker_notes: false };
 }

--- a/packages/backend/src/harness/prompt-builder.ts
+++ b/packages/backend/src/harness/prompt-builder.ts
@@ -1,33 +1,28 @@
-import { readFile } from "node:fs/promises";
 import path from "node:path";
 import type { UserEvent } from "@bg/shared/events";
-import {
-  attachmentExtractedTextPath,
-  attachmentSummaryPath,
-} from "../services/attachment-paths";
 import type { buildSessionContext } from "../services/context";
 import { buildResearchPromptContext } from "../services/research-purpose";
 import { selectPromptLearning } from "../db/learning-store";
 import { getSqlite } from "../db/sqlite-client";
-import {
-  readAttachmentSummaryFile,
-  type AttachmentSummary,
-} from "../services/attachment-summary";
 import { DECK_SKILL_MD } from "./skills/deck-skill";
 import { DIAGRAM_SKILL_MD } from "./skills/diagram-skill";
 import { PROTOTYPE_SKILL_MD } from "./skills/prototype-skill";
+import { appendAttachmentContext } from "./prompt-attachments";
+import {
+  COMPACT_DECK_SKILL_MD,
+  COMPACT_PROTOTYPE_SKILL_MD,
+} from "./prompt-compact-skills";
+import { appendDesignSystemContext } from "./prompt-design-system";
 import {
   summarizeDeckHtml,
   summarizePrototypeHtml,
 } from "./structure-extractor";
 
+export { MAX_SKILL_CHARS } from "./prompt-design-system";
+
 type SessionContext = NonNullable<Awaited<ReturnType<typeof buildSessionContext>>>;
 
 const MAX_FILES_LISTED = 60;
-export const MAX_SKILL_CHARS = 5000;
-const MAX_TOKENS_CSS_LINES = 150;
-const MAX_README_LINES = 120;
-const MAX_ATTACHMENT_PAGES = 4;
 
 export type PromptContextMode = "compact" | "full";
 
@@ -148,90 +143,15 @@ export async function buildPrompt(
   }
 
   if (context.designSystem) {
-    const ds = context.designSystem;
-    lines.push("## Design system");
-    lines.push(`- name: ${ds.name}`);
-    lines.push(`- directory: ${ds.dir_path}`);
-    if (ds.skill_md_path) lines.push(`- skill: ${ds.skill_md_path}`);
-    if (ds.tokens_css_path) lines.push(`- tokens: ${ds.tokens_css_path}`);
-    if (ds.readme_md_path) lines.push(`- readme: ${ds.readme_md_path}`);
-    lines.push("");
-
-    if (contextMode === "compact") {
-      lines.push("### Compact design-system handling");
-      lines.push(
-        "- Use the design-system paths above as source of truth. Read SKILL.md, tokens, or README only when exact brand rules or token names are needed for this request.",
-      );
-      lines.push(
-        "- Prefer targeted Grep/Read ranges over loading full design-system files. Reuse existing CSS variables instead of inventing new palettes or type stacks.",
-      );
-      lines.push("");
-    } else if (ds.skill_md_path) {
-      const content = await readOptional(ds.skill_md_path);
-      if (content) {
-        lines.push("### SKILL.md");
-        lines.push("```markdown");
-        lines.push(content.slice(0, MAX_SKILL_CHARS));
-        lines.push("```");
-        lines.push("");
-      }
-    }
-    if (contextMode === "full" && ds.tokens_css_path) {
-      const content = await readOptional(ds.tokens_css_path);
-      if (content) {
-        lines.push("### colors_and_type.css (excerpt)");
-        lines.push("```css");
-        lines.push(content.split("\n").slice(0, MAX_TOKENS_CSS_LINES).join("\n"));
-        lines.push("```");
-        lines.push("");
-      }
-    }
-    if (contextMode === "full" && ds.readme_md_path) {
-      const content = await readOptional(ds.readme_md_path);
-      if (content) {
-        lines.push("### README.md (excerpt)");
-        lines.push("```markdown");
-        lines.push(content.split("\n").slice(0, MAX_README_LINES).join("\n"));
-        lines.push("```");
-        lines.push("");
-      }
-    }
+    await appendDesignSystemContext(lines, context.designSystem, contextMode);
   }
 
   if (userEvent.attachments && userEvent.attachments.length > 0) {
-    lines.push("## Attachments");
-    const selected = context.attachments.filter((attachment) =>
-      userEvent.attachments?.includes(attachment.file_path),
+    await appendAttachmentContext(
+      lines,
+      context.attachments,
+      userEvent.attachments,
     );
-    for (const attachment of selected) {
-      lines.push(
-        `- ${attachment.original_name} (${attachment.mime_type}, ${attachment.size_bytes}B)`,
-      );
-      const summary = await readAttachmentSummary(attachment.file_path);
-      if (summary) {
-        const extractedTextPath = attachmentExtractedTextPath(attachment.file_path);
-        const hasExtractedText = (await readOptional(extractedTextPath)) != null;
-        lines.push(
-          `  source_path: ${attachment.file_path} (binary attachment; do not Read/Glob/Bash this file directly)`,
-        );
-        if (hasExtractedText) {
-          lines.push(
-            `  extracted_text_path: ${extractedTextPath} (safe text version for Read)`,
-          );
-        }
-        for (const summaryLine of renderAttachmentSummary(summary)) {
-          lines.push(`  ${summaryLine}`);
-        }
-      } else {
-        lines.push(`  path: ${attachment.file_path}`);
-      }
-    }
-    for (const p of userEvent.attachments) {
-      if (!selected.some((attachment) => attachment.file_path === p)) {
-        lines.push(`- ${p}`);
-      }
-    }
-    lines.push("");
   }
 
   if (context.openComments.length > 0) {
@@ -307,89 +227,6 @@ const DIAGRAM_REQUEST_PATTERN =
 
 function isDiagramRequest(request: string): boolean {
   return DIAGRAM_REQUEST_PATTERN.test(request);
-}
-
-const COMPACT_DECK_SKILL_MD = `# Slide deck compact contract
-
-## Token budget rules (READ THESE FIRST)
-- The "## Deck structure" section above is your map. Use it to plan instead of Reading the full file.
-- **Read \`deck.html\` at most ONCE per turn.** Re-reading the same file is forbidden — keep findings in working memory across tool calls.
-- When you do need a slide's exact markup, use \`Grep\` for \`data-bg-node-id="slide-N"\` to find the line, then \`Read\` with \`offset\`/\`limit\` covering that slide only — never the whole file.
-- Prefer multiple targeted \`Edit\` calls (small \`old_string\`/\`new_string\`) over a \`Write\` of the whole file. \`Write\` re-emits the entire 100 KB+ artifact and is the most expensive thing you can do.
-- For multi-slide redesigns, plan all edits before executing, then issue them as a batch. Do not Read between Edits.
-
-## Structure
-- Every slide is a top-level \`<section data-slide>\` directly under \`<body>\`. Preserve order unless the user asks for narrative change.
-- Preserve \`<script src="/runtime/deck-stage.js" defer></script>\`; do not set \`data-active\` statically or reimplement deck navigation.
-- Every visible text element needs a unique \`data-bg-node-id="slide-{N}-{purpose}"\`; parent slides use \`data-bg-node-id="slide-{N}"\`.
-
-## Style
-- Use asymmetric layouts, oversized type or KPI numbers where useful, and avoid centered-everything except cover/closing slides.
-- Keep CSS inline in the top \`<style>\` block. Reference design-system CSS variables (see list above) and avoid new palettes, font stacks, or typefaces.`;
-
-const COMPACT_PROTOTYPE_SKILL_MD = `# Prototype compact contract
-
-## Token budget rules (READ THESE FIRST)
-- The "## Prototype structure" section above is your map. Use it to plan instead of Reading the full file.
-- **Read \`index.html\` at most ONCE per turn.** Re-reading the same file is forbidden — keep findings in working memory across tool calls.
-- When you need a section's exact markup, use \`Grep\` for \`data-section="..."\` (or \`data-bg-node-id\`) to find the line, then \`Read\` with \`offset\`/\`limit\` covering that section only.
-- Prefer multiple targeted \`Edit\` calls over \`Write\`. \`Write\` re-emits the entire artifact and is the most expensive thing you can do.
-
-## Structure & style
-- Work in \`index.html\`; keep the artifact self-contained with inline CSS and vanilla JS unless the user explicitly asks otherwise.
-- Top-level semantic sections need \`data-section\` and unique \`data-bg-node-id\` values for visible text and editable parent sections.
-- Strong visual hierarchy, asymmetric sections outside true heroes, responsive down to 360 px, no hidden primary value.
-- Keep CSS in one top \`<style>\` block. Reference design-system CSS variables (see list above) and avoid new palettes, font stacks, or typefaces.`;
-
-async function readOptional(filePath: string): Promise<string | null> {
-  try {
-    return await readFile(filePath, "utf8");
-  } catch {
-    return null;
-  }
-}
-
-async function readAttachmentSummary(
-  filePath: string,
-): Promise<AttachmentSummary | null> {
-  return readAttachmentSummaryFile(attachmentSummaryPath(filePath));
-}
-
-function renderAttachmentSummary(summary: AttachmentSummary): string[] {
-  const lines = [
-    `summary: ${summary.kind.toUpperCase()} | ${summary.page_count} page(s) | brand=${summary.brand_name ?? "unknown"}`,
-  ];
-  if (summary.fonts.length > 0) {
-    lines.push(`fonts: ${summary.fonts.slice(0, 4).join(", ")}`);
-  }
-  if (summary.colors.length > 0) {
-    lines.push(`colors: ${summary.colors.slice(0, 6).join(", ")}`);
-  }
-  if (summary.headings.length > 0) {
-    lines.push(`headings: ${summary.headings.slice(0, 3).join(" | ")}`);
-  }
-  if (summary.bodies.length > 0) {
-    lines.push(`body samples: ${summary.bodies.slice(0, 2).join(" | ")}`);
-  }
-  if (summary.pages.length > 0) {
-    lines.push("page summaries:");
-    for (const page of summary.pages.slice(0, MAX_ATTACHMENT_PAGES)) {
-      lines.push(
-        `- page ${page.index}: ${page.title} -> ${page.summary || page.text_excerpt}`,
-      );
-    }
-  }
-  if (summary.notes.length > 0) {
-    lines.push(`notes: ${summary.notes.slice(0, 2).join(" | ")}`);
-  }
-  lines.push("instruction: use this compact summary first for planning.");
-  lines.push(
-    "instruction: if an extracted_text_path is listed and you need slide/page wording, Read that file instead of the original binary file.",
-  );
-  lines.push(
-    "instruction: do not use Read, Glob, or Bash against the original .pptx/.pdf attachment path.",
-  );
-  return lines;
 }
 
 function parseSlideDeckOptions(optionsJson: string | null): {

--- a/packages/backend/src/harness/prompt-compact-skills.ts
+++ b/packages/backend/src/harness/prompt-compact-skills.ts
@@ -1,0 +1,31 @@
+export const COMPACT_DECK_SKILL_MD = `# Slide deck compact contract
+
+## Token budget rules (READ THESE FIRST)
+- The "## Deck structure" section above is your map. Use it to plan instead of Reading the full file.
+- **Read \`deck.html\` at most ONCE per turn.** Re-reading the same file is forbidden — keep findings in working memory across tool calls.
+- When you do need a slide's exact markup, use \`Grep\` for \`data-bg-node-id="slide-N"\` to find the line, then \`Read\` with \`offset\`/\`limit\` covering that slide only — never the whole file.
+- Prefer multiple targeted \`Edit\` calls (small \`old_string\`/\`new_string\`) over a \`Write\` of the whole file. \`Write\` re-emits the entire 100 KB+ artifact and is the most expensive thing you can do.
+- For multi-slide redesigns, plan all edits before executing, then issue them as a batch. Do not Read between Edits.
+
+## Structure
+- Every slide is a top-level \`<section data-slide>\` directly under \`<body>\`. Preserve order unless the user asks for narrative change.
+- Preserve \`<script src="/runtime/deck-stage.js" defer></script>\`; do not set \`data-active\` statically or reimplement deck navigation.
+- Every visible text element needs a unique \`data-bg-node-id="slide-{N}-{purpose}"\`; parent slides use \`data-bg-node-id="slide-{N}"\`.
+
+## Style
+- Use asymmetric layouts, oversized type or KPI numbers where useful, and avoid centered-everything except cover/closing slides.
+- Keep CSS inline in the top \`<style>\` block. Reference design-system CSS variables (see list above) and avoid new palettes, font stacks, or typefaces.`;
+
+export const COMPACT_PROTOTYPE_SKILL_MD = `# Prototype compact contract
+
+## Token budget rules (READ THESE FIRST)
+- The "## Prototype structure" section above is your map. Use it to plan instead of Reading the full file.
+- **Read \`index.html\` at most ONCE per turn.** Re-reading the same file is forbidden — keep findings in working memory across tool calls.
+- When you need a section's exact markup, use \`Grep\` for \`data-section="..."\` (or \`data-bg-node-id\`) to find the line, then \`Read\` with \`offset\`/\`limit\` covering that section only.
+- Prefer multiple targeted \`Edit\` calls over \`Write\`. \`Write\` re-emits the entire artifact and is the most expensive thing you can do.
+
+## Structure & style
+- Work in \`index.html\`; keep the artifact self-contained with inline CSS and vanilla JS unless the user explicitly asks otherwise.
+- Top-level semantic sections need \`data-section\` and unique \`data-bg-node-id\` values for visible text and editable parent sections.
+- Strong visual hierarchy, asymmetric sections outside true heroes, responsive down to 360 px, no hidden primary value.
+- Keep CSS in one top \`<style>\` block. Reference design-system CSS variables (see list above) and avoid new palettes, font stacks, or typefaces.`;

--- a/packages/backend/src/harness/prompt-design-brief.ts
+++ b/packages/backend/src/harness/prompt-design-brief.ts
@@ -1,0 +1,12 @@
+import type { DesignBriefV1 } from "@bg/shared";
+
+export function appendDesignBriefContext(
+  lines: string[],
+  designBrief: DesignBriefV1 | null,
+): void {
+  if (designBrief === null) return;
+  lines.push("<burnguard-design-brief-v1>");
+  lines.push(JSON.stringify(designBrief));
+  lines.push("</burnguard-design-brief-v1>");
+  lines.push("");
+}

--- a/packages/backend/src/harness/prompt-design-system.ts
+++ b/packages/backend/src/harness/prompt-design-system.ts
@@ -1,0 +1,76 @@
+import type { buildSessionContext } from "../services/context";
+import { readOptional } from "./prompt-file-reader";
+
+type SessionContext = NonNullable<
+  Awaited<ReturnType<typeof buildSessionContext>>
+>;
+type DesignSystem = NonNullable<SessionContext["designSystem"]>;
+
+export const MAX_SKILL_CHARS = 5000;
+const MAX_TOKENS_CSS_LINES = 150;
+const MAX_README_LINES = 120;
+
+export async function appendDesignSystemContext(
+  lines: string[],
+  designSystem: DesignSystem,
+  contextMode: "compact" | "full",
+): Promise<void> {
+  lines.push("## Design system");
+  lines.push(`- name: ${designSystem.name}`);
+  lines.push(`- directory: ${designSystem.dir_path}`);
+  if (designSystem.skill_md_path) {
+    lines.push(`- skill: ${designSystem.skill_md_path}`);
+  }
+  if (designSystem.tokens_css_path) {
+    lines.push(`- tokens: ${designSystem.tokens_css_path}`);
+  }
+  if (designSystem.readme_md_path) {
+    lines.push(`- readme: ${designSystem.readme_md_path}`);
+  }
+  lines.push("");
+
+  if (contextMode === "compact") {
+    lines.push("### Compact design-system handling");
+    lines.push(
+      "- Use the design-system paths above as source of truth. Read SKILL.md, tokens, or README only when exact brand rules or token names are needed for this request.",
+    );
+    lines.push(
+      "- Prefer targeted Grep/Read ranges over loading full design-system files. Reuse existing CSS variables instead of inventing new palettes or type stacks.",
+    );
+    lines.push("");
+    return;
+  }
+
+  if (designSystem.skill_md_path) {
+    const content = await readOptional(designSystem.skill_md_path);
+    if (content) {
+      lines.push("### SKILL.md");
+      lines.push("```markdown");
+      lines.push(content.slice(0, MAX_SKILL_CHARS));
+      lines.push("```");
+      lines.push("");
+    }
+  }
+  if (designSystem.tokens_css_path) {
+    const content = await readOptional(designSystem.tokens_css_path);
+    if (content) {
+      lines.push("### colors_and_type.css (excerpt)");
+      lines.push("```css");
+      lines.push(
+        content.split("\n").slice(0, MAX_TOKENS_CSS_LINES).join("\n"),
+      );
+      lines.push("```");
+      lines.push("");
+    }
+  }
+  if (designSystem.readme_md_path) {
+    const content = await readOptional(designSystem.readme_md_path);
+    if (content) {
+      lines.push("### README.md (excerpt)");
+      lines.push("```markdown");
+      lines.push(content.split("\n").slice(0, MAX_README_LINES).join("\n"));
+      lines.push("```");
+      lines.push("");
+    }
+  }
+}

--- a/packages/backend/src/harness/prompt-file-reader.ts
+++ b/packages/backend/src/harness/prompt-file-reader.ts
@@ -1,0 +1,9 @@
+import { readFile } from "node:fs/promises";
+
+export async function readOptional(filePath: string): Promise<string | null> {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
+}

--- a/packages/backend/src/harness/prompt-reference-layout.ts
+++ b/packages/backend/src/harness/prompt-reference-layout.ts
@@ -1,0 +1,27 @@
+import type { buildSessionContext } from "../services/context";
+import { buildReferenceLayoutContext } from "../services/reference-layout";
+import { REFERENCE_LAYOUT_SKILL_MD } from "./skills/reference-layout-skill";
+
+type SessionContext = NonNullable<
+  Awaited<ReturnType<typeof buildSessionContext>>
+>;
+
+export function appendReferenceLayoutContext(
+  lines: string[],
+  input: {
+    readonly request: string;
+    readonly attachments: SessionContext["attachments"];
+    readonly requestedPaths: readonly string[];
+  },
+): boolean {
+  const context = buildReferenceLayoutContext(input);
+  if (context === null) return false;
+  lines.push("<burnguard-reference-layout-v1>");
+  lines.push(JSON.stringify(context));
+  lines.push("</burnguard-reference-layout-v1>");
+  lines.push("");
+  lines.push("## Reference layout skill");
+  lines.push(REFERENCE_LAYOUT_SKILL_MD);
+  lines.push("");
+  return true;
+}

--- a/packages/backend/src/harness/skills/deck-skill.ts
+++ b/packages/backend/src/harness/skills/deck-skill.ts
@@ -20,10 +20,10 @@ export const DECK_SKILL_MD = `# Slide deck authoring conventions
 - Each slide is a top-level \`<section data-slide data-layout="<archetype>">\`
   directly inside \`<body>\`. No wrapper divs.
 - Reuse template classes (\`deck-slide\`, \`deck-cover\`, \`deck-closing\`).
-- Default pitch deck is 15 slides: cover → problem → why now → solution →
-  product → how-it-works → market (TAM/SAM/SOM) → business model →
-  traction → competition → go-to-market → team → financials/roadmap →
-  ask → closing. Deviate only if the user asks.
+- Select the narrative from the machine-readable research purpose and
+  \`<burnguard-design-brief-v1>\` objective: company, sales, report, training,
+  or pitch. If no purpose is resolved, use a neutral objective-led outline;
+  never silently default to an investor pitch.
 
 ## Per-slide content rules (strict)
 

--- a/packages/backend/src/harness/skills/reference-layout-skill.ts
+++ b/packages/backend/src/harness/skills/reference-layout-skill.ts
@@ -1,0 +1,29 @@
+export const REFERENCE_LAYOUT_SKILL_MD = `# Reference layout contract
+
+Use the versioned \`<burnguard-reference-layout-v1>\` JSON as the sole layout
+authority for this turn.
+
+## Materialize before editing
+
+- Create or update \`layout-spec.json\` in the project before changing the
+  artifact. Preserve every known value and explicit unknown from the context.
+- Use one top-left coordinate system. Store stable element anchors in normalized
+  0..1 coordinates and keep their identifiers stable across revisions.
+- Treat the selected reference attachment as an immutable underlay. Never edit,
+  overwrite, move, rename, or optimize the original attachment.
+
+## Geometry and visual evidence
+
+- Preserve the reference aspect ratio and requested orientation.
+- Hard geometry controls page bounds, scale, dimensions, and anchor placement.
+  Visual inspiration may guide composition or styling but never overrides hard
+  geometry.
+- Do not infer missing scale, bleed, safe margins, or dimensions. Keep the
+  corresponding \`unknown\` status in \`layout-spec.json\`.
+
+## Export boundary
+
+- Keep custom dimensions in the HTML canvas and layout spec.
+- If the context marks PDF or PPTX unsupported, report that limitation and
+  preserve the spec. Never silently coerce custom paper to A4.
+- Use the provided raster target only when its status is \`known\`.`;

--- a/packages/backend/src/research-data/purpose-references.json
+++ b/packages/backend/src/research-data/purpose-references.json
@@ -2,6 +2,33 @@
   "schema_version": 1,
   "purposes": [
     {
+      "id": "deck.company",
+      "axes": {
+        "project_type": "slide_deck",
+        "request_intent": "company",
+        "creation_mode": "authored",
+        "fallback": "other"
+      },
+      "title": "Company deck reference set",
+      "guidance": [
+        "Lead with the company purpose, audience, and decision context.",
+        "Separate verified company facts from positioning or future claims.",
+        "Keep section hierarchy and reading order clear across HTML, PDF, and PPTX."
+      ],
+      "common_rule_ids": [
+        "CR-001",
+        "CR-002",
+        "CR-004",
+        "CR-008"
+      ],
+      "source_ids": [
+        "S-037",
+        "S-042"
+      ],
+      "confidence": "medium",
+      "limitations": "Sources support attention and accessible delivery, not a universal company-deck narrative or company-specific claims."
+    },
+    {
       "id": "deck.pitch",
       "axes": {
         "project_type": "slide_deck",
@@ -27,6 +54,87 @@
       ],
       "confidence": "medium",
       "limitations": "Sources support attention and accessible delivery, not a universal investor-pitch narrative or template."
+    },
+    {
+      "id": "deck.report",
+      "axes": {
+        "project_type": "slide_deck",
+        "request_intent": "report",
+        "creation_mode": "authored",
+        "fallback": "other"
+      },
+      "title": "Report deck reference set",
+      "guidance": [
+        "State the reporting period, audience, and decision objective before metrics.",
+        "Distinguish observed results, comparisons, causes, and next actions.",
+        "Keep metric labels and reading order explicit across HTML, PDF, and PPTX."
+      ],
+      "common_rule_ids": [
+        "CR-001",
+        "CR-002",
+        "CR-004",
+        "CR-008"
+      ],
+      "source_ids": [
+        "S-037",
+        "S-042"
+      ],
+      "confidence": "medium",
+      "limitations": "Sources support attention and accessible delivery, not metric correctness, reporting policy, or a universal report outline."
+    },
+    {
+      "id": "deck.sales",
+      "axes": {
+        "project_type": "slide_deck",
+        "request_intent": "sales",
+        "creation_mode": "authored",
+        "fallback": "other"
+      },
+      "title": "Sales deck reference set",
+      "guidance": [
+        "Frame the customer's situation and desired decision before the offer.",
+        "Separate evidence, product capabilities, commercial terms, and requested action.",
+        "Keep claims and calls to action readable across HTML, PDF, and PPTX."
+      ],
+      "common_rule_ids": [
+        "CR-001",
+        "CR-002",
+        "CR-004",
+        "CR-008"
+      ],
+      "source_ids": [
+        "S-037",
+        "S-042"
+      ],
+      "confidence": "medium",
+      "limitations": "Sources support attention and accessible delivery, not sales claims, pricing, or a universal proposal narrative."
+    },
+    {
+      "id": "deck.training",
+      "axes": {
+        "project_type": "slide_deck",
+        "request_intent": "training",
+        "creation_mode": "authored",
+        "fallback": "other"
+      },
+      "title": "Training deck reference set",
+      "guidance": [
+        "Start with the learner, learning objective, and expected action.",
+        "Sequence concepts, worked examples, checks, and recap explicitly.",
+        "Keep instructions and checkpoints readable across HTML, PDF, and PPTX."
+      ],
+      "common_rule_ids": [
+        "CR-001",
+        "CR-002",
+        "CR-004",
+        "CR-008"
+      ],
+      "source_ids": [
+        "S-037",
+        "S-042"
+      ],
+      "confidence": "medium",
+      "limitations": "Sources support attention and accessible delivery, not learning efficacy, curriculum policy, or a universal training sequence."
     },
     {
       "id": "prototype.dashboard",

--- a/packages/backend/src/routes/home-project-input.ts
+++ b/packages/backend/src/routes/home-project-input.ts
@@ -1,0 +1,114 @@
+import type { CreateProjectRequest } from "@bg/shared";
+import { UpgradeContractError } from "@bg/shared";
+import { parseProjectOptions } from "../services/project-options";
+
+type ProjectInputErrorCode =
+  | "invalid_body"
+  | "invalid_name"
+  | "invalid_type"
+  | "invalid_design_system"
+  | "invalid_backend"
+  | "invalid_project_options";
+
+export class ProjectInputError extends Error {
+  readonly name = "ProjectInputError";
+
+  constructor(
+    readonly code: ProjectInputErrorCode,
+    message: string,
+    readonly details?: unknown,
+  ) {
+    super(message);
+  }
+}
+
+export type ParsedProjectInput = {
+  readonly name: string;
+  readonly type: CreateProjectRequest["type"];
+  readonly designSystemId: string | null;
+  readonly backendId: CreateProjectRequest["backend_id"];
+  readonly optionsJson: string | null;
+  readonly entrypoint: "deck.html" | "index.html";
+};
+
+export function parseProjectInput(input: unknown): ParsedProjectInput {
+  if (!isRecord(input)) {
+    throw new ProjectInputError(
+      "invalid_body",
+      "Expected a JSON object request body",
+    );
+  }
+  const { name, type, design_system_id: designSystemId, backend_id: backendId } =
+    input;
+  if (typeof name !== "string" || name.trim().length === 0) {
+    throw new ProjectInputError(
+      "invalid_name",
+      "Project name is required",
+      { name },
+    );
+  }
+  if (!isProjectType(type)) {
+    throw new ProjectInputError(
+      "invalid_type",
+      "Unsupported project type",
+      { type },
+    );
+  }
+  if (!(designSystemId === null || typeof designSystemId === "string")) {
+    throw new ProjectInputError(
+      "invalid_design_system",
+      "design_system_id must be string or null",
+    );
+  }
+  if (!isBackendId(backendId)) {
+    throw new ProjectInputError(
+      "invalid_backend",
+      "Unsupported backend id",
+      { backend_id: backendId },
+    );
+  }
+  let optionsJson: string | null = null;
+  if (input["options"] !== undefined) {
+    try {
+      optionsJson = JSON.stringify(parseProjectOptions(input["options"]));
+    } catch (error) {
+      if (error instanceof UpgradeContractError) {
+        throw new ProjectInputError(
+          "invalid_project_options",
+          error.message,
+          { code: error.code, path: error.path },
+        );
+      }
+      throw error;
+    }
+  }
+  return {
+    name: name.trim(),
+    type,
+    designSystemId,
+    backendId,
+    optionsJson,
+    entrypoint: type === "slide_deck" ? "deck.html" : "index.html",
+  };
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isProjectType(
+  value: unknown,
+): value is CreateProjectRequest["type"] {
+  return (
+    value === "prototype" ||
+    value === "slide_deck" ||
+    value === "from_template" ||
+    value === "other"
+  );
+}
+
+function isBackendId(
+  value: unknown,
+): value is CreateProjectRequest["backend_id"] {
+  return value === "claude-code" || value === "codex";
+}

--- a/packages/backend/src/routes/home.ts
+++ b/packages/backend/src/routes/home.ts
@@ -4,7 +4,6 @@ import type {
   ApiMeta,
   ApiSuccess,
   BackendDetectionResult,
-  CreateProjectRequest,
   DesignSystemStatus,
   SettingsSummary,
 } from "@bg/shared";
@@ -18,6 +17,10 @@ import {
 import { getPromptSampleBySlug, seedTutorialsOnce } from "../db/seed-tutorials";
 import { detectBackends } from "../services/backends";
 import { ensureProjectWatcher } from "../services/watchers";
+import {
+  parseProjectInput,
+  ProjectInputError,
+} from "./home-project-input";
 
 const VALID_PROJECT_TABS = new Set(["recent", "mine", "examples"]);
 const VALID_SYSTEM_STATUSES = new Set<DesignSystemStatus>([
@@ -48,16 +51,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function isProjectType(value: unknown): value is CreateProjectRequest["type"] {
-  return (
-    value === "prototype" ||
-    value === "slide_deck" ||
-    value === "from_template" ||
-    value === "other"
-  );
-}
-
-function isBackendId(value: unknown): value is CreateProjectRequest["backend_id"] {
+function isBackendId(
+  value: unknown,
+): value is SettingsSummary["default_backend"] {
   return value === "claude-code" || value === "codex";
 }
 
@@ -121,40 +117,23 @@ homeRoutes.get("/api/design-systems", async (c) => {
 
 homeRoutes.post("/api/projects", async (c) => {
   const body = await c.req.json<unknown>().catch(() => null);
-  if (!isRecord(body)) {
-    return c.json(fail("invalid_body", "Expected a JSON object request body"), 400);
-  }
-
-  const { name, type, design_system_id, backend_id } = body;
-  if (typeof name !== "string" || name.trim().length === 0) {
-    return c.json(
-      fail("invalid_name", "Project name is required", { name }),
-      400,
-    );
-  }
-  if (!isProjectType(type)) {
-    return c.json(fail("invalid_type", "Unsupported project type", { type }), 400);
-  }
-  if (!(design_system_id === null || typeof design_system_id === "string")) {
-    return c.json(
-      fail("invalid_design_system", "design_system_id must be string or null"),
-      400,
-    );
-  }
-  if (!isBackendId(backend_id)) {
-    return c.json(
-      fail("invalid_backend", "Unsupported backend id", { backend_id }),
-      400,
-    );
+  let input: ReturnType<typeof parseProjectInput>;
+  try {
+    input = parseProjectInput(body);
+  } catch (error) {
+    if (error instanceof ProjectInputError) {
+      return c.json(fail(error.code, error.message, error.details), 400);
+    }
+    throw error;
   }
 
   const response = await createProjectRecord({
-    name: name.trim(),
-    type,
-    designSystemId: design_system_id,
-    backendId: backend_id,
-    optionsJson: body.options ? JSON.stringify(body.options) : null,
-    entrypoint: type === "slide_deck" ? "deck.html" : "index.html",
+    name: input.name,
+    type: input.type,
+    designSystemId: input.designSystemId,
+    backendId: input.backendId,
+    optionsJson: input.optionsJson,
+    entrypoint: input.entrypoint,
     thumbnailPath: null,
   });
   await ensureProjectWatcher(response.id);

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -130,7 +130,7 @@ export function createApp(authority?: RequestAuthorityOptions): Hono {
   return app;
 }
 
-export type ApiRouteDomain = "health" | "research" | "catalog" | "learning" | "system" | "managed-files" | "artifact-operations" | "artifacts" | "comments" | "session" | "runtime" | "home" | "project" | "not-found";
+export type ApiRouteDomain = "health" | "research" | "catalog" | "learning" | "system" | "managed-files" | "artifact-operations" | "artifacts" | "comments" | "session" | "runtime" | "settings" | "home" | "project" | "not-found";
 
 export function classifyApiRoute(pathname: string, method: string): ApiRouteDomain {
   if (pathname === "/api/health") return "health";
@@ -144,7 +144,8 @@ export function classifyApiRoute(pathname: string, method: string): ApiRouteDoma
   if (pathname.startsWith("/api/comments") || /\/comments(?:\/|$)/.test(pathname)) return "comments";
   if (pathname.startsWith("/api/sessions")) return "session";
   if (pathname.startsWith("/api/runtime")) return "runtime";
-  if (pathname.startsWith("/api/settings") || pathname.startsWith("/api/backends") || pathname.startsWith("/api/home") || pathname === "/api/projects") return "home";
+  if (pathname.startsWith("/api/settings/")) return "settings";
+  if (pathname === "/api/settings" || pathname.startsWith("/api/backends") || pathname.startsWith("/api/home") || pathname === "/api/projects") return "home";
   if (pathname.startsWith("/api/projects")) {
     if (/\/checkpoints(?:\/|$)/.test(pathname)) return "session";
     if (/\/draws(?:\/|$)/.test(pathname) && (method === "GET" || method === "PUT")) return "managed-files";
@@ -169,6 +170,7 @@ async function apiRoutes(domain: ApiRouteDomain): Promise<Hono> {
     case "comments": return (await import("./routes/comments")).commentRoutes;
     case "session": return (await import("./routes/session")).sessionRoutes;
     case "runtime": return (await import("./routes/runtime")).runtimeRoutes;
+    case "settings": return (await import("./routes/settings")).settingsRoutes;
     case "home": return (await import("./routes/home")).homeRoutes;
     case "project": return (await import("./routes/project")).projectRoutes;
     case "not-found": return new Hono();

--- a/packages/backend/src/services/project-options.ts
+++ b/packages/backend/src/services/project-options.ts
@@ -1,0 +1,63 @@
+import {
+  parseDesignBriefV1,
+  UpgradeContractError,
+  type DesignBriefV1,
+} from "@bg/shared";
+import { isRecord } from "@bg/shared/contract-parser";
+
+export type ProjectOptions = {
+  readonly use_speaker_notes: boolean;
+  readonly copy_as_is: boolean;
+  readonly design_brief: DesignBriefV1 | null;
+};
+
+const DEFAULT_OPTIONS: ProjectOptions = {
+  use_speaker_notes: false,
+  copy_as_is: false,
+  design_brief: null,
+};
+
+export function parseProjectOptions(input: unknown): ProjectOptions {
+  if (input === undefined || input === null) return DEFAULT_OPTIONS;
+  if (!isRecord(input)) {
+    throw new UpgradeContractError("expected_object", "options");
+  }
+  return {
+    use_speaker_notes: optionalBoolean(input, "use_speaker_notes"),
+    copy_as_is: optionalBoolean(input, "copy_as_is"),
+    design_brief:
+      input["design_brief"] === undefined
+        ? null
+        : parseDesignBriefV1(input["design_brief"]),
+  };
+}
+
+export function parseStoredProjectOptions(
+  optionsJson: string | null,
+): ProjectOptions {
+  if (optionsJson === null) return DEFAULT_OPTIONS;
+  try {
+    const parsed: unknown = JSON.parse(optionsJson);
+    return parseProjectOptions(parsed);
+  } catch (error) {
+    if (
+      error instanceof SyntaxError ||
+      error instanceof UpgradeContractError
+    ) {
+      return DEFAULT_OPTIONS;
+    }
+    throw error;
+  }
+}
+
+function optionalBoolean(
+  record: Readonly<Record<string, unknown>>,
+  key: string,
+): boolean {
+  const value = record[key];
+  if (value === undefined) return false;
+  if (typeof value !== "boolean") {
+    throw new UpgradeContractError("invalid_field", `options.${key}`);
+  }
+  return value;
+}

--- a/packages/backend/src/services/prompt-purpose.ts
+++ b/packages/backend/src/services/prompt-purpose.ts
@@ -1,0 +1,20 @@
+export const PROMPT_PURPOSES = [
+  "deck.company",
+  "deck.pitch",
+  "deck.report",
+  "deck.sales",
+  "deck.training",
+  "prototype.dashboard",
+  "prototype.diagram",
+  "prototype.editorial",
+  "prototype.landing",
+  "prototype.sandbox",
+] as const;
+
+export type PromptPurpose = (typeof PROMPT_PURPOSES)[number];
+
+const PROMPT_PURPOSE_SET = new Set<string>(PROMPT_PURPOSES);
+
+export function isPromptPurpose(value: unknown): value is PromptPurpose {
+  return typeof value === "string" && PROMPT_PURPOSE_SET.has(value);
+}

--- a/packages/backend/src/services/reference-layout-export.ts
+++ b/packages/backend/src/services/reference-layout-export.ts
@@ -1,0 +1,72 @@
+import type {
+  ReferenceLayoutContextV1,
+  ReferenceLayoutUnit,
+} from "@bg/shared";
+
+type Dimensions = {
+  readonly width: number;
+  readonly height: number;
+  readonly unit: ReferenceLayoutUnit;
+};
+
+export function rasterTarget(
+  dimensions: Dimensions | null,
+  dpi: number | null,
+): ReferenceLayoutContextV1["canvas"]["raster_target_px"] {
+  if (dimensions === null) {
+    return { status: "unknown", width: null, height: null };
+  }
+  if (dimensions.unit === "px") {
+    return {
+      status: "known",
+      width: Math.round(dimensions.width),
+      height: Math.round(dimensions.height),
+    };
+  }
+  if (dpi === null) return { status: "unknown", width: null, height: null };
+  const inches =
+    dimensions.unit === "in"
+      ? 1
+      : dimensions.unit === "cm"
+        ? 1 / 2.54
+        : 1 / 25.4;
+  return {
+    status: "known",
+    width: Math.round(dimensions.width * inches * dpi),
+    height: Math.round(dimensions.height * inches * dpi),
+  };
+}
+
+export function referenceExportConstraints(
+  canvas: ReferenceLayoutContextV1["canvas"],
+): ReferenceLayoutContextV1["export_constraints"] {
+  return {
+    pdf: exportCapability(
+      canvas.preset === "a4" ||
+        canvas.preset === "letter" ||
+        canvas.preset === "widescreen-16x9",
+      "preset_only",
+    ),
+    pptx: exportCapability(
+      canvas.preset === "widescreen-16x9" ||
+        canvas.preset === "standard-4x3",
+      "aspect_presets_only",
+    ),
+    png: exportCapability(
+      canvas.raster_target_px.status === "known",
+      "explicit_pixel_dimensions",
+    ),
+  };
+}
+
+function exportCapability(
+  supported: boolean,
+  limitation: "preset_only" | "aspect_presets_only" | "explicit_pixel_dimensions",
+) {
+  return {
+    supported,
+    limitation,
+    coerce_to_a4: false,
+    on_unsupported: "report_and_preserve_spec",
+  } as const;
+}

--- a/packages/backend/src/services/reference-layout-values.ts
+++ b/packages/backend/src/services/reference-layout-values.ts
@@ -13,11 +13,13 @@ type Dimensions = {
 };
 
 const INTENT_PATTERN =
-  /\b(?:reference layout|match (?:the )?layout|blueprint|floor plan|drawing|underlay|paper size|canvas size|artboard)\b|참조\s*(?:레이아웃|이미지)|도면|설계도|평면도|밑그림|용지\s*(?:크기|사이즈)|출력\s*크기/iu;
+  /\b(?:reference layout|match (?:the )?layout|blueprint|floor plan|underlay|paper size|canvas size|artboard|(?:this|the|attached)\s+drawing|drawing\s+(?:file|plan|layout|reference))\b|참조\s*(?:레이아웃|이미지)|도면|설계도|평면도|밑그림|용지\s*(?:크기|사이즈)|출력\s*크기/iu;
 const HARD_GEOMETRY_PATTERN =
-  /\b(?:blueprint|floor plan|drawing|underlay|spatial plan)\b|도면|설계도|평면도|배치도|밑그림/iu;
+  /\b(?:blueprint|floor plan|underlay|spatial plan|(?:this|the|attached)\s+drawing|drawing\s+(?:file|plan|layout|reference))\b|도면|설계도|평면도|배치도|밑그림/iu;
 const VISUAL_INSPIRATION_PATTERN =
   /\b(?:visual inspiration|style reference|mood reference)\b|스타일\s*참고|분위기\s*참고|시각\s*참고/iu;
+const REFERENCE_FILENAME_PATTERN =
+  /(?:^|[-_.\s])(?:blueprint|floor[-_.\s]?plan|drawing|layout|reference|sketch|underlay|도면|설계도|평면도|배치도|밑그림)(?:[-_.\s]|$)/iu;
 const DIMENSION_PATTERN =
   /(\d+(?:\.\d+)?)\s*(?:x|×|by)\s*(\d+(?:\.\d+)?)\s*(mm|cm|inches?|in|px|밀리미터|센티미터|인치|픽셀)\b/iu;
 const LABELLED_ASPECT_PATTERN =
@@ -44,14 +46,17 @@ export function hasReferenceLayoutIntent(request: string): boolean {
 export function isReferenceLayoutAttachment(input: {
   readonly mime_type: string;
   readonly original_name: string;
-}): boolean {
-  if (
+}, requestHasLayoutIntent: boolean): boolean {
+  const supported =
     input.mime_type.startsWith("image/") ||
-    input.mime_type === "application/pdf"
-  ) {
-    return true;
-  }
-  return /\.(?:svg|ai|eps|dwg|dxf|pdf)$/iu.test(input.original_name);
+    input.mime_type === "application/pdf" ||
+    /\.(?:svg|ai|eps|dwg|dxf|pdf)$/iu.test(input.original_name);
+  return (
+    supported &&
+    (requestHasLayoutIntent ||
+      REFERENCE_FILENAME_PATTERN.test(input.original_name) ||
+      /\.(?:dwg|dxf)$/iu.test(input.original_name))
+  );
 }
 
 export function parseReferenceLayoutCanvas(
@@ -135,11 +140,23 @@ function parsePreset(
 ): Exclude<ReferenceLayoutPreset, "custom"> | null {
   if (/\bA3\b/iu.test(request)) return "a3";
   if (/\bA4\b/iu.test(request)) return "a4";
-  if (/\b(?:US\s*)?Letter\b/iu.test(request)) return "letter";
+  if (
+    /\b(?:US\s+Letter|Letter(?=\s+(?:size|paper|page|sheet|portrait|landscape)))\b/iu.test(
+      request,
+    )
+  ) {
+    return "letter";
+  }
   if (/\b(?:16\s*:\s*9|widescreen)\b/iu.test(request)) {
     return "widescreen-16x9";
   }
-  if (/\b(?:4\s*:\s*3|standard)\b/iu.test(request)) return "standard-4x3";
+  if (
+    /\b(?:4\s*:\s*3|standard\s+(?:4\s*:\s*3|slide|page|aspect|format))\b/iu.test(
+      request,
+    )
+  ) {
+    return "standard-4x3";
+  }
   return null;
 }
 

--- a/packages/backend/src/services/reference-layout-values.ts
+++ b/packages/backend/src/services/reference-layout-values.ts
@@ -1,0 +1,241 @@
+import type {
+  ReferenceLayoutContextV1,
+  ReferenceLayoutMeasurement,
+  ReferenceLayoutPreset,
+  ReferenceLayoutUnit,
+} from "@bg/shared";
+import { rasterTarget } from "./reference-layout-export";
+
+type Dimensions = {
+  readonly width: number;
+  readonly height: number;
+  readonly unit: ReferenceLayoutUnit;
+};
+
+const INTENT_PATTERN =
+  /\b(?:reference layout|match (?:the )?layout|blueprint|floor plan|drawing|underlay|paper size|canvas size|artboard)\b|참조\s*(?:레이아웃|이미지)|도면|설계도|평면도|밑그림|용지\s*(?:크기|사이즈)|출력\s*크기/iu;
+const HARD_GEOMETRY_PATTERN =
+  /\b(?:blueprint|floor plan|drawing|underlay|spatial plan)\b|도면|설계도|평면도|배치도|밑그림/iu;
+const VISUAL_INSPIRATION_PATTERN =
+  /\b(?:visual inspiration|style reference|mood reference)\b|스타일\s*참고|분위기\s*참고|시각\s*참고/iu;
+const DIMENSION_PATTERN =
+  /(\d+(?:\.\d+)?)\s*(?:x|×|by)\s*(\d+(?:\.\d+)?)\s*(mm|cm|inches?|in|px|밀리미터|센티미터|인치|픽셀)\b/iu;
+const LABELLED_ASPECT_PATTERN =
+  /(?:aspect(?:\s+ratio)?|종횡비|화면\s*비율)\s*(?:is|:|=)?\s*(\d+(?:\.\d+)?)\s*:\s*(\d+(?:\.\d+)?)/iu;
+const DPI_PATTERN = /\b(\d{2,4})\s*dpi\b/iu;
+
+const PRESETS: Readonly<
+  Record<
+    Exclude<ReferenceLayoutPreset, "custom">,
+    Dimensions
+  >
+> = {
+  a3: { width: 297, height: 420, unit: "mm" },
+  a4: { width: 210, height: 297, unit: "mm" },
+  letter: { width: 8.5, height: 11, unit: "in" },
+  "widescreen-16x9": { width: 16, height: 9, unit: "in" },
+  "standard-4x3": { width: 4, height: 3, unit: "in" },
+};
+
+export function hasReferenceLayoutIntent(request: string): boolean {
+  return INTENT_PATTERN.test(request);
+}
+
+export function isReferenceLayoutAttachment(input: {
+  readonly mime_type: string;
+  readonly original_name: string;
+}): boolean {
+  if (
+    input.mime_type.startsWith("image/") ||
+    input.mime_type === "application/pdf"
+  ) {
+    return true;
+  }
+  return /\.(?:svg|ai|eps|dwg|dxf|pdf)$/iu.test(input.original_name);
+}
+
+export function parseReferenceLayoutCanvas(
+  request: string,
+): ReferenceLayoutContextV1["canvas"] {
+  const dimensions = parseDimensions(request);
+  const namedPreset = parsePreset(request);
+  const preset =
+    dimensions === null ? namedPreset : (namedPreset ?? "custom");
+  const resolved =
+    dimensions ?? (namedPreset === null ? null : PRESETS[namedPreset]);
+  const orientation = parseOrientation(
+    request,
+    resolved?.width ?? null,
+    resolved?.height ?? null,
+  );
+  const canvasDimensions =
+    resolved === null ? null : orientDimensions(resolved, orientation);
+  const dpi = parseDpi(request);
+  const explicitAspect = parseAspectRatio(request);
+  const aspectRatio =
+    explicitAspect ??
+    (canvasDimensions === null
+      ? null
+      : {
+          width: canvasDimensions.width,
+          height: canvasDimensions.height,
+          source: dimensions === null ? "preset" : "dimensions",
+        } as const);
+  return {
+    preset,
+    width: canvasDimensions?.width ?? null,
+    height: canvasDimensions?.height ?? null,
+    unit: canvasDimensions?.unit ?? null,
+    orientation,
+    aspect_ratio: aspectRatio,
+    dpi,
+    scale: parseScale(request),
+    bleed: parseMeasurement(request, /\bbleed\b|블리드|재단\s*여백/iu),
+    safe_margin: parseMeasurement(
+      request,
+      /\bsafe(?:ty)?\s*margin\b|안전\s*여백/iu,
+    ),
+    raster_target_px: rasterTarget(canvasDimensions, dpi),
+  };
+}
+
+export function referenceEvidenceBoundary(
+  request: string,
+): "hard_geometry" | "visual_inspiration" | "mixed" {
+  const hard = HARD_GEOMETRY_PATTERN.test(request);
+  const visual = VISUAL_INSPIRATION_PATTERN.test(request);
+  return hard && !visual
+    ? "hard_geometry"
+    : visual && !hard
+      ? "visual_inspiration"
+      : "mixed";
+}
+
+export function referenceLanguage(
+  request: string,
+): "ko" | "en" | "unknown" {
+  if (/[가-힣]/u.test(request)) return "ko";
+  if (/[a-z]/iu.test(request)) return "en";
+  return "unknown";
+}
+
+function parseDimensions(request: string): Dimensions | null {
+  const match = request.match(DIMENSION_PATTERN);
+  if (match === null) return null;
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+  const unit = normalizeUnit(match[3]);
+  return Number.isFinite(width) && Number.isFinite(height) && unit !== null
+    ? { width, height, unit }
+    : null;
+}
+
+function parsePreset(
+  request: string,
+): Exclude<ReferenceLayoutPreset, "custom"> | null {
+  if (/\bA3\b/iu.test(request)) return "a3";
+  if (/\bA4\b/iu.test(request)) return "a4";
+  if (/\b(?:US\s*)?Letter\b/iu.test(request)) return "letter";
+  if (/\b(?:16\s*:\s*9|widescreen)\b/iu.test(request)) {
+    return "widescreen-16x9";
+  }
+  if (/\b(?:4\s*:\s*3|standard)\b/iu.test(request)) return "standard-4x3";
+  return null;
+}
+
+function parseOrientation(
+  request: string,
+  width: number | null,
+  height: number | null,
+): "portrait" | "landscape" | "unknown" {
+  if (/\bportrait\b|세로/iu.test(request)) return "portrait";
+  if (/\blandscape\b|가로/iu.test(request)) return "landscape";
+  if (width === null || height === null || width === height) return "unknown";
+  return width > height ? "landscape" : "portrait";
+}
+
+function orientDimensions(
+  dimensions: Dimensions,
+  orientation: "portrait" | "landscape" | "unknown",
+): Dimensions {
+  const shouldSwap =
+    (orientation === "landscape" && dimensions.width < dimensions.height) ||
+    (orientation === "portrait" && dimensions.width > dimensions.height);
+  return shouldSwap
+    ? { ...dimensions, width: dimensions.height, height: dimensions.width }
+    : dimensions;
+}
+
+function parseAspectRatio(request: string): {
+  readonly width: number;
+  readonly height: number;
+  readonly source: "explicit";
+} | null {
+  const match =
+    request.match(LABELLED_ASPECT_PATTERN) ??
+    request.match(/\b(16)\s*:\s*(9)\b/u) ??
+    request.match(/\b(4)\s*:\s*(3)\b/u);
+  if (match === null) return null;
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+  return width > 0 && height > 0
+    ? { width, height, source: "explicit" }
+    : null;
+}
+
+function parseDpi(request: string): number | null {
+  const value = request.match(DPI_PATTERN)?.[1];
+  if (value === undefined) return null;
+  const dpi = Number(value);
+  return dpi >= 36 && dpi <= 2400 ? dpi : null;
+}
+
+function parseScale(request: string):
+  | { readonly status: "known"; readonly value: string }
+  | { readonly status: "unknown"; readonly value: null } {
+  const known = request.match(
+    /\bscale\s*(?:is|:|=)?\s*(1\s*:\s*\d+)\b|축척\s*(?:은|:|=)?\s*(1\s*:\s*\d+)/iu,
+  );
+  const value = known?.[1] ?? known?.[2];
+  return value === undefined
+    ? { status: "unknown", value: null }
+    : { status: "known", value: value.replace(/\s/gu, "") };
+}
+
+function parseMeasurement(
+  request: string,
+  label: RegExp,
+): ReferenceLayoutMeasurement {
+  const index = request.search(label);
+  if (index < 0) return { status: "unknown", value: null, unit: null };
+  const tail = request.slice(index).replace(label, "").slice(0, 64);
+  const clause =
+    tail.split(/[,;\n]|[.](?=\s*[A-Za-z가-힣])/u, 1)[0] ?? tail;
+  if (/unknown|unspecified|미정|알\s*수\s*없/iu.test(clause)) {
+    return { status: "unknown", value: null, unit: null };
+  }
+  const match = clause.match(
+    /(\d+(?:\.\d+)?)\s*(mm|cm|inches?|in|px|밀리미터|센티미터|인치|픽셀)\b/iu,
+  );
+  const unit = normalizeUnit(match?.[2]);
+  return match === null || unit === null
+    ? { status: "unknown", value: null, unit: null }
+    : { status: "known", value: Number(match[1]), unit };
+}
+
+function normalizeUnit(value: string | undefined): ReferenceLayoutUnit | null {
+  if (value === undefined) return null;
+  const normalized = value.toLowerCase();
+  if (normalized === "mm" || normalized === "밀리미터") return "mm";
+  if (normalized === "cm" || normalized === "센티미터") return "cm";
+  if (
+    normalized === "in" ||
+    normalized === "inch" ||
+    normalized === "inches" ||
+    normalized === "인치"
+  ) {
+    return "in";
+  }
+  if (normalized === "px" || normalized === "픽셀") return "px";
+  return null;
+}

--- a/packages/backend/src/services/reference-layout.ts
+++ b/packages/backend/src/services/reference-layout.ts
@@ -23,12 +23,12 @@ export type ReferenceLayoutInput = {
 export function buildReferenceLayoutContext(
   input: ReferenceLayoutInput,
 ): ReferenceLayoutContextV1 | null {
+  const requestDetected = hasReferenceLayoutIntent(input.request);
   const selected = input.attachments.filter(
     (attachment) =>
       input.requestedPaths.includes(attachment.file_path) &&
-      isReferenceLayoutAttachment(attachment),
+      isReferenceLayoutAttachment(attachment, requestDetected),
   );
-  const requestDetected = hasReferenceLayoutIntent(input.request);
   if (!requestDetected && selected.length === 0) return null;
 
   const reference = selected[0] ?? null;

--- a/packages/backend/src/services/reference-layout.ts
+++ b/packages/backend/src/services/reference-layout.ts
@@ -1,0 +1,71 @@
+import type { ReferenceLayoutContextV1 } from "@bg/shared";
+import {
+  hasReferenceLayoutIntent,
+  isReferenceLayoutAttachment,
+  parseReferenceLayoutCanvas,
+  referenceEvidenceBoundary,
+  referenceLanguage,
+} from "./reference-layout-values";
+import { referenceExportConstraints } from "./reference-layout-export";
+
+export type ReferenceLayoutAttachment = {
+  readonly file_path: string;
+  readonly mime_type: string;
+  readonly original_name: string;
+};
+
+export type ReferenceLayoutInput = {
+  readonly request: string;
+  readonly attachments: readonly ReferenceLayoutAttachment[];
+  readonly requestedPaths: readonly string[];
+};
+
+export function buildReferenceLayoutContext(
+  input: ReferenceLayoutInput,
+): ReferenceLayoutContextV1 | null {
+  const selected = input.attachments.filter(
+    (attachment) =>
+      input.requestedPaths.includes(attachment.file_path) &&
+      isReferenceLayoutAttachment(attachment),
+  );
+  const requestDetected = hasReferenceLayoutIntent(input.request);
+  if (!requestDetected && selected.length === 0) return null;
+
+  const reference = selected[0] ?? null;
+  const canvas = parseReferenceLayoutCanvas(input.request);
+  return {
+    schema_version: 1,
+    layout_spec_path: "layout-spec.json",
+    intent: {
+      detected: true,
+      source:
+        requestDetected && reference !== null
+          ? "request_and_attachment"
+          : requestDetected
+            ? "request"
+            : "attachment",
+      language: referenceLanguage(input.request),
+    },
+    reference:
+      reference === null
+        ? null
+        : {
+            attachment_path: reference.file_path,
+            original_name: reference.original_name,
+            mime_type: reference.mime_type,
+            role: "immutable_underlay",
+            evidence_boundary: referenceEvidenceBoundary(input.request),
+            editable: false,
+          },
+    canvas,
+    geometry_contract: {
+      origin: "top_left",
+      x_axis: "right",
+      y_axis: "down",
+      anchor_space: "normalized_0_1",
+      stable_anchors_required: true,
+      preserve_aspect_ratio: true,
+    },
+    export_constraints: referenceExportConstraints(canvas),
+  };
+}

--- a/packages/backend/src/services/research-catalog.ts
+++ b/packages/backend/src/services/research-catalog.ts
@@ -1,12 +1,16 @@
-import { RESEARCH_PROJECT_PURPOSES, type ResearchProjectPurpose } from "@bg/shared";
 import commonDocument from "../research-data/common-rules.json";
 import purposeDocument from "../research-data/purpose-references.json";
 import sourceDocument from "../research-data/sources.json";
+import {
+  isPromptPurpose,
+  PROMPT_PURPOSES,
+  type PromptPurpose,
+} from "./prompt-purpose";
 
 export type CatalogConfidence = "high" | "medium" | "low";
 export type CatalogSource = { readonly id: string; readonly retrieved: string; readonly url: string; readonly title_or_owner: string; readonly tags: readonly string[]; readonly evidence: string; readonly license_usage: string; readonly confidence: CatalogConfidence; readonly limitations: string };
 export type CatalogCommonRule = { readonly id: string; readonly authority_class: "normative_web_constraint" | "sampled_system_guidance"; readonly topic: string; readonly statement: string; readonly source_ids: readonly string[]; readonly confidence: CatalogConfidence; readonly limitations: string };
-export type CatalogPurpose = { readonly id: ResearchProjectPurpose; readonly axes: { readonly project_type: string; readonly request_intent: string; readonly creation_mode: string; readonly fallback: string }; readonly title: string; readonly guidance: readonly string[]; readonly common_rule_ids: readonly string[]; readonly source_ids: readonly string[]; readonly confidence: CatalogConfidence; readonly limitations: string };
+export type CatalogPurpose = { readonly id: PromptPurpose; readonly axes: { readonly project_type: string; readonly request_intent: string; readonly creation_mode: string; readonly fallback: string }; readonly title: string; readonly guidance: readonly string[]; readonly common_rule_ids: readonly string[]; readonly source_ids: readonly string[]; readonly confidence: CatalogConfidence; readonly limitations: string };
 export type ResearchCatalog = { readonly sources: readonly CatalogSource[]; readonly common_rules: readonly CatalogCommonRule[]; readonly purposes: readonly CatalogPurpose[] };
 
 export class ResearchCatalogError extends Error {
@@ -39,7 +43,7 @@ export function parseResearchCatalog(sourcesInput: unknown, commonInput: unknown
   version(purposeRoot, "purposes");
   const purposes = array(purposeRoot["purposes"], "purposes.purposes").map(parsePurpose);
   sortedUnique(purposes.map((purpose) => purpose.id), "purposes.purposes", 1);
-  if (purposes.length !== RESEARCH_PROJECT_PURPOSES.length || purposes.some((purpose, index) => purpose.id !== RESEARCH_PROJECT_PURPOSES[index])) fail("purposes.purposes");
+  if (purposes.length !== PROMPT_PURPOSES.length || purposes.some((purpose, index) => purpose.id !== PROMPT_PURPOSES[index])) fail("purposes.purposes");
   for (const purpose of purposes) {
     citations(purpose.source_ids, sourceIds, `purposes.${purpose.id}.source_ids`);
     citations(purpose.common_rule_ids, commonIds, `purposes.${purpose.id}.common_rule_ids`);
@@ -96,7 +100,9 @@ function identified(record: JsonObject, key: string, path: string, pattern: RegE
 function exact(record: JsonObject, keys: readonly string[], path: string): void { if (Object.keys(record).length !== keys.length || keys.some((key) => !(key in record))) fail(path); }
 function version(record: JsonObject, path: string): void { if (record["schema_version"] !== 1) fail(`${path}.schema_version`); }
 function confidence(value: unknown, path: string): CatalogConfidence { switch (value) { case "high": case "medium": case "low": return value; default: return fail(path); } }
-function purposeId(value: unknown, path: string): ResearchProjectPurpose { switch (value) { case "deck.pitch": case "prototype.dashboard": case "prototype.diagram": case "prototype.editorial": case "prototype.landing": case "prototype.sandbox": return value; default: return fail(path); } }
+function purposeId(value: unknown, path: string): PromptPurpose {
+  return isPromptPurpose(value) ? value : fail(path);
+}
 function sortedUnique(values: readonly string[], path: string, minimum: number): void { if (values.length < minimum) fail(path); for (let index = 1; index < values.length; index += 1) { const previous = values[index - 1]; const current = values[index]; if (previous === undefined || current === undefined || previous >= current) fail(path); } }
 function citations(values: readonly string[], known: ReadonlySet<string>, path: string): void { if (values.some((value) => !known.has(value))) fail(path); }
 function fail(path: string): never { throw new ResearchCatalogError(path); }

--- a/packages/backend/src/services/research-purpose.ts
+++ b/packages/backend/src/services/research-purpose.ts
@@ -1,16 +1,21 @@
-import type { ProjectType, ResearchProjectPurpose } from "@bg/shared";
+import type { ProjectType } from "@bg/shared";
 import { loadResearchCatalog, type CatalogConfidence, type CatalogPurpose } from "./research-catalog";
+import type { PromptPurpose } from "./prompt-purpose";
 
 const COMMON_BASELINE_IDS = ["CR-001", "CR-002", "CR-003", "CR-004", "CR-005", "CR-008", "CR-009"] as const;
 const PPTX_REQUEST_PATTERN = /\b(?:pptx|powerpoint)\b/i;
 
 const INTENT_SELECTORS = [
-  { intent: "diagram", purpose: "prototype.diagram", pattern: /\b(?:diagram|flowchart|org(?:anization(?:al)?)? chart|process map|service topology|system topology)\b/i },
-  { intent: "dashboard", purpose: "prototype.dashboard", pattern: /\b(?:dashboard|admin console|analytics console)\b/i },
-  { intent: "editorial_microsite", purpose: "prototype.editorial", pattern: /\b(?:editorial microsite|editorial site|magazine site|newsletter site)\b/i },
-  { intent: "design_sandbox", purpose: "prototype.sandbox", pattern: /\b(?:design sandbox|design-system playground|design system playground|component gallery)\b/i },
-  { intent: "landing", purpose: "prototype.landing", pattern: /\b(?:landing page|marketing homepage|marketing site)\b/i },
-  { intent: "pitch", purpose: "deck.pitch", pattern: /\b(?:investor pitch|pitch deck|fundrais(?:e|ing))\b/i },
+  { intent: "company", purpose: "deck.company", pattern: /\b(?:company profile|corporate overview|company introduction)\b|(?:회사|기업)\s*(?:소개|개요)|회사소개서|기업소개서/iu },
+  { intent: "sales", purpose: "deck.sales", pattern: /\b(?:sales proposal|client proposal|commercial proposal|sales deck)\b|(?:고객사?|영업)\s*(?:제안서|자료|덱|슬라이드)|영업제안서/iu },
+  { intent: "report", purpose: "deck.report", pattern: /\b(?:quarterly|annual|business|status|performance)\s+report(?:\s+deck)?\b|(?:분기|연간)\s*(?:실적|업무|성과)?\s*(?:보고서|보고 자료|리포트)|(?:업무|실적|성과)\s*(?:보고서|보고 자료|리포트)/iu },
+  { intent: "training", purpose: "deck.training", pattern: /\b(?:training deck|training material|employee training|onboarding training)\b|(?:신입사원|사내)?\s*교육\s*(?:자료|덱|슬라이드)|연수\s*(?:자료|덱|슬라이드)/iu },
+  { intent: "diagram", purpose: "prototype.diagram", pattern: /\b(?:diagram|flowchart|org(?:anization(?:al)?)? chart|process map|service topology|system topology)\b|다이어그램|흐름도|조직도|프로세스\s*맵|서비스\s*구조/iu },
+  { intent: "dashboard", purpose: "prototype.dashboard", pattern: /\b(?:dashboard|admin console|analytics console)\b|대시보드|관리자\s*화면|분석\s*화면/iu },
+  { intent: "editorial_microsite", purpose: "prototype.editorial", pattern: /\b(?:editorial microsite|editorial site|magazine site|newsletter site)\b|편집형\s*사이트|매거진\s*사이트|뉴스레터\s*사이트/iu },
+  { intent: "design_sandbox", purpose: "prototype.sandbox", pattern: /\b(?:design sandbox|design-system playground|design system playground|component gallery)\b|디자인\s*샌드박스|컴포넌트\s*(?:갤러리|쇼케이스)|디자인\s*시스템\s*문서/iu },
+  { intent: "landing", purpose: "prototype.landing", pattern: /\b(?:landing page|marketing homepage|marketing site)\b|랜딩\s*페이지|마케팅\s*홈페이지|홍보\s*사이트/iu },
+  { intent: "pitch", purpose: "deck.pitch", pattern: /\b(?:investor pitch|pitch deck|fundrais(?:e|ing))\b|투자\s*유치|IR\s*자료|피치\s*덱/iu },
 ] as const;
 
 type RequestIntent = (typeof INTENT_SELECTORS)[number]["intent"] | "unspecified";
@@ -23,7 +28,7 @@ type ResearchRouting = {
   readonly request_intent: RequestIntent;
   readonly creation_mode: CreationMode;
   readonly fallback: "common_baseline" | "none";
-  readonly purpose: ResearchProjectPurpose | null;
+  readonly purpose: PromptPurpose | null;
 };
 
 type PromptResearchRule = {

--- a/packages/backend/src/services/research-selection.ts
+++ b/packages/backend/src/services/research-selection.ts
@@ -2,6 +2,10 @@ import type { Database } from "bun:sqlite";
 import { parseResearchResultV1, type ResearchConflict, type ResearchProjectPurpose, type ResearchRule, type ResearchSourceRecord } from "@bg/shared";
 import { ResearchCorruptionError, evidenceSetDigest, getResearchRun, listResearchSources } from "../db/research-repository";
 import { type CatalogConfidence, type CatalogSource, loadResearchCatalog, type ResearchCatalog } from "./research-catalog";
+import {
+  isPromptPurpose,
+  type PromptPurpose,
+} from "./prompt-purpose";
 
 export class ResearchSelectionError extends Error {
   readonly name = "ResearchSelectionError";
@@ -15,14 +19,14 @@ export type LayerConflict = { readonly axis: string; readonly winner_id: string;
 export type LayerResolution = { readonly rules: readonly ResolvedLayerRule[]; readonly conflicts: readonly LayerConflict[] };
 export type SelectedSource = { readonly id: string; readonly url: string };
 export type CatalogSelectedRule = { readonly id: string; readonly axis: string; readonly directive: string; readonly rationale: string; readonly confidence: CatalogConfidence; readonly low_confidence: boolean; readonly source_ids: readonly string[]; readonly sources: readonly SelectedSource[] };
-export type CatalogRuleSelection = { readonly purpose: ResearchProjectPurpose; readonly title: string; readonly confidence: CatalogConfidence; readonly low_confidence: boolean; readonly limitations: string; readonly common_rules: readonly CatalogSelectedRule[]; readonly purpose_rules: readonly CatalogSelectedRule[] };
+export type CatalogRuleSelection = { readonly purpose: PromptPurpose; readonly title: string; readonly confidence: CatalogConfidence; readonly low_confidence: boolean; readonly limitations: string; readonly common_rules: readonly CatalogSelectedRule[]; readonly purpose_rules: readonly CatalogSelectedRule[] };
 export type RuntimeSelectedRule = ResearchRule & { readonly low_confidence: boolean; readonly sources: readonly SelectedSource[] };
 export type ResearchPromptContext = { readonly schema_version: 1; readonly purpose: ResearchProjectPurpose; readonly run_id: string; readonly result_digest: string; readonly outcome: "completed" | "partial"; readonly common_rules: readonly RuntimeSelectedRule[]; readonly purpose_rules: readonly RuntimeSelectedRule[]; readonly conflicts: readonly ResearchConflict[] };
 
 type FlattenedDeclaration = { readonly layerId: string; readonly declaration: ResearchRule | RuleReference };
 
 export function selectCatalogRules(catalog: ResearchCatalog, purposeInput: unknown): CatalogRuleSelection {
-  const purpose = supportedPurpose(purposeInput);
+  const purpose = supportedPromptPurpose(purposeInput);
   const purposeRecord = catalog.purposes.find((item) => item.id === purpose);
   if (purposeRecord === undefined) throw new ResearchSelectionError("unknown_purpose", String(purposeInput));
   const sources = new Map(catalog.sources.map((source) => [source.id, source]));
@@ -84,7 +88,7 @@ export function resolveResearchRuleLayers(layers: readonly ResearchRuleLayer[]):
 }
 
 export function selectResearchPromptContext(db: Database, purposeInput: unknown): ResearchPromptContext | null {
-  const purpose = supportedPurpose(purposeInput);
+  const purpose = supportedResearchPurpose(purposeInput);
   const candidates = db.query<{ readonly id: string }, []>("SELECT id FROM research_runs WHERE usable=1 AND status IN ('completed','partial') ORDER BY completed_at DESC,id DESC").all();
   for (const candidate of candidates) {
     try {
@@ -121,5 +125,9 @@ function validatedContext(db: Database, runId: string, purpose: ResearchProjectP
 function selectedRuntimeRule(rule: ResearchRule, sources: ReadonlyMap<string, ResearchSourceRecord>, runId: string): RuntimeSelectedRule { return { ...rule, low_confidence: rule.confidence < 0.5, sources: runtimeSources(rule.source_ids, sources, runId) }; }
 function runtimeSources(ids: readonly string[], sources: ReadonlyMap<string, ResearchSourceRecord>, runId: string): readonly SelectedSource[] { return ids.map((id) => { const source = sources.get(id); if (source === undefined || source.run_id !== runId || source.status !== "succeeded") corrupt(`${runId}:${id}`); return { id, url: source.canonical_locator }; }); }
 function catalogSources(ids: readonly string[], sources: ReadonlyMap<string, CatalogSource>): readonly SelectedSource[] { return ids.map((id) => { const source = sources.get(id); if (source === undefined) throw new ResearchSelectionError("invalid_reference", id); return { id, url: source.url }; }); }
-function supportedPurpose(value: unknown): ResearchProjectPurpose { switch (value) { case "deck.pitch": case "prototype.dashboard": case "prototype.diagram": case "prototype.editorial": case "prototype.landing": case "prototype.sandbox": return value; default: throw new ResearchSelectionError("unknown_purpose", String(value)); } }
+function supportedPromptPurpose(value: unknown): PromptPurpose {
+  if (isPromptPurpose(value)) return value;
+  throw new ResearchSelectionError("unknown_purpose", String(value));
+}
+function supportedResearchPurpose(value: unknown): ResearchProjectPurpose { switch (value) { case "deck.pitch": case "prototype.dashboard": case "prototype.diagram": case "prototype.editorial": case "prototype.landing": case "prototype.sandbox": return value; default: throw new ResearchSelectionError("unknown_purpose", String(value)); } }
 function corrupt(detail: string): never { throw new ResearchSelectionError("corrupt_result", detail); }

--- a/packages/backend/tests/catalog.test.ts
+++ b/packages/backend/tests/catalog.test.ts
@@ -109,6 +109,8 @@ describe("production API route registration", () => {
       ["/api/sessions/id", "GET", "session"],
       ["/api/runtime", "GET", "runtime"],
       ["/api/settings", "GET", "home"],
+      ["/api/settings/playwright", "GET", "settings"],
+      ["/api/settings/python", "GET", "settings"],
       ["/api/unknown", "GET", "not-found"],
     ] as const;
 

--- a/packages/backend/tests/design-brief-prompt.test.ts
+++ b/packages/backend/tests/design-brief-prompt.test.ts
@@ -1,0 +1,81 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { getSqlite } from "../src/db/sqlite-client";
+import { buildPrompt } from "../src/harness/prompt-builder";
+import { ensureLearningSchema } from "./learning-fixture";
+
+type BuildContext = Parameters<typeof buildPrompt>[0];
+
+beforeAll(() => ensureLearningSchema(getSqlite()));
+
+function context(optionsJson: string | null): BuildContext {
+  return {
+    project: {
+      project_id: "brief-project",
+      project_name: "분기 영업 보고서",
+      project_type: "slide_deck",
+      project_dir: "/tmp/brief-project",
+      entrypoint: "deck.html",
+      options_json: optionsJson,
+      current_revision: 0,
+      current_digest: null,
+    },
+    designSystem: null,
+    files: [],
+    attachments: [],
+    openComments: [],
+  };
+}
+
+function taggedJson(prompt: string, tag: string): Readonly<Record<string, unknown>> {
+  const match = prompt.match(new RegExp(`<${tag}>\\n([^\\n]+)\\n</${tag}>`));
+  expect(match).not.toBeNull();
+  const parsed: unknown = JSON.parse(match?.[1] ?? "{}");
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`Expected ${tag} to contain an object`);
+  }
+  return parsed;
+}
+
+describe("design brief prompt context", () => {
+  test("Given a versioned project brief When the prompt is built Then machine fields are injected", async () => {
+    const designBrief = {
+      schema_version: 1,
+      output_type: "slide_deck",
+      audience: "영업팀 리더",
+      objective: "분기 성과와 다음 행동을 공유한다",
+      content_source: "attached",
+      locale: "ko-KR",
+      brand_mode: "selected_design_system",
+      visual_mood: "formal",
+      density: "balanced",
+      output_size: "widescreen-16x9",
+    } as const;
+    const prompt = await buildPrompt(
+      context(JSON.stringify({ design_brief: designBrief })),
+      { type: "user.message", text: "이 자료로 영업 보고서를 만들어줘" },
+    );
+
+    expect(taggedJson(prompt, "burnguard-design-brief-v1")).toEqual(
+      designBrief,
+    );
+  });
+
+  test("Given malformed project options When the prompt is built Then no partial brief leaks", async () => {
+    const prompt = await buildPrompt(
+      context(
+        JSON.stringify({
+          design_brief: {
+            schema_version: 1,
+            output_type: "slide_deck",
+            audience: "",
+          },
+        }),
+      ),
+      { type: "user.message", text: "자료를 만들어줘" },
+    );
+
+    expect(prompt).not.toMatch(
+      /<burnguard-design-brief-v1>\n[^\n]+\n<\/burnguard-design-brief-v1>/u,
+    );
+  });
+});

--- a/packages/backend/tests/home-project-input.test.ts
+++ b/packages/backend/tests/home-project-input.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { homeRoutes } from "../src/routes/home";
+
+type ErrorEnvelope = {
+  readonly error: {
+    readonly code: string;
+    readonly details?: unknown;
+  };
+};
+
+function errorEnvelope(value: unknown): ErrorEnvelope {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("error" in value) ||
+    typeof value.error !== "object" ||
+    value.error === null ||
+    !("code" in value.error) ||
+    typeof value.error.code !== "string"
+  ) {
+    throw new Error("Expected an error envelope");
+  }
+  return { error: { code: value.error.code } };
+}
+
+async function createProject(body: unknown): Promise<Response> {
+  return homeRoutes.request("http://local/api/projects", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("home project input boundary", () => {
+  test.each([
+    [{}, "invalid_name"],
+    [
+      {
+        name: "Project",
+        type: "graphic",
+        design_system_id: null,
+        backend_id: "claude-code",
+      },
+      "invalid_type",
+    ],
+    [
+      {
+        name: "Project",
+        type: "prototype",
+        design_system_id: 7,
+        backend_id: "claude-code",
+      },
+      "invalid_design_system",
+    ],
+    [
+      {
+        name: "Project",
+        type: "prototype",
+        design_system_id: null,
+        backend_id: "unknown",
+      },
+      "invalid_backend",
+    ],
+    [
+      {
+        name: "Project",
+        type: "prototype",
+        design_system_id: null,
+        backend_id: "claude-code",
+        options: { design_brief: { schema_version: 1 } },
+      },
+      "invalid_project_options",
+    ],
+  ])("Given malformed project input When posted Then the boundary returns its error code", async (body, code) => {
+    const response = await createProject(body);
+    const error = errorEnvelope(await response.json());
+    expect(response.status).toBe(400);
+    expect(error.error.code).toBe(code);
+  });
+});

--- a/packages/backend/tests/project-options.test.ts
+++ b/packages/backend/tests/project-options.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { UpgradeContractError } from "@bg/shared";
+import {
+  parseProjectOptions,
+  parseStoredProjectOptions,
+} from "../src/services/project-options";
+
+const validBrief = {
+  schema_version: 1,
+  output_type: "slide_deck",
+  audience: "영업팀",
+  objective: "성과와 다음 행동을 공유한다",
+  content_source: "attached",
+  locale: "ko-KR",
+  brand_mode: "selected_design_system",
+  visual_mood: "formal",
+  density: "balanced",
+  output_size: "widescreen-16x9",
+} as const;
+
+describe("project options", () => {
+  test("Given valid options When parsed Then the canonical brief is preserved", () => {
+    expect(
+      parseProjectOptions({
+        use_speaker_notes: true,
+        copy_as_is: false,
+        design_brief: validBrief,
+      }),
+    ).toEqual({
+      use_speaker_notes: true,
+      copy_as_is: false,
+      design_brief: validBrief,
+    });
+  });
+
+  test("Given invalid option fields When parsed Then typed boundary errors identify them", () => {
+    expect(() =>
+      parseProjectOptions({ use_speaker_notes: "yes" }),
+    ).toThrow(UpgradeContractError);
+    expect(() =>
+      parseProjectOptions({
+        design_brief: { ...validBrief, visual_mood: "cinematic" },
+      }),
+    ).toThrow(UpgradeContractError);
+  });
+
+  test("Given malformed stored JSON When parsed Then safe defaults are returned", () => {
+    expect(parseStoredProjectOptions("{")).toEqual({
+      use_speaker_notes: false,
+      copy_as_is: false,
+      design_brief: null,
+    });
+  });
+});

--- a/packages/backend/tests/reference-layout-prompt.test.ts
+++ b/packages/backend/tests/reference-layout-prompt.test.ts
@@ -1,0 +1,215 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { getSqlite } from "../src/db/sqlite-client";
+import { buildPrompt } from "../src/harness/prompt-builder";
+import { ensureLearningSchema } from "./learning-fixture";
+
+type BuildContext = Parameters<typeof buildPrompt>[0];
+type Attachment = BuildContext["attachments"][number];
+type JsonRecord = Readonly<Record<string, unknown>>;
+
+beforeAll(() => ensureLearningSchema(getSqlite()));
+
+function attachment(
+  filePath: string,
+  mimeType: string,
+  originalName: string,
+): Attachment {
+  return {
+    id: originalName,
+    session_id: "layout-session",
+    turn_id: null,
+    file_path: filePath,
+    mime_type: mimeType,
+    original_name: originalName,
+    size_bytes: 1024,
+    sha256: "a".repeat(64),
+    created_at: 1,
+  };
+}
+
+function context(attachments: readonly Attachment[]): BuildContext {
+  return {
+    project: {
+      project_id: "layout-project",
+      project_name: "Reference layout",
+      project_type: "other",
+      project_dir: "/tmp/layout-project",
+      entrypoint: "index.html",
+      options_json: null,
+      current_revision: 0,
+      current_digest: null,
+    },
+    designSystem: null,
+    files: [],
+    attachments,
+    openComments: [],
+  };
+}
+
+function taggedJson(prompt: string): JsonRecord {
+  const match = prompt.match(
+    /<burnguard-reference-layout-v1>\n([^\n]+)\n<\/burnguard-reference-layout-v1>/u,
+  );
+  expect(match).not.toBeNull();
+  const parsed: unknown = JSON.parse(match?.[1] ?? "{}");
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("Expected reference-layout context object");
+  }
+  return parsed;
+}
+
+function nested(record: JsonRecord, key: string): JsonRecord {
+  const value = record[key];
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`Expected ${key} object`);
+  }
+  return value;
+}
+
+describe("reference layout prompt context", () => {
+  test("Given a Korean drawing and metric sheet When built Then geometry and unknown scale are explicit", async () => {
+    const filePath = "/tmp/floor-plan.svg";
+    const prompt = await buildPrompt(
+      context([
+        attachment(filePath, "image/svg+xml", "floor-plan.svg"),
+        attachment("/tmp/unselected.png", "image/png", "unselected.png"),
+      ]),
+      {
+        type: "user.message",
+        text: "이 도면을 A3 가로 420×297mm, 300 DPI, 재단 여백 3mm, 안전 여백 12mm로 배치해줘. 축척은 미정이야.",
+        attachments: [filePath],
+      },
+    );
+    const block = taggedJson(prompt);
+    const intent = nested(block, "intent");
+    const reference = nested(block, "reference");
+    const canvas = nested(block, "canvas");
+    const scale = nested(canvas, "scale");
+    const bleed = nested(canvas, "bleed");
+    const safeMargin = nested(canvas, "safe_margin");
+    const geometry = nested(block, "geometry_contract");
+    const exporters = nested(block, "export_constraints");
+
+    expect(block["schema_version"]).toBe(1);
+    expect(block["layout_spec_path"]).toBe("layout-spec.json");
+    expect(intent).toEqual({
+      detected: true,
+      source: "request_and_attachment",
+      language: "ko",
+    });
+    expect(reference).toEqual({
+      attachment_path: filePath,
+      original_name: "floor-plan.svg",
+      mime_type: "image/svg+xml",
+      role: "immutable_underlay",
+      evidence_boundary: "hard_geometry",
+      editable: false,
+    });
+    expect(canvas["preset"]).toBe("a3");
+    expect(canvas["width"]).toBe(420);
+    expect(canvas["height"]).toBe(297);
+    expect(canvas["unit"]).toBe("mm");
+    expect(canvas["orientation"]).toBe("landscape");
+    expect(canvas["aspect_ratio"]).toEqual({
+      width: 420,
+      height: 297,
+      source: "dimensions",
+    });
+    expect(canvas["dpi"]).toBe(300);
+    expect(scale).toEqual({ status: "unknown", value: null });
+    expect(bleed).toEqual({ status: "known", value: 3, unit: "mm" });
+    expect(safeMargin).toEqual({ status: "known", value: 12, unit: "mm" });
+    expect(geometry).toEqual({
+      origin: "top_left",
+      x_axis: "right",
+      y_axis: "down",
+      anchor_space: "normalized_0_1",
+      stable_anchors_required: true,
+      preserve_aspect_ratio: true,
+    });
+    expect(nested(exporters, "pdf")).toEqual({
+      supported: false,
+      limitation: "preset_only",
+      coerce_to_a4: false,
+      on_unsupported: "report_and_preserve_spec",
+    });
+    expect(nested(exporters, "pptx")["supported"]).toBe(false);
+    expect(nested(exporters, "png")["supported"]).toBe(true);
+    expect(JSON.stringify(block)).not.toContain("unselected.png");
+
+    const repeated = await buildPrompt(
+      context([
+        attachment(filePath, "image/svg+xml", "floor-plan.svg"),
+        attachment("/tmp/unselected.png", "image/png", "unselected.png"),
+      ]),
+      {
+        type: "user.message",
+        text: "이 도면을 A3 가로 420×297mm, 300 DPI, 재단 여백 3mm, 안전 여백 12mm로 배치해줘. 축척은 미정이야.",
+        attachments: [filePath],
+      },
+    );
+    expect(taggedJson(repeated)).toEqual(block);
+  });
+
+  test("Given explicit imperial dimensions When built Then scale and raster mapping remain deterministic", async () => {
+    const filePath = "/tmp/floor-plan.pdf";
+    const prompt = await buildPrompt(
+      context([attachment(filePath, "application/pdf", "floor-plan.pdf")]),
+      {
+        type: "user.message",
+        text: "Use this floor plan as an immutable underlay on a 24x36in portrait sheet at 150 DPI. Bleed unknown, safe margin 0.5in, scale 1:100.",
+        attachments: [filePath],
+      },
+    );
+    const block = taggedJson(prompt);
+    const canvas = nested(block, "canvas");
+
+    expect(canvas["preset"]).toBe("custom");
+    expect(canvas["width"]).toBe(24);
+    expect(canvas["height"]).toBe(36);
+    expect(canvas["unit"]).toBe("in");
+    expect(canvas["orientation"]).toBe("portrait");
+    expect(canvas["aspect_ratio"]).toEqual({
+      width: 24,
+      height: 36,
+      source: "dimensions",
+    });
+    expect(nested(canvas, "scale")).toEqual({
+      status: "known",
+      value: "1:100",
+    });
+    expect(nested(canvas, "bleed")).toEqual({
+      status: "unknown",
+      value: null,
+      unit: null,
+    });
+    expect(nested(canvas, "safe_margin")).toEqual({
+      status: "known",
+      value: 0.5,
+      unit: "in",
+    });
+    expect(nested(canvas, "raster_target_px")).toEqual({
+      status: "known",
+      width: 3600,
+      height: 5400,
+    });
+  });
+
+  test("Given unrelated or unselected attachments When built Then no reference context is emitted", async () => {
+    const prompt = await buildPrompt(
+      context([
+        attachment("/tmp/notes.txt", "text/plain", "notes.txt"),
+        attachment("/tmp/reference.png", "image/png", "reference.png"),
+      ]),
+      {
+        type: "user.message",
+        text: "Summarize the attached notes",
+        attachments: ["/tmp/notes.txt"],
+      },
+    );
+
+    expect(prompt).not.toMatch(
+      /<burnguard-reference-layout-v1>\n[^\n]+\n<\/burnguard-reference-layout-v1>/u,
+    );
+  });
+});

--- a/packages/backend/tests/reference-layout-prompt.test.ts
+++ b/packages/backend/tests/reference-layout-prompt.test.ts
@@ -1,6 +1,10 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { getSqlite } from "../src/db/sqlite-client";
 import { buildPrompt } from "../src/harness/prompt-builder";
+import {
+  hasReferenceLayoutIntent,
+  parseReferenceLayoutCanvas,
+} from "../src/services/reference-layout-values";
 import { ensureLearningSchema } from "./learning-fixture";
 
 type BuildContext = Parameters<typeof buildPrompt>[0];
@@ -211,5 +215,55 @@ describe("reference layout prompt context", () => {
     expect(prompt).not.toMatch(
       /<burnguard-reference-layout-v1>\n[^\n]+\n<\/burnguard-reference-layout-v1>/u,
     );
+  });
+
+  test("Given an ordinary selected logo When requested as content Then no layout contract is emitted", async () => {
+    const filePath = "/tmp/logo.png";
+    const prompt = await buildPrompt(
+      context([attachment(filePath, "image/png", "logo.png")]),
+      {
+        type: "user.message",
+        text: "Add our logo to the header",
+        attachments: [filePath],
+      },
+    );
+
+    expect(prompt).not.toMatch(
+      /<burnguard-reference-layout-v1>\n[^\n]+\n<\/burnguard-reference-layout-v1>/u,
+    );
+  });
+
+  test("Given ordinary English wording When canvas values are parsed Then no preset is inferred", () => {
+    expect(
+      parseReferenceLayoutCanvas(
+        "Use this cover letter as a style reference with a standard report structure",
+      ).preset,
+    ).toBeNull();
+    expect(
+      parseReferenceLayoutCanvas(
+        "Consider drawing attention to the primary call to action",
+      ).preset,
+    ).toBeNull();
+    expect(
+      hasReferenceLayoutIntent(
+        "Consider drawing attention to the primary call to action",
+      ),
+    ).toBe(false);
+  });
+
+  test("Given a selected drawing filename When request text is generic Then the layout contract still activates", async () => {
+    const filePath = "/tmp/floor-plan.svg";
+    const prompt = await buildPrompt(
+      context([attachment(filePath, "image/svg+xml", "floor-plan.svg")]),
+      {
+        type: "user.message",
+        text: "Use the attached file",
+        attachments: [filePath],
+      },
+    );
+
+    const block = taggedJson(prompt);
+    expect(nested(block, "intent")["source"]).toBe("attachment");
+    expect(nested(block, "reference")["role"]).toBe("immutable_underlay");
   });
 });

--- a/packages/backend/tests/research-catalog.test.ts
+++ b/packages/backend/tests/research-catalog.test.ts
@@ -3,7 +3,11 @@ import { readFile } from "node:fs/promises";
 
 const DATA_ROOT = new URL("../src/research-data/", import.meta.url);
 const PURPOSE_IDS = [
+  "deck.company",
   "deck.pitch",
+  "deck.report",
+  "deck.sales",
+  "deck.training",
   "prototype.dashboard",
   "prototype.diagram",
   "prototype.editorial",
@@ -130,6 +134,24 @@ describe("research catalog artifacts", () => {
       expectSortedUniqueTexts(ruleIds);
       expect(citations.every((id) => sourceIds.has(id))).toBe(true);
       expect(ruleIds.every((id) => commonRuleIds.has(id))).toBe(true);
+    }
+  });
+
+  test("Given deck purposes When validated Then each deck kind is separately axed at bounded confidence", async () => {
+    // Given
+    const catalogValue = await catalog("purpose-references.json");
+
+    // When
+    const deckPurposes = records(catalogValue["purposes"]).filter((purpose) => text(purpose["id"]).startsWith("deck."));
+
+    // Then
+    expect(deckPurposes.map((purpose) => text(purpose["id"]))).toEqual(["deck.company", "deck.pitch", "deck.report", "deck.sales", "deck.training"]);
+    expect(deckPurposes.map((purpose) => text(record(purpose["axes"])["request_intent"]))).toEqual(["company", "pitch", "report", "sales", "training"]);
+    for (const purpose of deckPurposes) {
+      expect(text(record(purpose["axes"])["project_type"])).toBe("slide_deck");
+      expect(text(purpose["confidence"])).toBe("medium");
+      expect(texts(purpose["guidance"]).length).toBeGreaterThanOrEqual(3);
+      expect(text(purpose["limitations"]).length).toBeGreaterThan(0);
     }
   });
 });

--- a/packages/backend/tests/research-purpose-prompt.test.ts
+++ b/packages/backend/tests/research-purpose-prompt.test.ts
@@ -42,6 +42,38 @@ describe("research purpose prompt integration", () => {
     expect(researchBlock(await buildPrompt(context(projectType), { type: "user.message", text: request })).routing.purpose).toBe(purpose);
   });
 
+  test.each([
+    ["회사소개서를 만들어 주세요", "deck.company", "company"],
+    ["Create a company profile deck", "deck.company", "company"],
+    ["고객사 제안서 슬라이드를 준비해 줘", "deck.sales", "sales"],
+    ["Create a sales proposal deck", "deck.sales", "sales"],
+    ["분기 실적 보고서를 만들어 줘", "deck.report", "report"],
+    ["Create a quarterly report deck", "deck.report", "report"],
+    ["신입사원 교육 자료를 만들어 줘", "deck.training", "training"],
+    ["Create a training deck", "deck.training", "training"],
+    ["투자 유치 IR 자료를 만들어 줘", "deck.pitch", "pitch"],
+  ])("Given a Korean or English deck request When built Then purpose and intent separate by deck kind", async (request, purpose, intent) => {
+    const block = researchBlock(await buildPrompt(context("slide_deck"), { type: "user.message", text: request }));
+    expect(block.routing.purpose).toBe(purpose);
+    expect(block.routing.request_intent).toBe(intent);
+  });
+
+  test("Given a Korean sales deck request When built Then purpose rules carry catalog ids and explicit confidence", async () => {
+    const block = researchBlock(await buildPrompt(context("slide_deck"), { type: "user.message", text: "영업 제안서 덱을 만들어 줘" }));
+    const purposeRules = block.rules.filter((rule) => rule.id.startsWith("deck.sales:"));
+    expect(purposeRules.map((rule) => rule.id)).toEqual(["deck.sales:1", "deck.sales:2", "deck.sales:3"]);
+    expect(purposeRules.every((rule) => rule.confidence === "medium" && rule.source_ids.length > 0 && rule.authority_class === "research_heuristic")).toBe(true);
+    expect(block.rules.map((rule) => rule.id)).toEqual(expect.arrayContaining(["CR-001", "CR-002", "CR-004", "CR-008"]));
+    expect(block.output_profile).toBe("web");
+  });
+
+  test("Given a Korean training deck for PowerPoint When built Then the purpose and text-first profile hold together", async () => {
+    const block = researchBlock(await buildPrompt(context("slide_deck"), { type: "user.message", text: "사내 교육 자료를 PPTX로 만들어 줘" }));
+    expect(block.routing).toEqual({ project_type: "slide_deck", request_intent: "training", creation_mode: "blank", fallback: "none", purpose: "deck.training" });
+    expect(block.output_profile).toBe("pptx_text_first");
+    expect(block.advice).toContain("pptx_text_first");
+  });
+
   test("Given generic and template requests When built Then fallback remains separate from intent and mode", async () => {
     const generic = researchBlock(await buildPrompt(context(), { type: "user.message", text: "Polish this" }));
     const template = researchBlock(await buildPrompt(context("from_template"), { type: "user.message", text: "Polish this" }));

--- a/packages/backend/tests/research-selection.test.ts
+++ b/packages/backend/tests/research-selection.test.ts
@@ -62,6 +62,21 @@ describe("research catalog selection", () => {
     expect(selected.limitations).toContain("not a universal investor-pitch narrative");
   });
 
+  test("Given a prompt-only deck purpose When selected Then catalog rules resolve while persisted selection rejects it", () => {
+    // Given
+    const catalog = loadResearchCatalog();
+    // When
+    const selected = selectCatalogRules(catalog, "deck.training");
+    // Then
+    expect(selected.purpose).toBe("deck.training");
+    expect(selected.confidence).toBe("medium");
+    expect(selected.low_confidence).toBe(true);
+    expect(selected.common_rules.map((rule) => rule.id)).toEqual(["CR-001", "CR-002", "CR-004", "CR-008"]);
+    expect(selected.purpose_rules.map((rule) => rule.id)).toEqual(["deck.training:1", "deck.training:2", "deck.training:3"]);
+    expect(selected.purpose_rules.every((rule) => rule.sources.length > 0 && rule.low_confidence)).toBe(true);
+    expect(() => selectResearchPromptContext(db, "deck.training")).toThrow(ResearchSelectionError);
+  });
+
   test("Given usable runtime results When selected Then newest valid result and citations are preserved", () => {
     // Given
     persistResult({ id: "run-a", completedAt: 20, directive: "Older" });

--- a/packages/frontend/src/components/chat/ChatPane.tsx
+++ b/packages/frontend/src/components/chat/ChatPane.tsx
@@ -111,8 +111,12 @@ export default function ChatPane({
           />
         </>
       ) : (
-        <div className="flex-1 grid place-items-center text-xs text-muted-foreground p-6 text-center">
-          Comments land in Phase 2.
+        <div className="flex-1 grid place-items-center p-6 text-center text-xs leading-relaxed text-foreground/80">
+          <p>
+            코멘트는 캔버스에서 남겨요. 위쪽 도구 막대에서 Comment 모드를 켠 뒤
+            화면의 원하는 위치를 클릭하면 그 자리에 코멘트가 붙고, 캔버스 옆
+            Comments 패널에 모입니다.
+          </p>
         </div>
       )}
     </aside>

--- a/packages/frontend/src/components/chat/Composer.tsx
+++ b/packages/frontend/src/components/chat/Composer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
-import { Import, Paperclip, Send, Settings2, StopCircle } from "lucide-react";
+import { Paperclip, Send, Settings2, StopCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useUIStore } from "@/state/uiStore";
 import { cn } from "@/lib/utils";
 
 const IDLE_PLACEHOLDER =
@@ -10,15 +11,15 @@ const IDLE_PLACEHOLDER =
 // while the turn is running turns the wait into a tiny loop of "the
 // app is alive" signals instead of a blank disabled textarea.
 const WAITING_PLACEHOLDERS = [
-  "로컬 CLI 워밍업 중... ☕",
+  "로컬 CLI 워밍업 중...",
   "Claude가 키보드를 두드리는 중...",
-  "토큰을 한 장 한 장 세는 중... 📜",
+  "토큰을 한 장 한 장 세는 중...",
   "GPU가 기어를 올리는 소리가 들려요...",
-  "deck에 잉크를 바르는 중... 🎨",
+  "덱에 잉크를 바르는 중...",
   "프롬프트를 천천히 음미하는 중...",
   "로컬이라 좀 느립니다. 딴짓해도 돼요.",
-  "당신의 문장을 조립 중... 🧱",
-  "Claude가 스크롤을 읽는 중... 📚",
+  "당신의 문장을 조립 중...",
+  "Claude가 스크롤을 읽는 중...",
   "그림의 남은 한 조각을 찾는 중...",
 ];
 const WAITING_INTERVAL_MS = 2400;
@@ -51,6 +52,7 @@ export default function Composer({
    */
   initialText?: string;
 }) {
+  const setSettingsOpen = useUIStore((s) => s.setSettingsOpen);
   const [text, setText] = useState(initialText);
   const [files, setFiles] = useState<File[]>([]);
   const [dragOver, setDragOver] = useState(false);
@@ -108,9 +110,11 @@ export default function Composer({
               key={i}
               className="inline-flex items-center gap-1 rounded bg-muted text-muted-foreground text-[11px] px-2 py-1"
             >
-              📎 <span className="max-w-[120px] truncate">{f.name}</span>
+              <Paperclip className="h-3 w-3" />
+              <span className="max-w-[120px] truncate">{f.name}</span>
               <button
                 className="ml-0.5 text-muted-foreground hover:text-foreground"
+                title={`${f.name} 첨부 취소`}
                 onClick={() =>
                   setFiles((prev) => prev.filter((_, j) => j !== i))
                 }
@@ -153,29 +157,20 @@ export default function Composer({
           variant="ghost"
           size="icon"
           className="h-7 w-7 text-muted-foreground"
-          title="Settings"
-          disabled={disabled}
+          title="설정 열기"
+          onClick={() => setSettingsOpen(true)}
         >
           <Settings2 className="h-3.5 w-3.5" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7 text-muted-foreground"
-          title="Attach files"
-          disabled={disabled}
-          onClick={() => fileInput.current?.click()}
-        >
-          <Paperclip className="h-3.5 w-3.5" />
         </Button>
         <Button
           variant="outline"
           size="sm"
           className="h-7 gap-1 text-xs"
-          title="Import a folder"
+          title="참고할 파일을 첨부합니다"
           disabled={disabled}
+          onClick={() => fileInput.current?.click()}
         >
-          <Import className="h-3.5 w-3.5" /> Import
+          <Paperclip className="h-3.5 w-3.5" /> 자료 첨부
         </Button>
         <div className="flex-1" />
         {disabled && canInterrupt ? (
@@ -185,10 +180,10 @@ export default function Composer({
             className="h-7 gap-1 text-xs"
             disabled={interruptPending || !onInterrupt}
             onClick={() => onInterrupt?.()}
-            title="Interrupt the running turn"
+            title="진행 중인 작업을 중단합니다"
           >
             <StopCircle className="h-3.5 w-3.5" />
-            {interruptPending ? "Stopping…" : "Stop"}
+            {interruptPending ? "중단하는 중..." : "중단"}
           </Button>
         ) : (
           <Button
@@ -197,15 +192,15 @@ export default function Composer({
             className="h-7 gap-1 text-xs"
             disabled={!canSend}
             onClick={send}
-            title="Send (Cmd/Ctrl+Enter)"
+            title="보내기 (Cmd/Ctrl+Enter)"
           >
-            <Send className="h-3.5 w-3.5" /> Send
+            <Send className="h-3.5 w-3.5" /> 보내기
           </Button>
         )}
       </div>
 
-      <p className="mt-1.5 text-[10px] text-muted-foreground text-center">
-        Drop files, docs, or Figma links to attach.
+      <p className="mt-1.5 text-center text-[10px] leading-relaxed text-foreground/80">
+        파일을 여기로 끌어다 놓거나 자료 첨부로 올릴 수 있어요.
       </p>
     </div>
   );

--- a/packages/frontend/src/components/home/NewProjectPanel.tsx
+++ b/packages/frontend/src/components/home/NewProjectPanel.tsx
@@ -144,7 +144,7 @@ export default function NewProjectPanel({
 
         <p className="text-[11px] leading-relaxed text-foreground/80">
           {isTemplate
-            ? "게시된 템플릿만 고를 수 있어요."
+            ? "게시된 디자인 시스템을 템플릿으로 사용할 수 있어요."
             : "게시된 디자인 시스템만 목록에 나와요. 없이도 시작할 수 있어요."}
         </p>
 

--- a/packages/frontend/src/components/home/NewProjectPanel.tsx
+++ b/packages/frontend/src/components/home/NewProjectPanel.tsx
@@ -1,29 +1,39 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import type {
   BackendId,
+  CreateProjectRequest,
   CreateProjectResponse,
   DesignSystemSummary,
+  ProjectType,
 } from "@bg/shared";
 import { createProject } from "@/api/home";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Switch } from "@/components/ui/switch";
+import ProjectBriefFields, {
+  ToggleRow,
+} from "@/components/home/ProjectBriefFields";
+import {
+  INITIAL_BRIEF_FORM,
+  PROBLEM_MESSAGE,
+  PROJECT_CONTROL_CLASS,
+  PROJECT_LABEL_CLASS,
+  buildCreateProjectRequest,
+  keepSelectedDesignSystemId,
+  selectableDesignSystems,
+  type BriefForm,
+} from "@/lib/project-creation";
 import { useUIStore } from "@/state/uiStore";
 
-export type ProjectType =
-  | "prototype"
-  | "slide_deck"
-  | "from_template"
-  | "other";
+export type { ProjectType };
 
 const TYPE_LABEL: Record<ProjectType, string> = {
-  prototype: "New prototype",
-  slide_deck: "New slide deck",
-  from_template: "New from template",
-  other: "New project",
+  prototype: "새 프로토타입",
+  slide_deck: "새 슬라이드 덱",
+  from_template: "템플릿으로 시작",
+  other: "새 프로젝트",
 };
 
 export default function NewProjectPanel({
@@ -40,57 +50,50 @@ export default function NewProjectPanel({
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const pushToast = useUIStore((s) => s.pushToast);
-  const [name, setName] = useState("");
-  const [dsId, setDsId] = useState<string>(designSystems[0]?.id ?? "");
-  const [useSpeakerNotes, setUseSpeakerNotes] = useState(false);
+  const [form, setForm] = useState<BriefForm>(INITIAL_BRIEF_FORM);
+  const [pickedSystemId, setPickedSystemId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!designSystems.find((s) => s.id === dsId) && designSystems[0]) {
-      setDsId(designSystems[0].id);
-    }
-  }, [designSystems, dsId]);
+  // Derived on every render instead of synced by an effect: a late
+  // design-system fetch or a project-type switch can never silently
+  // promote a draft system into the user's explicit choice.
+  const selectable = selectableDesignSystems(designSystems, type);
+  const designSystemId = keepSelectedDesignSystemId(
+    pickedSystemId,
+    selectable,
+  );
+  const isTemplate = type === "from_template";
 
   const createMutation = useMutation({
-    mutationFn: () =>
-      createProject({
-        name: name.trim(),
-        type,
-        design_system_id: dsId || null,
-        backend_id: defaultBackend,
-        options:
-          type === "slide_deck"
-            ? { use_speaker_notes: useSpeakerNotes }
-            : undefined,
-      }),
+    mutationFn: (request: CreateProjectRequest) => createProject(request),
     onSuccess: async (created) => {
       await queryClient.invalidateQueries({ queryKey: ["projects"] });
       onCreated(created);
       navigate(`/projects/${created.id}`);
-      setName("");
-      setUseSpeakerNotes(false);
+      setForm(INITIAL_BRIEF_FORM);
+      setPickedSystemId(null);
       setError(null);
     },
     onError: (err) => {
       const message =
-        err instanceof Error ? err.message : "Failed to create project";
+        err instanceof Error ? err.message : "프로젝트를 만들지 못했어요.";
       setError(message);
       pushToast({
-        title: "Could not create project",
+        title: "프로젝트를 만들지 못했어요",
         body: message,
         tone: "error",
       });
     },
   });
 
-  const canCreate = name.trim().length > 0 && !createMutation.isPending;
-  const hasSystems = designSystems.length > 0;
+  const built = buildCreateProjectRequest(
+    { ...form, type, backendId: defaultBackend, designSystemId },
+    designSystems,
+  );
+  const disabled = createMutation.isPending;
 
-  function handleCreate() {
-    if (!canCreate || !hasSystems) {
-      return;
-    }
-    createMutation.mutate();
+  function update<K extends keyof BriefForm>(key: K, value: BriefForm[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
   }
 
   return (
@@ -99,83 +102,100 @@ export default function NewProjectPanel({
 
       <div className="space-y-4">
         <div className="space-y-1.5">
-          <label
-            htmlFor="project-name"
-            className="text-xs font-medium text-muted-foreground"
-          >
-            Project name
+          <label htmlFor="project-name" className={PROJECT_LABEL_CLASS}>
+            프로젝트 이름
           </label>
           <Input
             id="project-name"
-            placeholder="Untitled"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            placeholder="제목 없음"
+            value={form.name}
+            disabled={disabled}
+            onChange={(e) => update("name", e.target.value)}
           />
         </div>
 
         <div className="space-y-1.5">
-          <label
-            htmlFor="design-system"
-            className="text-xs font-medium text-muted-foreground"
-          >
-            Design system
+          <label htmlFor="design-system" className={PROJECT_LABEL_CLASS}>
+            {isTemplate ? "사용할 템플릿" : "디자인 시스템"}
           </label>
           <select
             id="design-system"
-            value={dsId}
-            onChange={(e) => setDsId(e.target.value)}
-            disabled={!hasSystems || createMutation.isPending}
-            className="flex h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:opacity-50"
+            value={designSystemId ?? ""}
+            disabled={disabled || selectable.length === 0}
+            onChange={(e) => setPickedSystemId(e.target.value || null)}
+            className={PROJECT_CONTROL_CLASS}
           >
-            {hasSystems ? (
-              designSystems.map((s) => (
-                <option key={s.id} value={s.id}>
-                  {s.name}
-                  {s.is_template ? " (Template)" : ""}
-                  {s.status === "draft"
-                    ? " (Draft)"
-                    : s.status === "review"
-                      ? " (Review)"
-                      : ""}
-                </option>
-              ))
-            ) : (
-              <option value="">No design systems available</option>
-            )}
+            <option value="">
+              {selectable.length === 0
+                ? isTemplate
+                  ? "사용할 수 있는 템플릿이 없어요"
+                  : "사용할 수 있는 디자인 시스템이 없어요"
+                : isTemplate
+                  ? "템플릿을 선택하세요"
+                  : "디자인 시스템 없이 시작"}
+            </option>
+            {selectable.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
           </select>
         </div>
 
+        <p className="text-[11px] leading-relaxed text-foreground/80">
+          {isTemplate
+            ? "게시된 템플릿만 고를 수 있어요."
+            : "게시된 디자인 시스템만 목록에 나와요. 없이도 시작할 수 있어요."}
+        </p>
+
+        <ProjectBriefFields
+          form={form}
+          disabled={disabled}
+          onChange={update}
+        />
+
         {type === "slide_deck" && (
-          <div className="flex items-center justify-between rounded-md border border-border px-3 py-2">
-            <div>
-              <div className="text-sm">Use speaker notes</div>
-              <div className="text-xs text-muted-foreground">
-                Less text on slides
-              </div>
-            </div>
-            <Switch
-              checked={useSpeakerNotes}
-              onCheckedChange={setUseSpeakerNotes}
-            />
-          </div>
+          <ToggleRow
+            title="발표자 노트 사용"
+            hint="슬라이드 위 글자를 줄여요"
+            checked={form.useSpeakerNotes}
+            disabled={disabled}
+            onChange={(v) => update("useSpeakerNotes", v)}
+          />
+        )}
+
+        {isTemplate && (
+          <ToggleRow
+            title="템플릿을 그대로 복사"
+            hint="구조는 유지하고 내용만 바꿔요"
+            checked={form.copyAsIs}
+            disabled={disabled}
+            onChange={(v) => update("copyAsIs", v)}
+          />
         )}
       </div>
 
       <Button
         className="mt-6 w-full"
         variant="cta"
-        disabled={!canCreate || !hasSystems}
-        onClick={handleCreate}
+        disabled={!built.ok || disabled}
+        onClick={() => {
+          if (!built.ok || disabled) return;
+          setError(null);
+          createMutation.mutate(built.request);
+        }}
       >
         <Plus className="h-4 w-4" />{" "}
-        {createMutation.isPending ? "Creating..." : "Create"}
+        {createMutation.isPending ? "만드는 중..." : "만들기"}
       </Button>
 
       {error ? (
         <p className="mt-3 text-center text-[11px] text-destructive">{error}</p>
       ) : (
-        <p className="mt-3 text-center text-[11px] text-muted-foreground">
-          Only you can see your project by default.
+        <p className="mt-3 text-center text-[11px] leading-relaxed text-foreground/80">
+          {built.ok
+            ? "이 프로젝트는 기본적으로 나만 볼 수 있어요."
+            : PROBLEM_MESSAGE[built.problem]}
         </p>
       )}
     </div>

--- a/packages/frontend/src/components/home/ProjectBriefFields.tsx
+++ b/packages/frontend/src/components/home/ProjectBriefFields.tsx
@@ -1,0 +1,178 @@
+/**
+ * The bounded Korean project brief fieldset. Pure presentation: it owns
+ * no state and never talks to the network, so NewProjectPanel stays the
+ * only place that decides whether a project can be created.
+ */
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import {
+  AUDIENCE_MAX_LENGTH,
+  CONTENT_SOURCE_CHOICES,
+  DENSITY_CHOICES,
+  OBJECTIVE_MAX_LENGTH,
+  OUTPUT_SIZE_CHOICES,
+  PROJECT_CONTROL_CLASS,
+  PROJECT_LABEL_CLASS,
+  VISUAL_MOOD_CHOICES,
+  type BriefChoice,
+  type BriefForm,
+} from "@/lib/project-creation";
+
+export type BriefFieldChange = <K extends keyof BriefForm>(
+  key: K,
+  value: BriefForm[K],
+) => void;
+
+export default function ProjectBriefFields({
+  form,
+  disabled,
+  onChange,
+}: {
+  form: BriefForm;
+  disabled: boolean;
+  onChange: BriefFieldChange;
+}) {
+  return (
+    <div className="space-y-3 border-t border-border pt-4">
+      <div className="text-[10px] font-medium uppercase tracking-wide text-foreground/80">
+        브리프
+      </div>
+
+      <div className="space-y-1.5">
+        <label htmlFor="brief-audience" className={PROJECT_LABEL_CLASS}>
+          누가 보게 되나요?
+        </label>
+        <Input
+          id="brief-audience"
+          placeholder="예: 국내 투자 심사역"
+          maxLength={AUDIENCE_MAX_LENGTH}
+          value={form.audience}
+          disabled={disabled}
+          onChange={(e) => onChange("audience", e.target.value)}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <label htmlFor="brief-objective" className={PROJECT_LABEL_CLASS}>
+          무엇을 얻고 싶나요?
+        </label>
+        <textarea
+          id="brief-objective"
+          rows={2}
+          placeholder="예: 다음 분기 예산 승인 받기"
+          maxLength={OBJECTIVE_MAX_LENGTH}
+          value={form.objective}
+          disabled={disabled}
+          onChange={(e) => onChange("objective", e.target.value)}
+          className={`${PROJECT_CONTROL_CLASS} h-auto resize-none py-2 leading-relaxed`}
+        />
+      </div>
+
+      <ChoiceField
+        id="brief-content-source"
+        label="자료는 어디서 오나요?"
+        choices={CONTENT_SOURCE_CHOICES}
+        value={form.contentSource}
+        disabled={disabled}
+        onSelect={(v) => onChange("contentSource", v)}
+      />
+
+      <div className="grid grid-cols-2 gap-3">
+        <ChoiceField
+          id="brief-visual-mood"
+          label="분위기"
+          choices={VISUAL_MOOD_CHOICES}
+          value={form.visualMood}
+          disabled={disabled}
+          onSelect={(v) => onChange("visualMood", v)}
+        />
+        <ChoiceField
+          id="brief-density"
+          label="정보 밀도"
+          choices={DENSITY_CHOICES}
+          value={form.density}
+          disabled={disabled}
+          onSelect={(v) => onChange("density", v)}
+        />
+      </div>
+
+      <ChoiceField
+        id="brief-output-size"
+        label="출력 크기"
+        choices={OUTPUT_SIZE_CHOICES}
+        value={form.outputSize}
+        disabled={disabled}
+        onSelect={(v) => onChange("outputSize", v)}
+      />
+    </div>
+  );
+}
+
+function ChoiceField<T extends string>({
+  id,
+  label,
+  choices,
+  value,
+  disabled,
+  onSelect,
+}: {
+  id: string;
+  label: string;
+  choices: readonly BriefChoice<T>[];
+  value: T;
+  disabled: boolean;
+  onSelect: (value: T) => void;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <label htmlFor={id} className={PROJECT_LABEL_CLASS}>
+        {label}
+      </label>
+      <select
+        id={id}
+        value={value}
+        disabled={disabled}
+        onChange={(e) => {
+          const picked = choices.find((c) => c.value === e.target.value);
+          if (picked) onSelect(picked.value);
+        }}
+        className={PROJECT_CONTROL_CLASS}
+      >
+        {choices.map((c) => (
+          <option key={c.value} value={c.value}>
+            {c.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export function ToggleRow({
+  title,
+  hint,
+  checked,
+  disabled,
+  onChange,
+}: {
+  title: string;
+  hint: string;
+  checked: boolean;
+  disabled: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between rounded-md border border-border px-3 py-2">
+      <div>
+        <div className="text-sm">{title}</div>
+        <div className="text-xs text-foreground/80">{hint}</div>
+      </div>
+      <Switch
+        aria-label={title}
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={onChange}
+      />
+    </div>
+  );
+}

--- a/packages/frontend/src/components/layout/Sidebar.tsx
+++ b/packages/frontend/src/components/layout/Sidebar.tsx
@@ -1,19 +1,18 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import type { BackendId, SettingsSummary } from "@bg/shared";
+import type { ProjectType, SettingsSummary } from "@bg/shared";
 import { Palette } from "lucide-react";
 import { getSettings, listDesignSystems } from "@/api/home";
-import NewProjectPanel, {
-  type ProjectType,
-} from "@/components/home/NewProjectPanel";
+import NewProjectPanel from "@/components/home/NewProjectPanel";
 import { Badge } from "@/components/ui/badge";
+import { useUIStore } from "@/state/uiStore";
 
 const TYPES: Array<{ id: ProjectType; label: string }> = [
-  { id: "prototype", label: "Prototype" },
-  { id: "slide_deck", label: "Slide deck" },
-  { id: "from_template", label: "From template" },
-  { id: "other", label: "Other" },
+  { id: "prototype", label: "프로토타입" },
+  { id: "slide_deck", label: "슬라이드 덱" },
+  { id: "from_template", label: "템플릿" },
+  { id: "other", label: "기타" },
 ];
 
 const FALLBACK_SETTINGS: SettingsSummary = {
@@ -28,16 +27,17 @@ const FALLBACK_SETTINGS: SettingsSummary = {
 
 export default function Sidebar() {
   const navigate = useNavigate();
+  const setSettingsOpen = useUIStore((s) => s.setSettingsOpen);
   const [activeType, setActiveType] = useState<ProjectType>("slide_deck");
 
   const settingsQuery = useQuery({
     queryKey: ["settings"],
     queryFn: getSettings,
   });
-  // Match HomeView's systems tab so a freshly extracted design system
-  // (P4.1 creates rows in `draft`) can be picked for a brand-new project.
-  // Shares the react-query cache key with HomeView so both views dedupe
-  // into a single fetch while the user navigates between them.
+  // Shares HomeView's cache key so both views dedupe into a single
+  // fetch. The full list is passed down as-is; NewProjectPanel decides
+  // what is actually selectable (published only) so a half-finished
+  // draft system can never become a new project's brand.
   const systemsQuery = useQuery({
     queryKey: ["design-systems", "all"],
     queryFn: async () => {
@@ -73,7 +73,7 @@ export default function Sidebar() {
               >
                 Local
               </Badge>
-              <span className="text-[11px] text-muted-foreground">
+              <span className="text-[11px] text-foreground/70">
                 v{settings.app_version}
               </span>
             </div>
@@ -90,7 +90,7 @@ export default function Sidebar() {
               "px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
               activeType === t.id
                 ? "border-foreground text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground",
+                : "border-transparent text-foreground/70 hover:text-foreground",
             ].join(" ")}
           >
             {t.label}
@@ -102,31 +102,26 @@ export default function Sidebar() {
         <NewProjectPanel
           type={activeType}
           designSystems={systems}
-          defaultBackend={settings.default_backend as BackendId}
+          defaultBackend={settings.default_backend}
           onCreated={(project) => navigate(`/projects/${project.id}`)}
         />
       </div>
 
       <footer className="border-t border-border p-4">
-        <div className="text-xs text-muted-foreground">
-          Signed in as{" "}
+        <div className="text-xs text-foreground/70">
+          사용자{" "}
           <span className="text-foreground">
             {settings.user.display_name}
           </span>
         </div>
         <div className="mt-1 flex items-center gap-3">
-          <a
-            href="#"
-            className="text-xs text-muted-foreground hover:text-foreground"
+          <button
+            type="button"
+            onClick={() => setSettingsOpen(true)}
+            className="text-xs text-foreground/70 hover:text-foreground"
           >
-            Docs
-          </a>
-          <a
-            href="/settings"
-            className="text-xs text-muted-foreground hover:text-foreground"
-          >
-            Settings
-          </a>
+            설정
+          </button>
         </div>
       </footer>
     </aside>

--- a/packages/frontend/src/components/ui/dialog.tsx
+++ b/packages/frontend/src/components/ui/dialog.tsx
@@ -32,7 +32,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-border bg-background p-6 shadow-app-4 rounded-xl",
+        "fixed left-1/2 top-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-full max-w-lg [translate:-50%_-50%] gap-4 overflow-y-auto overscroll-contain rounded-xl border border-border bg-background p-6 shadow-app-4",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         className,
       )}

--- a/packages/frontend/src/lib/project-creation.ts
+++ b/packages/frontend/src/lib/project-creation.ts
@@ -111,9 +111,9 @@ export const PROBLEM_MESSAGE: Record<DraftProblem, string> = {
 
 /**
  * Design systems the user may pick for `type`. Template projects can
- * only start from a published template; every other project type can
- * only use a published non-template system, so a half-finished draft
- * never silently becomes a project's brand.
+ * start from any published system because real installs do not seed
+ * template-marked rows. Every other project type excludes templates,
+ * and no project can select a half-finished draft.
  */
 export function selectableDesignSystems(
   systems: readonly DesignSystemSummary[],
@@ -122,7 +122,7 @@ export function selectableDesignSystems(
   const wantTemplate = type === "from_template";
   return systems.filter(
     (system) =>
-      system.status === "published" && system.is_template === wantTemplate,
+      system.status === "published" && (wantTemplate || !system.is_template),
   );
 }
 

--- a/packages/frontend/src/lib/project-creation.ts
+++ b/packages/frontend/src/lib/project-creation.ts
@@ -1,0 +1,209 @@
+/**
+ * Pure project-creation helpers. No React, no network, no data source.
+ *
+ * The panel collects a small Korean brief; this module is the single
+ * place that decides which design systems may be chosen and how the
+ * form maps onto the canonical `CreateProjectRequest`.
+ */
+import type {
+  BackendId,
+  CreateProjectRequest,
+  DesignBriefContentSource,
+  DesignBriefDensity,
+  DesignBriefOutputSize,
+  DesignBriefV1,
+  DesignBriefVisualMood,
+  DesignSystemSummary,
+  ProjectType,
+} from "@bg/shared";
+
+export const BRIEF_LOCALE = "ko";
+export const AUDIENCE_MAX_LENGTH = 200;
+export const OBJECTIVE_MAX_LENGTH = 1000;
+
+export type BriefChoice<T> = { readonly value: T; readonly label: string };
+
+export const CONTENT_SOURCE_CHOICES: readonly BriefChoice<DesignBriefContentSource>[] =
+  [
+    { value: "none", label: "없음 · 새로 작성" },
+    { value: "attached", label: "첨부한 자료" },
+    { value: "template", label: "템플릿 내용" },
+    { value: "existing_files", label: "프로젝트에 있는 파일" },
+  ];
+
+export const VISUAL_MOOD_CHOICES: readonly BriefChoice<DesignBriefVisualMood>[] =
+  [
+    { value: "formal", label: "격식 있게" },
+    { value: "friendly", label: "친근하게" },
+    { value: "premium", label: "고급스럽게" },
+  ];
+
+export const DENSITY_CHOICES: readonly BriefChoice<DesignBriefDensity>[] = [
+  { value: "sparse", label: "여백 넉넉하게" },
+  { value: "balanced", label: "보통" },
+  { value: "dense", label: "정보 빽빽하게" },
+];
+
+export const OUTPUT_SIZE_CHOICES: readonly BriefChoice<DesignBriefOutputSize>[] =
+  [
+    { value: "responsive", label: "화면 크기에 맞춤" },
+    { value: "widescreen-16x9", label: "와이드 16:9" },
+    { value: "standard-4x3", label: "표준 4:3" },
+    { value: "a4", label: "A4 문서" },
+    { value: "letter", label: "레터 문서" },
+  ];
+
+export type ProjectDraft = {
+  readonly name: string;
+  readonly type: ProjectType;
+  readonly backendId: BackendId;
+  readonly designSystemId: string | null;
+  readonly audience: string;
+  readonly objective: string;
+  readonly contentSource: DesignBriefContentSource;
+  readonly visualMood: DesignBriefVisualMood;
+  readonly density: DesignBriefDensity;
+  readonly outputSize: DesignBriefOutputSize;
+  readonly useSpeakerNotes: boolean;
+  readonly copyAsIs: boolean;
+};
+
+export type BriefForm = Omit<
+  ProjectDraft,
+  "type" | "backendId" | "designSystemId"
+>;
+
+export const INITIAL_BRIEF_FORM: BriefForm = {
+  name: "",
+  audience: "",
+  objective: "",
+  contentSource: "none",
+  visualMood: "formal",
+  density: "balanced",
+  outputSize: "responsive",
+  useSpeakerNotes: false,
+  copyAsIs: false,
+};
+
+export const PROJECT_LABEL_CLASS = "text-xs font-medium text-foreground/80";
+export const PROJECT_CONTROL_CLASS =
+  "flex h-9 w-full rounded-md border border-input bg-background px-3 text-sm text-foreground opacity-100 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:opacity-50";
+
+export type DraftProblem =
+  | "name_required"
+  | "audience_invalid"
+  | "objective_invalid"
+  | "design_system_required"
+  | "design_system_not_selectable";
+
+export type BuildResult =
+  | { readonly ok: true; readonly request: CreateProjectRequest }
+  | { readonly ok: false; readonly problem: DraftProblem };
+
+export const PROBLEM_MESSAGE: Record<DraftProblem, string> = {
+  name_required: "프로젝트 이름을 입력해 주세요.",
+  audience_invalid: `누가 보게 되는지 ${AUDIENCE_MAX_LENGTH}자 이내로 적어 주세요.`,
+  objective_invalid: `무엇을 얻고 싶은지 ${OBJECTIVE_MAX_LENGTH}자 이내로 적어 주세요.`,
+  design_system_required: "사용할 템플릿을 선택해 주세요.",
+  design_system_not_selectable:
+    "선택한 디자인 시스템은 지금 사용할 수 없어요. 목록에서 다시 골라 주세요.",
+};
+
+/**
+ * Design systems the user may pick for `type`. Template projects can
+ * only start from a published template; every other project type can
+ * only use a published non-template system, so a half-finished draft
+ * never silently becomes a project's brand.
+ */
+export function selectableDesignSystems(
+  systems: readonly DesignSystemSummary[],
+  type: ProjectType,
+): DesignSystemSummary[] {
+  const wantTemplate = type === "from_template";
+  return systems.filter(
+    (system) =>
+      system.status === "published" && system.is_template === wantTemplate,
+  );
+}
+
+/**
+ * Keeps an explicit selection alive across list changes. Never picks a
+ * system on the user's behalf: an unknown or no-longer-selectable id
+ * collapses to "nothing selected".
+ */
+export function keepSelectedDesignSystemId(
+  selectedId: string | null,
+  selectable: readonly DesignSystemSummary[],
+): string | null {
+  if (selectedId === null) return null;
+  return selectable.some((system) => system.id === selectedId)
+    ? selectedId
+    : null;
+}
+
+export function buildCreateProjectRequest(
+  draft: ProjectDraft,
+  systems: readonly DesignSystemSummary[],
+): BuildResult {
+  const name = draft.name.trim();
+  if (name.length === 0) return { ok: false, problem: "name_required" };
+
+  const audience = draft.audience.trim();
+  if (audience.length === 0 || audience.length > AUDIENCE_MAX_LENGTH) {
+    return { ok: false, problem: "audience_invalid" };
+  }
+
+  const objective = draft.objective.trim();
+  if (objective.length === 0 || objective.length > OBJECTIVE_MAX_LENGTH) {
+    return { ok: false, problem: "objective_invalid" };
+  }
+
+  const selectable = selectableDesignSystems(systems, draft.type);
+  const designSystemId = keepSelectedDesignSystemId(
+    draft.designSystemId,
+    selectable,
+  );
+  if (designSystemId === null && draft.designSystemId !== null) {
+    return { ok: false, problem: "design_system_not_selectable" };
+  }
+  if (designSystemId === null && draft.type === "from_template") {
+    return { ok: false, problem: "design_system_required" };
+  }
+
+  const brief: DesignBriefV1 = {
+    schema_version: 1,
+    output_type: draft.type,
+    audience,
+    objective,
+    content_source: draft.contentSource,
+    locale: BRIEF_LOCALE,
+    brand_mode:
+      draft.type === "from_template"
+        ? "template"
+        : designSystemId === null
+          ? "none"
+          : "selected_design_system",
+    visual_mood: draft.visualMood,
+    density: draft.density,
+    output_size: draft.outputSize,
+  };
+
+  return {
+    ok: true,
+    request: {
+      name,
+      type: draft.type,
+      design_system_id: designSystemId,
+      backend_id: draft.backendId,
+      options: {
+        ...(draft.type === "slide_deck"
+          ? { use_speaker_notes: draft.useSpeakerNotes }
+          : {}),
+        ...(draft.type === "from_template"
+          ? { copy_as_is: draft.copyAsIs }
+          : {}),
+        design_brief: brief,
+      },
+    },
+  };
+}

--- a/packages/frontend/tests/project-creation.test.ts
+++ b/packages/frontend/tests/project-creation.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseDesignBriefV1,
+  type CreateProjectRequest,
+  type DesignSystemSummary,
+  type ProjectType,
+} from "@bg/shared";
+import {
+  BRIEF_LOCALE,
+  buildCreateProjectRequest,
+  keepSelectedDesignSystemId,
+  selectableDesignSystems,
+  type BuildResult,
+  type ProjectDraft,
+} from "../src/lib/project-creation";
+
+function system(
+  id: string,
+  status: DesignSystemSummary["status"],
+  isTemplate: boolean,
+): DesignSystemSummary {
+  return {
+    id,
+    name: id,
+    status,
+    is_template: isTemplate,
+    thumbnail_path: null,
+    updated_at: 1,
+  };
+}
+
+const SYSTEMS: readonly DesignSystemSummary[] = [
+  system("draft-system", "draft", false),
+  system("review-system", "review", false),
+  system("published-system", "published", false),
+  system("draft-template", "draft", true),
+  system("published-template", "published", true),
+];
+
+function draft(overrides: Partial<ProjectDraft> = {}): ProjectDraft {
+  return {
+    name: "분기 리뷰 덱",
+    type: "slide_deck",
+    backendId: "claude-code",
+    designSystemId: null,
+    audience: "국내 투자 심사역",
+    objective: "다음 분기 투자 유치 승인을 받는다",
+    contentSource: "none",
+    visualMood: "formal",
+    density: "balanced",
+    outputSize: "widescreen-16x9",
+    useSpeakerNotes: false,
+    copyAsIs: false,
+    ...overrides,
+  };
+}
+
+function expectRequest(result: BuildResult): CreateProjectRequest {
+  if (!result.ok) {
+    throw new Error(`expected a request, got problem: ${result.problem}`);
+  }
+  return result.request;
+}
+
+describe("selectableDesignSystems", () => {
+  test("offers only published non-template systems to normal projects", () => {
+    const normalTypes: ProjectType[] = ["prototype", "slide_deck", "other"];
+    for (const type of normalTypes) {
+      expect(selectableDesignSystems(SYSTEMS, type).map((s) => s.id)).toEqual([
+        "published-system",
+      ]);
+    }
+  });
+
+  test("offers only published templates to template projects", () => {
+    expect(
+      selectableDesignSystems(SYSTEMS, "from_template").map((s) => s.id),
+    ).toEqual(["published-template"]);
+  });
+});
+
+describe("keepSelectedDesignSystemId", () => {
+  const selectable = [system("published-system", "published", false)];
+
+  test("never selects a system on the user's behalf", () => {
+    expect(keepSelectedDesignSystemId(null, selectable)).toBeNull();
+    expect(keepSelectedDesignSystemId(null, [])).toBeNull();
+  });
+
+  test("drops a selection that is no longer selectable without falling back", () => {
+    expect(keepSelectedDesignSystemId("draft-system", selectable)).toBeNull();
+  });
+
+  test("preserves an explicit selectable choice", () => {
+    expect(keepSelectedDesignSystemId("published-system", selectable)).toBe(
+      "published-system",
+    );
+  });
+});
+
+describe("buildCreateProjectRequest", () => {
+  test("allows a normal project with no design system", () => {
+    const request = expectRequest(
+      buildCreateProjectRequest(draft({ type: "prototype" }), SYSTEMS),
+    );
+    expect(request.design_system_id).toBeNull();
+    expect(parseDesignBriefV1(request.options?.design_brief).brand_mode).toBe(
+      "none",
+    );
+  });
+
+  test("rejects a normal project pointed at an unpublished system", () => {
+    expect(
+      buildCreateProjectRequest(
+        draft({ type: "prototype", designSystemId: "draft-system" }),
+        SYSTEMS,
+      ),
+    ).toEqual({ ok: false, problem: "design_system_not_selectable" });
+  });
+
+  test("requires an explicit published template for template projects", () => {
+    expect(
+      buildCreateProjectRequest(draft({ type: "from_template" }), SYSTEMS),
+    ).toEqual({ ok: false, problem: "design_system_required" });
+    expect(
+      buildCreateProjectRequest(
+        draft({ type: "from_template", designSystemId: "draft-template" }),
+        SYSTEMS,
+      ),
+    ).toEqual({ ok: false, problem: "design_system_not_selectable" });
+    expect(
+      buildCreateProjectRequest(
+        draft({ type: "from_template", designSystemId: "published-system" }),
+        SYSTEMS,
+      ),
+    ).toEqual({ ok: false, problem: "design_system_not_selectable" });
+  });
+
+  test("carries copy_as_is only for template projects", () => {
+    const template = expectRequest(
+      buildCreateProjectRequest(
+        draft({
+          type: "from_template",
+          designSystemId: "published-template",
+          copyAsIs: true,
+        }),
+        SYSTEMS,
+      ),
+    );
+    expect(template.design_system_id).toBe("published-template");
+    expect(template.options?.copy_as_is).toBe(true);
+    expect(parseDesignBriefV1(template.options?.design_brief).brand_mode).toBe(
+      "template",
+    );
+
+    const deck = expectRequest(buildCreateProjectRequest(draft(), SYSTEMS));
+    expect(deck.options?.copy_as_is).toBeUndefined();
+  });
+
+  test("emits a canonical design brief with exact type/locale/brand mapping", () => {
+    const request = expectRequest(
+      buildCreateProjectRequest(
+        draft({
+          name: "  분기 리뷰 덱  ",
+          designSystemId: "published-system",
+          audience: "  국내 투자 심사역  ",
+          objective: "  투자 유치 승인  ",
+          contentSource: "attached",
+          visualMood: "premium",
+          density: "sparse",
+          outputSize: "a4",
+          useSpeakerNotes: true,
+        }),
+        SYSTEMS,
+      ),
+    );
+
+    expect(request.name).toBe("분기 리뷰 덱");
+    expect(request.backend_id).toBe("claude-code");
+    expect(request.options?.use_speaker_notes).toBe(true);
+    expect(parseDesignBriefV1(request.options?.design_brief)).toEqual({
+      schema_version: 1,
+      output_type: "slide_deck",
+      audience: "국내 투자 심사역",
+      objective: "투자 유치 승인",
+      content_source: "attached",
+      locale: BRIEF_LOCALE,
+      brand_mode: "selected_design_system",
+      visual_mood: "premium",
+      density: "sparse",
+      output_size: "a4",
+    });
+  });
+
+  test("requires a name and bounded brief text", () => {
+    expect(buildCreateProjectRequest(draft({ name: "   " }), SYSTEMS)).toEqual({
+      ok: false,
+      problem: "name_required",
+    });
+    expect(buildCreateProjectRequest(draft({ audience: "" }), SYSTEMS)).toEqual({
+      ok: false,
+      problem: "audience_invalid",
+    });
+    expect(
+      buildCreateProjectRequest(draft({ objective: " " }), SYSTEMS),
+    ).toEqual({ ok: false, problem: "objective_invalid" });
+    expect(
+      buildCreateProjectRequest(draft({ audience: "가".repeat(201) }), SYSTEMS),
+    ).toEqual({ ok: false, problem: "audience_invalid" });
+    expect(
+      buildCreateProjectRequest(
+        draft({ objective: "가".repeat(1001) }),
+        SYSTEMS,
+      ),
+    ).toEqual({ ok: false, problem: "objective_invalid" });
+  });
+});

--- a/packages/frontend/tests/project-creation.test.ts
+++ b/packages/frontend/tests/project-creation.test.ts
@@ -72,10 +72,33 @@ describe("selectableDesignSystems", () => {
     }
   });
 
-  test("offers only published templates to template projects", () => {
+  test("offers every published system to template projects", () => {
     expect(
       selectableDesignSystems(SYSTEMS, "from_template").map((s) => s.id),
-    ).toEqual(["published-template"]);
+    ).toEqual(["published-system", "published-template"]);
+  });
+
+  test("keeps template creation usable when real published systems have no template flag", () => {
+    const realInstallSystems = [
+      system("draft-system", "draft", false),
+      system("published-system", "published", false),
+    ];
+
+    expect(
+      selectableDesignSystems(realInstallSystems, "from_template").map(
+        (entry) => entry.id,
+      ),
+    ).toEqual(["published-system"]);
+    expect(
+      buildCreateProjectRequest(
+        draft({
+          type: "from_template",
+          designSystemId: "published-system",
+          copyAsIs: true,
+        }),
+        realInstallSystems,
+      ).ok,
+    ).toBe(true);
   });
 });
 
@@ -118,7 +141,7 @@ describe("buildCreateProjectRequest", () => {
     ).toEqual({ ok: false, problem: "design_system_not_selectable" });
   });
 
-  test("requires an explicit published template for template projects", () => {
+  test("requires an explicit published system for template projects", () => {
     expect(
       buildCreateProjectRequest(draft({ type: "from_template" }), SYSTEMS),
     ).toEqual({ ok: false, problem: "design_system_required" });
@@ -133,7 +156,10 @@ describe("buildCreateProjectRequest", () => {
         draft({ type: "from_template", designSystemId: "published-system" }),
         SYSTEMS,
       ),
-    ).toEqual({ ok: false, problem: "design_system_not_selectable" });
+    ).toMatchObject({
+      ok: true,
+      request: { design_system_id: "published-system" },
+    });
   });
 
   test("carries copy_as_is only for template projects", () => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,6 +15,7 @@
     "./design-brief": "./src/design-brief.ts",
     "./home": "./src/home.ts",
     "./project": "./src/project.ts",
+    "./reference-layout": "./src/reference-layout.ts",
     "./contract-parser": "./src/contract-parser.ts",
     "./export": "./src/export.ts",
     "./extraction-domain": "./src/extraction-domain.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,6 +12,7 @@
     "./artifact": "./src/artifact.ts",
     "./harness": "./src/harness.ts",
     "./design-system": "./src/design-system.ts",
+    "./design-brief": "./src/design-brief.ts",
     "./home": "./src/home.ts",
     "./project": "./src/project.ts",
     "./contract-parser": "./src/contract-parser.ts",

--- a/packages/shared/src/design-brief.ts
+++ b/packages/shared/src/design-brief.ts
@@ -1,0 +1,175 @@
+import {
+  UpgradeContractError,
+  decodeContract,
+  requiredNumber,
+  requiredString,
+} from "./contract-parser";
+
+export const DESIGN_BRIEF_OUTPUT_TYPES = [
+  "prototype",
+  "slide_deck",
+  "from_template",
+  "other",
+] as const;
+export const DESIGN_BRIEF_CONTENT_SOURCES = [
+  "none",
+  "attached",
+  "template",
+  "existing_files",
+] as const;
+export const DESIGN_BRIEF_BRAND_MODES = [
+  "none",
+  "selected_design_system",
+  "template",
+] as const;
+export const DESIGN_BRIEF_VISUAL_MOODS = [
+  "formal",
+  "friendly",
+  "premium",
+] as const;
+export const DESIGN_BRIEF_DENSITIES = [
+  "sparse",
+  "balanced",
+  "dense",
+] as const;
+export const DESIGN_BRIEF_OUTPUT_SIZES = [
+  "responsive",
+  "widescreen-16x9",
+  "standard-4x3",
+  "a4",
+  "letter",
+  "custom",
+] as const;
+
+export type DesignBriefOutputType =
+  (typeof DESIGN_BRIEF_OUTPUT_TYPES)[number];
+export type DesignBriefContentSource =
+  (typeof DESIGN_BRIEF_CONTENT_SOURCES)[number];
+export type DesignBriefBrandMode =
+  (typeof DESIGN_BRIEF_BRAND_MODES)[number];
+export type DesignBriefVisualMood =
+  (typeof DESIGN_BRIEF_VISUAL_MOODS)[number];
+export type DesignBriefDensity = (typeof DESIGN_BRIEF_DENSITIES)[number];
+export type DesignBriefOutputSize =
+  (typeof DESIGN_BRIEF_OUTPUT_SIZES)[number];
+
+export type DesignBriefV1 = {
+  readonly schema_version: 1;
+  readonly output_type: DesignBriefOutputType;
+  readonly audience: string;
+  readonly objective: string;
+  readonly content_source: DesignBriefContentSource;
+  readonly locale: string;
+  readonly brand_mode: DesignBriefBrandMode;
+  readonly visual_mood: DesignBriefVisualMood;
+  readonly density: DesignBriefDensity;
+  readonly output_size: DesignBriefOutputSize;
+};
+
+export function parseDesignBriefV1(input: unknown): DesignBriefV1 {
+  const record = decodeContract(input);
+  if (requiredNumber(record, "schema_version") !== 1) {
+    invalid("schema_version");
+  }
+  const locale = boundedString(record, "locale", 32);
+  if (!/^[a-z]{2}(?:-[A-Z]{2})?$/.test(locale)) {
+    invalid("locale");
+  }
+  return {
+    schema_version: 1,
+    output_type: outputType(requiredString(record, "output_type")),
+    audience: boundedString(record, "audience", 200),
+    objective: boundedString(record, "objective", 1000),
+    content_source: contentSource(requiredString(record, "content_source")),
+    locale,
+    brand_mode: brandMode(requiredString(record, "brand_mode")),
+    visual_mood: visualMood(requiredString(record, "visual_mood")),
+    density: density(requiredString(record, "density")),
+    output_size: outputSize(requiredString(record, "output_size")),
+  };
+}
+
+function boundedString(
+  record: Readonly<Record<string, unknown>>,
+  key: string,
+  maxLength: number,
+): string {
+  const value = requiredString(record, key).trim();
+  if (value.length === 0 || value.length > maxLength) invalid(key);
+  return value;
+}
+
+function outputType(value: string): DesignBriefOutputType {
+  switch (value) {
+    case "prototype":
+    case "slide_deck":
+    case "from_template":
+    case "other":
+      return value;
+    default:
+      return invalid("output_type");
+  }
+}
+
+function contentSource(value: string): DesignBriefContentSource {
+  switch (value) {
+    case "none":
+    case "attached":
+    case "template":
+    case "existing_files":
+      return value;
+    default:
+      return invalid("content_source");
+  }
+}
+
+function brandMode(value: string): DesignBriefBrandMode {
+  switch (value) {
+    case "none":
+    case "selected_design_system":
+    case "template":
+      return value;
+    default:
+      return invalid("brand_mode");
+  }
+}
+
+function visualMood(value: string): DesignBriefVisualMood {
+  switch (value) {
+    case "formal":
+    case "friendly":
+    case "premium":
+      return value;
+    default:
+      return invalid("visual_mood");
+  }
+}
+
+function density(value: string): DesignBriefDensity {
+  switch (value) {
+    case "sparse":
+    case "balanced":
+    case "dense":
+      return value;
+    default:
+      return invalid("density");
+  }
+}
+
+function outputSize(value: string): DesignBriefOutputSize {
+  switch (value) {
+    case "responsive":
+    case "widescreen-16x9":
+    case "standard-4x3":
+    case "a4":
+    case "letter":
+    case "custom":
+      return value;
+    default:
+      return invalid("output_size");
+  }
+}
+
+function invalid(path: string): never {
+  throw new UpgradeContractError("invalid_field", path);
+}

--- a/packages/shared/src/home.ts
+++ b/packages/shared/src/home.ts
@@ -4,6 +4,7 @@ import type {
   ProjectType,
   ThemeMode,
 } from "./app";
+import type { DesignBriefV1 } from "./design-brief";
 
 export interface ProjectSummary {
   id: string;
@@ -33,6 +34,7 @@ export interface CreateProjectRequest {
   options?: {
     use_speaker_notes?: boolean;
     copy_as_is?: boolean;
+    design_brief?: DesignBriefV1;
   };
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,6 +6,7 @@ export * from "./catalog-contract";
 export * from "./comment";
 export * from "./contract-parser";
 export * from "./design-system";
+export * from "./design-brief";
 export * from "./events";
 export * from "./export";
 export * from "./export-attempt";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -17,5 +17,6 @@ export * from "./harness";
 export * from "./home";
 export * from "./learning-contract";
 export * from "./project";
+export * from "./reference-layout";
 export * from "./research-contract";
 export * from "./settings";

--- a/packages/shared/src/reference-layout.ts
+++ b/packages/shared/src/reference-layout.ts
@@ -1,0 +1,102 @@
+export type ReferenceLayoutUnit = "mm" | "cm" | "in" | "px";
+export type ReferenceLayoutOrientation =
+  | "portrait"
+  | "landscape"
+  | "unknown";
+export type ReferenceLayoutPreset =
+  | "a3"
+  | "a4"
+  | "letter"
+  | "widescreen-16x9"
+  | "standard-4x3"
+  | "custom";
+
+export type ReferenceLayoutMeasurement =
+  | {
+      readonly status: "known";
+      readonly value: number;
+      readonly unit: ReferenceLayoutUnit;
+    }
+  | {
+      readonly status: "unknown";
+      readonly value: null;
+      readonly unit: null;
+    };
+
+export type ReferenceLayoutScale =
+  | { readonly status: "known"; readonly value: string }
+  | { readonly status: "unknown"; readonly value: null };
+
+export type ReferenceLayoutContextV1 = {
+  readonly schema_version: 1;
+  readonly layout_spec_path: "layout-spec.json";
+  readonly intent: {
+    readonly detected: true;
+    readonly source:
+      | "request"
+      | "attachment"
+      | "request_and_attachment";
+    readonly language: "ko" | "en" | "unknown";
+  };
+  readonly reference: {
+    readonly attachment_path: string;
+    readonly original_name: string;
+    readonly mime_type: string;
+    readonly role: "immutable_underlay";
+    readonly evidence_boundary:
+      | "hard_geometry"
+      | "visual_inspiration"
+      | "mixed";
+    readonly editable: false;
+  } | null;
+  readonly canvas: {
+    readonly preset: ReferenceLayoutPreset | null;
+    readonly width: number | null;
+    readonly height: number | null;
+    readonly unit: ReferenceLayoutUnit | null;
+    readonly orientation: ReferenceLayoutOrientation;
+    readonly aspect_ratio: {
+      readonly width: number;
+      readonly height: number;
+      readonly source: "explicit" | "dimensions" | "preset";
+    } | null;
+    readonly dpi: number | null;
+    readonly scale: ReferenceLayoutScale;
+    readonly bleed: ReferenceLayoutMeasurement;
+    readonly safe_margin: ReferenceLayoutMeasurement;
+    readonly raster_target_px:
+      | {
+          readonly status: "known";
+          readonly width: number;
+          readonly height: number;
+        }
+      | {
+          readonly status: "unknown";
+          readonly width: null;
+          readonly height: null;
+        };
+  };
+  readonly geometry_contract: {
+    readonly origin: "top_left";
+    readonly x_axis: "right";
+    readonly y_axis: "down";
+    readonly anchor_space: "normalized_0_1";
+    readonly stable_anchors_required: true;
+    readonly preserve_aspect_ratio: true;
+  };
+  readonly export_constraints: {
+    readonly pdf: ReferenceLayoutExportCapability;
+    readonly pptx: ReferenceLayoutExportCapability;
+    readonly png: ReferenceLayoutExportCapability;
+  };
+};
+
+export type ReferenceLayoutExportCapability = {
+  readonly supported: boolean;
+  readonly limitation:
+    | "preset_only"
+    | "aspect_presets_only"
+    | "explicit_pixel_dimensions";
+  readonly coerce_to_a4: false;
+  readonly on_unsupported: "report_and_preserve_spec";
+};


### PR DESCRIPTION
## Summary

- add versioned shared design-brief and reference-layout contracts, then route Korean and English project intent through the backend prompt catalog without an investor-pitch fallback
- normalize selected drawings and explicit layout requests into deterministic prompt context with hard units, explicit unknowns, immutable-underlay guidance, stable anchors, and exporter limits; ordinary logos and prose no longer trigger the contract
- make Korean project creation use published design systems without implicit draft selection, keep the template path usable on default installs, and connect the real Settings, attachment, and Comments affordances
- document four-source provenance, the ten prompt purposes versus six persisted-research purposes, project options, UI behavior, and the advisory layout boundary in README and ADRs
- preserve the local-first request-authority, attachment-path, checkpoint, extraction, and export-validation boundaries; no runtime network dependency was added

## Verification

- `git diff --check` — pass
- changed-area Bun suite — 62 pass, 0 fail, 167 assertions across 7 files; the process exits 1 because focused coverage is evaluated against the repository-wide 0.8 threshold
- applicable suite excluding the inherited branch-bound `qa-harness.test.ts` — 683 pass, 0 fail, 5,550 assertions across 76 files; the process exits 1 under the configured per-file coverage semantics
- `bun run typecheck` — pass (`tsc --build`)
- `bun run build` — pass; 1,785 frontend modules and the Windows Bun binary built successfully
- `bash scripts/qa/task-8-gates.sh` — pass
- React Doctor changed-file scan — exit 0, no issues found
- real Chrome QA at 375, 768, and 1280 px — template selection, project creation, canonical Korean brief persistence, and responsive form evidence pass; independent functional and CJK visual reviews both PASS
- five-lane publication review — goal, QA, code, and security PASS; the context blocker was repaired, then focused context and code re-reviews both PASS

## Known limitations

- the latest complete `bun test` run reported 690 pass / 3 fail: two deterministic `qa-harness.test.ts` failures depend on ignored evidence state and a hard-coded `feat/burnguard-mass-ulw-research-20260825` branch; one timeout in untouched code shifts between loaded runs and passes in isolation
- isolated `qa-harness.test.ts` is 8 pass / 2 fail; `scripts/qa/repository.ts` is inherited unchanged and intentionally left outside this product branch rather than falsifying the expected branch
- reference immutability is an agent contract, not a filesystem write lock, and unsupported or unknown export dimensions are reported without coercion
- the existing 375 px fixed sidebar, 768 px Home tab/search clipping, frontend chunk-size advisory, and unavailable LSP daemon remain pre-existing; strict workspace typecheck and real-browser QA are the verification fallback
