### PR TITLE
feat: complete BurnGuard remaining product roadmap

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -73,6 +73,13 @@ for icons, borders, and large or bold labels.
   slide index. Resolved comments leave the active queue.
 - **ChatPane**: intent entry and streaming state. Chat must not obscure the
   artifact or imply a completed update before the backend event arrives.
+- **GraphicCanvas**: one finite, server-owned artboard with persisted CSS-pixel
+  width and height. Graphic projects never use slide structure or deck runtime;
+  their truthful delivery action is a DPR-1 PNG at the exact persisted size.
+  Creation offers editable bounded dimensions and named presets without hiding
+  the 16-million-pixel ceiling. In the canvas sandbox only, the exact artboard
+  scales down without upscaling and centres on a neutral letterbox; this preview
+  transform never changes the served artifact or export geometry.
 - **QualityPanel**: one fixed status/action header above a bounded, vertically
   scrolling findings body. Findings remain ordered as must-fix, recommended,
   unknown, then a collapsed explicit-pass count. Technical evidence is bounded

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -28,9 +28,18 @@ the chrome around it.
 - `danger`: `#d92d20`
 - `canvas-ink`: `#111111`
 
+The semantic CSS bindings `--success`, `--success-foreground`, `--warning`,
+and `--warning-foreground` expose the existing success and warning palette
+through Tailwind's `rgb(var(--token) / <alpha-value>)` convention.
+
 Use semantic Tailwind tokens instead of new one-off colors. Accent is reserved
 for the next meaningful action, selection focus, and keyboard focus rings.
 Danger is reserved for destructive or unrecoverable states.
+
+Alert copy on a `destructive/10` tint uses `text-foreground` with a
+`destructive/30` border: the tint and border carry the semantic while the copy
+itself stays above the 4.5:1 contrast floor. Danger-colored text is reserved
+for icons, borders, and large or bold labels.
 
 ### Type
 
@@ -64,6 +73,14 @@ Danger is reserved for destructive or unrecoverable states.
   slide index. Resolved comments leave the active queue.
 - **ChatPane**: intent entry and streaming state. Chat must not obscure the
   artifact or imply a completed update before the backend event arrives.
+- **QualityPanel**: one fixed status/action header above a bounded, vertically
+  scrolling findings body. Findings remain ordered as must-fix, recommended,
+  unknown, then a collapsed explicit-pass count. Technical evidence is bounded
+  and monospaced; skipped and unmeasurable checks are never presented as pass.
+  Audit reruns and safe fixes are mutually exclusive; reduced motion keeps the
+  textual progress signal while suppressing spinner motion.
+- **QualityLayer**: a reveal-only accent outline requested once through the
+  frame bridge for the active file and node. It never owns hit testing or polls.
 
 ## State and interaction rules
 
@@ -87,10 +104,26 @@ remove non-essential transitions and preserve the same visible state changes.
 
 ## Responsive behavior
 
+- The project route is capped to the viewport (`h-dvh`, `overflow-hidden`).
+  The document never scrolls: the project top bar and every panel header stay
+  in place, and each pane owns exactly one scrollport. Document-shaped routes
+  (home, settings, systems) keep normal page scrolling.
 - Desktop: chat, canvas, and the contextual inspector share the viewport
   without nested horizontal scrolling.
 - Narrow viewport: the inspector becomes a full-width contextual section below
-  the canvas; controls remain at least 44px high where touch is plausible.
+  the canvas; controls remain at least 44px high where touch is plausible. At
+  widths up to 900px, every canvas mode action is at least 44px high.
+- At widths up to 900px chat, canvas, and the inspector share the capped
+  height instead of scrolling the page: chat and the inspector shrink, the
+  canvas keeps a 192px floor, and each pane scrolls inside itself.
+- The artifact tab strip centres the active tab group — label and close button
+  together — inside its scrollport whenever the strip overflows, with an edge
+  fade and proximity snapping as the overflow affordance.
+- Korean Quality copy uses keep-all wrapping. The panel and toolbar must not
+  introduce horizontal overflow; the findings body owns bounded panel scroll.
+  Auxiliary units (`-고 있다`, `-지 않다`, `-ㄹ 수 없다`) are bound with U+00A0
+  so an ending never orphans onto its own line, and status/banner paragraphs
+  add `text-pretty`.
 - Long selectors and file paths truncate visually but remain available in a
   `title` or accessible description.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -19,13 +19,13 @@ the chrome around it.
 - `background`: `#ffffff`
 - `foreground`: `#17191a`
 - `muted`: `#f1f3f5`
-- `muted-foreground`: `#757b80`
+- `muted-foreground`: `#5e646c`
 - `border`: `#dce4ea`
 - `accent`: `#004fff`
 - `accent-soft`: `#ecf4ff`
 - `success`: `#00ce78`
 - `warning`: `#fca63d`
-- `danger`: `#ff524c`
+- `danger`: `#d92d20`
 - `canvas-ink`: `#111111`
 
 Use semantic Tailwind tokens instead of new one-off colors. Accent is reserved

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -73,6 +73,10 @@ for icons, borders, and large or bold labels.
   slide index. Resolved comments leave the active queue.
 - **ChatPane**: intent entry and streaming state. Chat must not obscure the
   artifact or imply a completed update before the backend event arrives.
+  Each queued PDF/PPTX owns a stable item identity and an explicit ordinary
+  content or immutable visual-reference role. Existing managed visual files
+  are disclosed as editable-only; unsupported network sources are named
+  without presenting a false selection action.
 - **GraphicCanvas**: one finite, server-owned artboard with persisted CSS-pixel
   width and height. Graphic projects never use slide structure or deck runtime;
   their truthful delivery action is a DPR-1 PNG at the exact persisted size.

--- a/packages/backend/src/adapters/claude-code/runner.ts
+++ b/packages/backend/src/adapters/claude-code/runner.ts
@@ -1,3 +1,5 @@
+import { closeOwnedProcessTree, ownedProcessSpawnOptions } from "../owned-process-tree";
+
 /**
  * Runs `claude -p --output-format stream-json --verbose` against a project dir,
  * piping the built prompt to stdin and parsing newline-delimited JSON on stdout.
@@ -51,9 +53,10 @@ export async function runClaudeCode(options: RunnerOptions): Promise<RunnerResul
     env: { ...process.env },
     signal: options.signal,
     killSignal: "SIGKILL",
+    ...ownedProcessSpawnOptions(),
   });
 
-  await Promise.all([
+  const readers = Promise.all([
     readLines(proc.stdout, options.onStdoutLine),
     options.onStderrLine
       ? readLines(proc.stderr, options.onStderrLine)
@@ -61,6 +64,8 @@ export async function runClaudeCode(options: RunnerOptions): Promise<RunnerResul
   ]);
 
   const exitCode = await proc.exited;
+  await closeOwnedProcessTree(proc.pid);
+  await readers;
   // eslint-disable-next-line no-console
   console.log(`[claude-code] exit=${exitCode}`);
   return { exitCode };

--- a/packages/backend/src/adapters/codex/index.ts
+++ b/packages/backend/src/adapters/codex/index.ts
@@ -1,6 +1,7 @@
 import { ulid } from "ulid";
 import type { AdapterRunInput, AdapterRunResult } from "../types";
 import { parseCodexLine, type CodexParserContext } from "./parser";
+import { closeOwnedProcessTree, ownedProcessSpawnOptions } from "../owned-process-tree";
 
 export function buildCodexCommand(binaryPath: string): string[] {
   return [
@@ -54,11 +55,12 @@ export async function runCodexTurn(
     stderr: "pipe",
     signal: input.signal,
     killSignal: "SIGKILL",
+    ...ownedProcessSpawnOptions(),
   });
 
   let exitCode: number;
   try {
-    await Promise.all([
+    const readers = Promise.all([
       readLines(proc.stdout, async (line) => {
         // Parser exceptions used to bubble up through readLines and
         // abort the read loop entirely, leaving the CLI subprocess
@@ -86,6 +88,8 @@ export async function runCodexTurn(
       }),
     ]);
     exitCode = await proc.exited;
+    await closeOwnedProcessTree(proc.pid);
+    await readers;
   } finally {
     // Always release the decision sink — see the matching comment in
     // the Claude Code adapter. A throw between subscribe and here

--- a/packages/backend/src/adapters/owned-process-tree.ts
+++ b/packages/backend/src/adapters/owned-process-tree.ts
@@ -1,0 +1,31 @@
+export function ownedProcessSpawnOptions(): { readonly detached: boolean } {
+  return { detached: process.platform !== "win32" };
+}
+
+export async function closeOwnedProcessTree(processId: number): Promise<void> {
+  if (process.platform === "win32") {
+    const result = Bun.spawnSync(["taskkill", "/PID", String(processId), "/T", "/F"], { stdout: "ignore", stderr: "ignore" });
+    if (result.exitCode !== 0 && isProcessPresent(processId)) throw new Error("adapter_process_tree_cleanup_failed");
+    return;
+  }
+  try {
+    process.kill(-processId, "SIGKILL");
+  } catch (error) {
+    if (!(error instanceof Error && "code" in error && error.code === "ESRCH")) throw error;
+  }
+  for (let attempt = 0; attempt < 1024; attempt += 1) {
+    if (!isProcessGroupPresent(processId)) return;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  throw new Error("adapter_process_tree_cleanup_failed");
+}
+
+function isProcessPresent(processId: number): boolean {
+  try { process.kill(processId, 0); return true; }
+  catch (error) { return !(error instanceof Error && "code" in error && error.code === "ESRCH"); }
+}
+
+function isProcessGroupPresent(processId: number): boolean {
+  try { process.kill(-processId, 0); return true; }
+  catch (error) { return !(error instanceof Error && "code" in error && error.code === "ESRCH"); }
+}

--- a/packages/backend/src/db/attachment-context.ts
+++ b/packages/backend/src/db/attachment-context.ts
@@ -1,4 +1,5 @@
 import { ulid } from "ulid";
+import type { VisualSourceRole } from "@bg/shared";
 import { getSqlite } from "./sqlite-client";
 
 export type AttachmentContext = {
@@ -10,11 +11,13 @@ export type AttachmentContext = {
 export type AttachmentRecordInput = {
   readonly sessionId: string; readonly filePath: string; readonly mimeType: string;
   readonly originalName: string; readonly sizeBytes: number; readonly sha256: string;
+  readonly sourceRole?: VisualSourceRole;
+  readonly sourceRoleExplicit?: boolean;
 };
 
 export function insertAttachmentRecord(input: AttachmentRecordInput): void {
-  getSqlite().prepare(`INSERT INTO attachments(id,session_id,file_path,mime_type,original_name,size_bytes,sha256,created_at)
-    VALUES (?,?,?,?,?,?,?,?)`).run(ulid(), input.sessionId, input.filePath, input.mimeType, input.originalName, input.sizeBytes, input.sha256, Date.now());
+  getSqlite().prepare(`INSERT INTO attachments(id,session_id,file_path,mime_type,original_name,size_bytes,sha256,source_role,source_role_explicit,created_at)
+    VALUES (?,?,?,?,?,?,?,?,?,?)`).run(ulid(), input.sessionId, input.filePath, input.mimeType, input.originalName, input.sizeBytes, input.sha256, input.sourceRole ?? "ordinary_content", input.sourceRoleExplicit ? 1 : 0, Date.now());
 }
 
 export function getAttachmentContext(sessionId: string): AttachmentContext | null {

--- a/packages/backend/src/db/attachments.ts
+++ b/packages/backend/src/db/attachments.ts
@@ -1,5 +1,6 @@
 import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import { ulid } from "ulid";
+import type { VisualSourceRole } from "@bg/shared";
 import { getDb } from "./client";
 import { attachmentsTable } from "./schema";
 
@@ -12,6 +13,8 @@ export interface AttachmentRecord {
   original_name: string;
   size_bytes: number;
   sha256: string | null;
+  source_role: VisualSourceRole;
+  source_role_explicit: boolean;
   created_at: number;
 }
 
@@ -23,6 +26,8 @@ export async function insertAttachment(input: {
   originalName: string;
   sizeBytes: number;
   sha256?: string | null;
+  sourceRole?: VisualSourceRole;
+  sourceRoleExplicit?: boolean;
 }) {
   const db = getDb();
   const id = ulid();
@@ -36,6 +41,8 @@ export async function insertAttachment(input: {
     originalName: input.originalName,
     sizeBytes: input.sizeBytes,
     sha256: input.sha256 ?? null,
+    sourceRole: input.sourceRole ?? "ordinary_content",
+    sourceRoleExplicit: input.sourceRoleExplicit ?? false,
     createdAt,
   });
 
@@ -48,6 +55,8 @@ export async function insertAttachment(input: {
     original_name: input.originalName,
     size_bytes: input.sizeBytes,
     sha256: input.sha256 ?? null,
+    source_role: input.sourceRole ?? "ordinary_content",
+    source_role_explicit: input.sourceRoleExplicit ?? false,
     created_at: createdAt,
   } satisfies AttachmentRecord;
 }
@@ -64,6 +73,8 @@ export async function listSessionAttachments(sessionId: string) {
       original_name: attachmentsTable.originalName,
       size_bytes: attachmentsTable.sizeBytes,
       sha256: attachmentsTable.sha256,
+      source_role: attachmentsTable.sourceRole,
+      source_role_explicit: attachmentsTable.sourceRoleExplicit,
       created_at: attachmentsTable.createdAt,
     })
     .from(attachmentsTable)

--- a/packages/backend/src/db/event-sequence-repository.ts
+++ b/packages/backend/src/db/event-sequence-repository.ts
@@ -1,5 +1,5 @@
 import type { Database } from "bun:sqlite";
-import { parseDesignDirectionState, type ExportAttemptStatus, type ExportProgress, type ExportStopReason, type NormalizedEvent, type SequencedEventEnvelope, type UserEvent } from "@bg/shared";
+import { VisualSourceContractError, parseDesignDirectionState, parseUploadedVisualSourceSelections, parseVisualSourceManifest, type ExportAttemptStatus, type ExportProgress, type ExportStopReason, type NormalizedEvent, type SequencedEventEnvelope, type TurnErrorCode, type UserEvent } from "@bg/shared";
 import { PipelineRepositoryError, parseJsonRecord } from "./pipeline-errors";
 
 export { insertSequencedEvent } from "./sequenced-event-writer";
@@ -9,8 +9,16 @@ export function parsePersistedNormalizedEvent(value: string, id: string): Normal
   const type = text(item, "type", id);
   const base = { id: text(item, "id", id), ts: integer(item, "ts", id) };
   switch (type) {
-    case "chat.user_message":
-      return { ...base, type, turnId: text(item, "turnId", id), text: text(item, "text", id), attachmentCount: integer(item, "attachmentCount", id) };
+    case "chat.user_message": {
+      const common = { ...base, type, turnId: text(item, "turnId", id), text: text(item, "text", id), attachmentCount: integer(item, "attachmentCount", id) };
+      if (item["visualSources"] === undefined) return common;
+      try {
+        const visualSources = parseVisualSourceManifest(item["visualSources"]);
+        if (visualSources.sources.some((source) => source.provenance.turn_id !== common.turnId)) throw new PipelineRepositoryError("corrupt_json", id);
+        return { ...common, visualSources };
+      }
+      catch (error) { if (error instanceof VisualSourceContractError) throw new PipelineRepositoryError("corrupt_json", id); throw error; }
+    }
     case "chat.delta":
     case "chat.thinking":
       return { ...base, type, turnId: text(item, "turnId", id), text: text(item, "text", id) };
@@ -36,8 +44,10 @@ export function parsePersistedNormalizedEvent(value: string, id: string): Normal
       return { ...base, type };
     case "status.idle":
       return { ...base, type, stopReason: stopReason(item, id) };
-    case "status.error":
-      return { ...base, type, message: text(item, "message", id), recoverable: truth(item, "recoverable", id) };
+    case "status.error": {
+      const common = { ...base, type, message: text(item, "message", id), recoverable: truth(item, "recoverable", id) };
+      return item["code"] === undefined ? common : { ...common, code: turnErrorCode(item, id) };
+    }
     case "usage.delta": {
       const cached = item["cached"];
       const common = { ...base, type, input: integer(item, "input", id), output: integer(item, "output", id) };
@@ -55,9 +65,15 @@ export function parsePersistedUserEvent(value: string, id: string): UserEvent {
     case "user.message": {
       const attachments = item["attachments"];
       const common = { type, text: text(item, "text", id) };
-      if (attachments === undefined) return common;
-      if (!Array.isArray(attachments) || !attachments.every((entry) => typeof entry === "string")) throw new PipelineRepositoryError("corrupt_json", id);
-      return { ...common, attachments };
+      if (attachments !== undefined && (!Array.isArray(attachments) || !attachments.every((entry) => typeof entry === "string"))) throw new PipelineRepositoryError("corrupt_json", id);
+      let visualSources;
+      try { visualSources = parseUploadedVisualSourceSelections(item["visualSources"]); }
+      catch (error) { if (error instanceof VisualSourceContractError) throw new PipelineRepositoryError("corrupt_json", id); throw error; }
+      return {
+        ...common,
+        ...(attachments === undefined ? {} : { attachments }),
+        ...(visualSources === undefined ? {} : { visualSources }),
+      };
     }
     case "user.interrupt":
       return { type };
@@ -77,7 +93,9 @@ export function listSequencedSessionEvents(db: Database, sessionId: string, afte
   const rows = db.query<{ readonly sequence: number | null; readonly payload_json: string; readonly id: string }, [string, number]>("SELECT sequence,payload_json,id FROM events WHERE session_id=? AND direction='down' AND sequence>? ORDER BY sequence").all(sessionId, afterSequence);
   return rows.map((row) => {
     if (row.sequence === null) throw new PipelineRepositoryError("corrupt_json", row.id);
-    return { sequence: row.sequence, event: parsePersistedNormalizedEvent(row.payload_json, row.id) };
+    const event = parsePersistedNormalizedEvent(row.payload_json, row.id);
+    if (event.type === "chat.user_message" && event.visualSources?.sources.some((source) => source.provenance.session_id !== sessionId)) throw new PipelineRepositoryError("corrupt_json", row.id);
+    return { sequence: row.sequence, event };
   });
 }
 
@@ -137,6 +155,14 @@ function fileAction(item: Readonly<Record<string, unknown>>, id: string): "creat
   const value = text(item, "action", id);
   switch (value) {
     case "created": case "edited": case "deleted": return value;
+    default: throw new PipelineRepositoryError("corrupt_json", id);
+  }
+}
+
+function turnErrorCode(item: Readonly<Record<string, unknown>>, id: string): TurnErrorCode {
+  const value = text(item, "code", id);
+  switch (value) {
+    case "backend_unavailable": case "path_unavailable": case "immutable_reference_mutated": case "immutable_reference_path_unavailable": case "immutable_reference_escaped": case "private_input_unavailable": case "publication_failed": case "operation_conflict": case "operation_cancelled": case "turn_failed": return value;
     default: throw new PipelineRepositoryError("corrupt_json", id);
   }
 }

--- a/packages/backend/src/db/event-sequence-repository.ts
+++ b/packages/backend/src/db/event-sequence-repository.ts
@@ -1,5 +1,5 @@
 import type { Database } from "bun:sqlite";
-import type { ExportAttemptStatus, ExportProgress, ExportStopReason, NormalizedEvent, SequencedEventEnvelope, UserEvent } from "@bg/shared";
+import { parseDesignDirectionState, type ExportAttemptStatus, type ExportProgress, type ExportStopReason, type NormalizedEvent, type SequencedEventEnvelope, type UserEvent } from "@bg/shared";
 import { PipelineRepositoryError, parseJsonRecord } from "./pipeline-errors";
 
 export { insertSequencedEvent } from "./sequenced-event-writer";
@@ -28,6 +28,8 @@ export function parsePersistedNormalizedEvent(value: string, id: string): Normal
       return { ...base, type, operationId: text(item, "operationId", id), revision: integer(item, "revision", id), digest: text(item, "digest", id), changedPaths: texts(item, "changedPaths", id), outcome: operationOutcome(item, id) };
     case "export.attempt":
       return { ...base, type, jobId: text(item, "jobId", id), attemptId: text(item, "attemptId", id), status: exportStatus(item, id), progress: exportProgress(item, id), projectRevision: integer(item, "projectRevision", id), projectDigest: text(item, "projectDigest", id), stopReason: exportStopReason(item, id) };
+    case "design.direction_state":
+      return { ...base, type, state: parseDesignDirectionState(item["state"]) };
     case "file.changed":
       return { ...base, type, turnId: text(item, "turnId", id), action: fileAction(item, id), path: text(item, "path", id) };
     case "status.running":

--- a/packages/backend/src/db/export-lifecycle-repository.ts
+++ b/packages/backend/src/db/export-lifecycle-repository.ts
@@ -62,6 +62,12 @@ export function markExportAttemptCorrupt(db: Database, input: { readonly jobId: 
   })();
 }
 
+export function recordExportAuditFindings(db: Database, attemptId: string, findings: readonly { readonly code: string; readonly path: string | null }[]): void {
+  if (findings.length > 200 || findings.some((finding) => finding.code.length === 0 || finding.code.length > 100 || finding.path !== null && finding.path.length > 512)) throw new ExportLifecycleError("invalid_findings");
+  const changed = db.prepare("UPDATE export_attempts SET findings_json=?,updated_at=? WHERE id=? AND status IN ('running','validating')").run(canonicalJson(findings), Date.now(), attemptId);
+  if (changed.changes !== 1) throw new ExportLifecycleError("transition_conflict");
+}
+
 export function requestExportCancellation(db: Database, attemptId: string): boolean {
   const changed = db.prepare("UPDATE export_attempts SET cancel_requested_at=COALESCE(cancel_requested_at,?),updated_at=? WHERE id=? AND status IN ('pending','retrying','running','validating','recovering')").run(Date.now(), Date.now(), attemptId);
   return changed.changes === 1;
@@ -71,4 +77,4 @@ function insertAttempt(db: Database, input: { readonly attemptId: string; readon
   db.prepare(`INSERT INTO export_attempts(id,job_id,parent_attempt_id,status,progress_json,project_revision,project_digest,canonical_options_json,options_digest,input_closure_digest,design_system_digest,renderer_digest,capture_digest,output_digest,receipt_digest,findings_json,retention_json,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,NULL,?,?,?,NULL,NULL,'[]',?,?,?)`).run(input.attemptId, input.jobId, input.parentAttemptId, input.status, canonicalJson({ stage: "queued", completed: 0, total: 6 }), input.identity.revision, input.identity.digest, input.optionsJson, sha256(input.optionsJson), input.identity.designSystemDigest, input.rendererDigest, input.captureDigest, canonicalJson({ retained_until: input.now + RETENTION_MS, output_available: false }), input.now, input.now);
 }
 function progressCompleted(stage: ExportProgressStage): number { switch (stage) { case "queued": return 0; case "snapshotting": return 1; case "rendering": return 2; case "validating": return 3; case "publishing": return 4; case "complete": return 6; } }
-export class ExportLifecycleError extends Error { readonly name = "ExportLifecycleError"; constructor(readonly code: "invalid_retry" | "transition_conflict") { super(code); } }
+export class ExportLifecycleError extends Error { readonly name = "ExportLifecycleError"; constructor(readonly code: "invalid_retry" | "transition_conflict" | "invalid_findings") { super(code); } }

--- a/packages/backend/src/db/home-project-list.ts
+++ b/packages/backend/src/db/home-project-list.ts
@@ -1,0 +1,62 @@
+import { desc, eq, isNull } from "drizzle-orm";
+import type { ProjectSummary } from "@bg/shared";
+import { projectThumbnailUrl } from "../services/project-thumbnails";
+import { getDb } from "./client";
+import { designSystemsTable, projectsTable } from "./schema";
+import { PROMPT_SAMPLE_TAG, TUTORIAL_TAG } from "./seed-tutorials";
+
+export async function listHomeProjects(
+  tab: string,
+  limit: number,
+  offset: number,
+) {
+  const rows = await getDb()
+    .select({
+      id: projectsTable.id,
+      name: projectsTable.name,
+      type: projectsTable.type,
+      design_system_id: projectsTable.designSystemId,
+      design_system_name: designSystemsTable.name,
+      current_revision: projectsTable.currentRevision,
+      current_digest: projectsTable.currentDigest,
+      updated_at: projectsTable.updatedAt,
+      archived_at: projectsTable.archivedAt,
+    })
+    .from(projectsTable)
+    .leftJoin(
+      designSystemsTable,
+      eq(projectsTable.designSystemId, designSystemsTable.id),
+    )
+    .where(isNull(projectsTable.archivedAt))
+    .orderBy(desc(projectsTable.updatedAt));
+
+  const filtered =
+    tab === "examples" ? rows.filter(isExampleProject) : rows;
+
+  return {
+    items: filtered.slice(offset, offset + limit).map(
+      ({ current_revision, current_digest, ...summary }) => ({
+        ...summary,
+        thumbnail_path: projectThumbnailUrl({
+          id: summary.id,
+          current_revision,
+          current_digest,
+        }),
+      }),
+    ) satisfies ProjectSummary[],
+    total: filtered.length,
+  };
+}
+
+export function isExampleProject(row: {
+  readonly type: string;
+  readonly name: string;
+}): boolean {
+  if (row.type === "from_template") {
+    return true;
+  }
+  return (
+    row.name.startsWith(TUTORIAL_TAG) ||
+    row.name.startsWith(PROMPT_SAMPLE_TAG)
+  );
+}

--- a/packages/backend/src/db/migrations/0011_graphic_project_type.sql
+++ b/packages/backend/src/db/migrations/0011_graphic_project_type.sql
@@ -1,0 +1,32 @@
+CREATE TABLE projects_graphic_v1 (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  type TEXT NOT NULL CHECK(type IN ('prototype','slide_deck','graphic','from_template','other')),
+  design_system_id TEXT REFERENCES design_systems(id),
+  dir_path TEXT NOT NULL,
+  entrypoint TEXT NOT NULL DEFAULT 'index.html',
+  thumbnail_path TEXT,
+  backend_id TEXT NOT NULL,
+  options_json TEXT,
+  archived_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  current_revision INTEGER NOT NULL DEFAULT 0,
+  current_digest TEXT
+);
+
+INSERT INTO projects_graphic_v1 (
+  id, name, type, design_system_id, dir_path, entrypoint, thumbnail_path,
+  backend_id, options_json, archived_at, created_at, updated_at,
+  current_revision, current_digest
+)
+SELECT
+  id, name, type, design_system_id, dir_path, entrypoint, thumbnail_path,
+  backend_id, options_json, archived_at, created_at, updated_at,
+  current_revision, current_digest
+FROM projects;
+
+DROP TABLE projects;
+ALTER TABLE projects_graphic_v1 RENAME TO projects;
+CREATE INDEX idx_projects_updated ON projects(updated_at DESC);
+CREATE INDEX idx_projects_ds ON projects(design_system_id);

--- a/packages/backend/src/db/migrations/0012_visual_source_role.sql
+++ b/packages/backend/src/db/migrations/0012_visual_source_role.sql
@@ -1,0 +1,3 @@
+ALTER TABLE attachments
+ADD COLUMN source_role TEXT NOT NULL DEFAULT 'ordinary_content'
+CHECK(source_role IN ('ordinary_content','immutable_reference'));

--- a/packages/backend/src/db/migrations/0013_visual_source_role_origin.sql
+++ b/packages/backend/src/db/migrations/0013_visual_source_role_origin.sql
@@ -1,0 +1,3 @@
+ALTER TABLE attachments
+ADD COLUMN source_role_explicit INTEGER NOT NULL DEFAULT 0
+CHECK(source_role_explicit IN (0,1));

--- a/packages/backend/src/db/pipeline-authorities.ts
+++ b/packages/backend/src/db/pipeline-authorities.ts
@@ -43,7 +43,7 @@ export const projectsTable = sqliteTable(
   {
     id: text("id").primaryKey(),
     name: text("name").notNull(),
-    type: text("type", { enum: ["prototype", "slide_deck", "from_template", "other"] }).notNull(),
+    type: text("type", { enum: ["prototype", "slide_deck", "graphic", "from_template", "other"] }).notNull(),
     designSystemId: text("design_system_id").references(() => designSystemsTable.id),
     dirPath: text("dir_path").notNull(),
     entrypoint: text("entrypoint").notNull().default("index.html"),

--- a/packages/backend/src/db/schema.ts
+++ b/packages/backend/src/db/schema.ts
@@ -30,6 +30,8 @@ export const attachmentsTable = sqliteTable(
     originalName: text("original_name").notNull(),
     sizeBytes: integer("size_bytes").notNull(),
     sha256: text("sha256"),
+    sourceRole: text("source_role", { enum: ["ordinary_content", "immutable_reference"] }).notNull().default("ordinary_content"),
+    sourceRoleExplicit: integer("source_role_explicit", { mode: "boolean" }).notNull().default(false),
     createdAt: integer("created_at").notNull(),
   },
   (table) => ({

--- a/packages/backend/src/db/seed.ts
+++ b/packages/backend/src/db/seed.ts
@@ -29,10 +29,11 @@ import {
   sessionsTable,
   usersTable,
 } from "./schema";
-import { PROMPT_SAMPLE_TAG, TUTORIAL_TAG } from "./seed-tutorials";
 import { SEEDED_PROJECT_HTML } from "./seeded-project-html";
 import { renderInitialArtifact } from "./templates";
 import type { SlideDeckOptions } from "./templates/slide-deck";
+
+export { isExampleProject, listHomeProjects } from "./home-project-list";
 
 export async function seedCoreData() {
   const db = getDb();
@@ -159,54 +160,6 @@ export async function seedCoreData() {
       }
     });
   }
-}
-
-export async function listHomeProjects(tab: string, limit: number, offset: number) {
-  const db = getDb();
-  const rows = await db
-    .select({
-      id: projectsTable.id,
-      name: projectsTable.name,
-      type: projectsTable.type,
-      design_system_id: projectsTable.designSystemId,
-      design_system_name: designSystemsTable.name,
-      thumbnail_path: projectsTable.thumbnailPath,
-      updated_at: projectsTable.updatedAt,
-      archived_at: projectsTable.archivedAt,
-    })
-    .from(projectsTable)
-    .leftJoin(
-      designSystemsTable,
-      eq(projectsTable.designSystemId, designSystemsTable.id),
-    )
-    .where(isNull(projectsTable.archivedAt))
-    .orderBy(desc(projectsTable.updatedAt));
-
-  const filtered =
-    tab === "examples" ? rows.filter(isExampleProject) : rows;
-
-  return {
-    items: filtered.slice(offset, offset + limit) as ProjectSummary[],
-    total: filtered.length,
-  };
-}
-
-/**
- * Decides whether a project row should appear under the Examples tab.
- *
- * Before this rule existed the filter was `type === "from_template"`
- * only, which left the seeded tutorials and prompt-samples — typed
- * `prototype` / `slide_deck` — invisible there. Examples then showed
- * a single placeholder template fixture instead of the six real
- * working examples the user actually expects to see (P4.7c).
- *
- * Pure / row-level so it can be unit-tested without a DB.
- */
-export function isExampleProject(row: { type: string; name: string }): boolean {
-  if (row.type === "from_template") return true;
-  return (
-    row.name.startsWith(TUTORIAL_TAG) || row.name.startsWith(PROMPT_SAMPLE_TAG)
-  );
 }
 
 export async function listHomeDesignSystems(status: DesignSystemSummary["status"]) {

--- a/packages/backend/src/db/seed.ts
+++ b/packages/backend/src/db/seed.ts
@@ -31,7 +31,7 @@ import {
 } from "./schema";
 import { SEEDED_PROJECT_HTML } from "./seeded-project-html";
 import { renderInitialArtifact } from "./templates";
-import type { SlideDeckOptions } from "./templates/slide-deck";
+import { parseStoredProjectOptions } from "../services/project-options";
 
 export { isExampleProject, listHomeProjects } from "./home-project-list";
 
@@ -305,7 +305,7 @@ export async function createProjectRecord(input: {
   const initialArtifact = renderInitialArtifact({
     name: input.name,
     type: input.type,
-    options: parseSlideDeckOptions(input.optionsJson),
+    options: parseStoredProjectOptions(input.optionsJson),
   });
 
   // Insert project + session atomically — without the transaction a
@@ -463,23 +463,4 @@ export async function getSessionInfo(sessionId: string) {
     updated_at: row.updated_at,
     last_active_at: row.last_active_at,
   } satisfies SessionInfo;
-}
-
-function parseSlideDeckOptions(optionsJson: string | null): SlideDeckOptions {
-  if (!optionsJson) return {};
-  try {
-    const parsed = JSON.parse(optionsJson);
-    if (parsed && typeof parsed === "object") {
-      const record = parsed as Record<string, unknown>;
-      return {
-        use_speaker_notes:
-          typeof record.use_speaker_notes === "boolean"
-            ? record.use_speaker_notes
-            : undefined,
-      };
-    }
-  } catch {
-    // malformed options JSON — fall through to defaults
-  }
-  return {};
 }

--- a/packages/backend/src/db/templates/graphic.ts
+++ b/packages/backend/src/db/templates/graphic.ts
@@ -1,0 +1,82 @@
+import type { GraphicCanvasV1 } from "@bg/shared";
+import { escapeHtml } from "./index";
+
+export function renderGraphic(
+  projectName: string,
+  canvas: GraphicCanvasV1,
+): string {
+  const title = escapeHtml(projectName);
+  const titleClass = [...projectName].length > 80 ? ' class="long-title"' : "";
+  return `<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${title}</title>
+  <style>
+    :root { color-scheme: light; }
+    * { box-sizing: border-box; }
+    html, body {
+      margin: 0;
+      width: ${canvas.width}px;
+      height: ${canvas.height}px;
+      overflow: hidden;
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #eaf0ff;
+      color: #14213d;
+    }
+    [data-graphic-artboard] {
+      position: relative;
+      width: ${canvas.width}px;
+      height: ${canvas.height}px;
+      overflow: hidden;
+      padding: clamp(24px, 7vw, 96px);
+      display: grid;
+      align-content: end;
+      background:
+        radial-gradient(circle at 82% 18%, rgba(0, 79, 255, 0.28), transparent 26%),
+        linear-gradient(145deg, #f8fbff 0%, #dce8ff 100%);
+    }
+    .mark {
+      position: absolute;
+      inset: clamp(24px, 7vw, 96px) auto auto clamp(24px, 7vw, 96px);
+      font-size: clamp(12px, 1.4vw, 18px);
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: #004fff;
+    }
+    h1 {
+      min-width: 0;
+      margin: 0;
+      max-width: min(15ch, 100%);
+      overflow-wrap: anywhere;
+      font-size: clamp(36px, 8vw, 112px);
+      line-height: 1.2;
+      letter-spacing: -0.055em;
+    }
+    h1.long-title {
+      max-width: 100%;
+      font-size: clamp(12px, 2vw, 24px);
+      line-height: 1.3;
+    }
+    p {
+      margin: clamp(12px, 2vw, 28px) 0 0;
+      max-width: 34em;
+      font-size: clamp(14px, 2vw, 26px);
+      line-height: 1.5;
+      color: #405273;
+    }
+  </style>
+</head>
+<body>
+  <main data-graphic-artboard data-bg-node-id="graphic-artboard">
+    <div class="mark" data-bg-node-id="graphic-mark">BurnGuard Graphic</div>
+    <h1${titleClass} data-bg-node-id="graphic-title">${title}</h1>
+    <p data-bg-node-id="graphic-copy">첫 메시지로 이 한 장의 그래픽을 완성하세요. Start with one clear visual message.</p>
+  </main>
+</body>
+</html>`;
+}

--- a/packages/backend/src/db/templates/index.ts
+++ b/packages/backend/src/db/templates/index.ts
@@ -1,21 +1,30 @@
-import type { ProjectType } from "@bg/shared";
+import type { GraphicCanvasV1, ProjectType } from "@bg/shared";
+import { renderGraphic } from "./graphic";
 import { renderPrototype } from "./prototype";
 import { renderSlideDeck, type SlideDeckOptions } from "./slide-deck";
 
 export interface TemplateContext {
-  name: string;
-  type: ProjectType;
-  options?: SlideDeckOptions;
+  readonly name: string;
+  readonly type: ProjectType;
+  readonly options?: SlideDeckOptions & {
+    readonly graphic_canvas?: GraphicCanvasV1 | null;
+  };
 }
 
 export function renderInitialArtifact(ctx: TemplateContext): string {
   switch (ctx.type) {
     case "slide_deck":
       return renderSlideDeck(ctx.name, ctx.options ?? {});
+    case "graphic": {
+      const canvas = ctx.options?.graphic_canvas;
+      if (canvas === undefined || canvas === null) {
+        throw new TypeError("Graphic template requires graphic_canvas");
+      }
+      return renderGraphic(ctx.name, canvas);
+    }
     case "prototype":
     case "from_template":
     case "other":
-    default:
       return renderPrototype(ctx.name);
   }
 }

--- a/packages/backend/src/harness/prompt-attachments.ts
+++ b/packages/backend/src/harness/prompt-attachments.ts
@@ -1,4 +1,6 @@
+import path from "node:path";
 import type { buildSessionContext } from "../services/context";
+import type { StageAttachmentInput } from "../services/stage-attachment-inputs";
 import {
   attachmentExtractedTextPath,
   attachmentSummaryPath,
@@ -20,46 +22,39 @@ export async function appendAttachmentContext(
   lines: string[],
   attachments: readonly Attachment[],
   requestedPaths: readonly string[],
+  projectDir: string,
+  stageInputs?: readonly StageAttachmentInput[],
 ): Promise<void> {
   lines.push("## Attachments");
   const selected = attachments.filter((attachment) =>
     requestedPaths.includes(attachment.file_path),
   );
   for (const attachment of selected) {
-    lines.push(
-      `- ${attachment.original_name} (${attachment.mime_type}, ${attachment.size_bytes}B)`,
-    );
+    lines.push(`- ${attachment.original_name} (${attachment.mime_type}, ${attachment.size_bytes}B)`);
+    const stageInput = stageInputs?.find((input) => input.attachmentId === attachment.id);
+    const relativeSource = stageInput?.sourcePath ?? path.relative(projectDir, attachment.file_path).replaceAll("\\", "/");
     const summary = await readAttachmentSummaryFile(
       attachmentSummaryPath(attachment.file_path),
     );
     if (summary) {
-      const extractedTextPath = attachmentExtractedTextPath(
-        attachment.file_path,
-      );
-      const hasExtractedText =
-        (await readOptional(extractedTextPath)) !== null;
+      const extractedTextPath = attachmentExtractedTextPath(attachment.file_path);
+      const relativeExtracted = stageInput?.extractedTextPath ?? path.relative(projectDir, extractedTextPath).replaceAll("\\", "/");
+      const hasExtractedText = stageInput !== undefined
+        ? stageInput.extractedTextPath !== null
+        : (await readOptional(extractedTextPath)) !== null;
       lines.push(
-        `  source_path: ${attachment.file_path} (binary attachment; do not Read/Glob/Bash this file directly)`,
+        `  source_path: ${relativeSource} (binary attachment; do not Read/Glob/Bash this file directly)`,
       );
       if (hasExtractedText) {
         lines.push(
-          `  extracted_text_path: ${extractedTextPath} (safe text version for Read)`,
+          `  extracted_text_path: ${relativeExtracted} (safe text version for Read)`,
         );
       }
       for (const summaryLine of renderAttachmentSummary(summary)) {
         lines.push(`  ${summaryLine}`);
       }
     } else {
-      lines.push(`  path: ${attachment.file_path}`);
-    }
-  }
-  for (const requestedPath of requestedPaths) {
-    if (
-      !selected.some(
-        (attachment) => attachment.file_path === requestedPath,
-      )
-    ) {
-      lines.push(`- ${requestedPath}`);
+      lines.push(`  path: ${relativeSource}`);
     }
   }
   lines.push("");

--- a/packages/backend/src/harness/prompt-builder.ts
+++ b/packages/backend/src/harness/prompt-builder.ts
@@ -94,6 +94,21 @@ export async function buildPrompt(
   }
   lines.push("");
 
+  const directionState = context.designDirectionState;
+  const selectedDirection = directionState?.selected_id === null
+    ? undefined
+    : directionState?.directions.find((direction) => direction.id === directionState.selected_id && direction.status === "ready");
+  if (directionState !== null && selectedDirection !== undefined) {
+    lines.push("## Selected design direction");
+    lines.push("### Content outline");
+    for (const item of directionState.content_outline.slice(0, 12)) lines.push(`- ${item.slice(0, 300)}`);
+    lines.push(`- title: ${selectedDirection.title.slice(0, 200)}`);
+    lines.push(`- layout: ${selectedDirection.layout_key}`);
+    lines.push(`- style facts: ${selectedDirection.style_facts.slice(0, 8).map((fact) => fact.slice(0, 200)).join("; ")}`);
+    lines.push("- Follow this selected direction only; do not merge details from unselected directions.");
+    lines.push("");
+  }
+
   lines.push("<burnguard-research-context-v1>");
   lines.push(JSON.stringify(buildResearchPromptContext({
     projectType: project.project_type,

--- a/packages/backend/src/harness/prompt-builder.ts
+++ b/packages/backend/src/harness/prompt-builder.ts
@@ -92,6 +92,21 @@ export async function buildPrompt(
       `- use_speaker_notes: ${projectOptions.use_speaker_notes ? "true" : "false"}`,
     );
   }
+  if (project.project_type === "graphic" && projectOptions.graphic_canvas !== null) {
+    const canvas = projectOptions.graphic_canvas;
+    lines.push("<burnguard-graphic-output-v1>");
+    lines.push(JSON.stringify({
+      schema_version: 1,
+      width_css_px: canvas.width,
+      height_css_px: canvas.height,
+      artboard_count: 1,
+      delivery_format: "png",
+    }));
+    lines.push("</burnguard-graphic-output-v1>");
+    lines.push(`- Exact canvas: ${canvas.width} × ${canvas.height} CSS px.`);
+    lines.push("- Author exactly one finite artboard; do not add slides, deck runtime, or a second artboard.");
+    lines.push("- Deliver this graphic as PNG only at the persisted canvas dimensions.");
+  }
   lines.push("");
 
   const directionState = context.designDirectionState;

--- a/packages/backend/src/harness/prompt-builder.ts
+++ b/packages/backend/src/harness/prompt-builder.ts
@@ -1,4 +1,6 @@
 import path from "node:path";
+import type { VisualSourceManifestV1 } from "@bg/shared";
+import type { StageAttachmentInput } from "../services/stage-attachment-inputs";
 import type { UserEvent } from "@bg/shared/events";
 import type { buildSessionContext } from "../services/context";
 import { parseStoredProjectOptions } from "../services/project-options";
@@ -16,6 +18,7 @@ import {
 import { appendDesignBriefContext } from "./prompt-design-brief";
 import { appendDesignSystemContext } from "./prompt-design-system";
 import { appendReferenceLayoutContext } from "./prompt-reference-layout";
+import { appendVisualSourceContext } from "./prompt-visual-sources";
 import {
   summarizeDeckHtml,
   summarizePrototypeHtml,
@@ -31,6 +34,8 @@ export type PromptContextMode = "compact" | "full";
 
 export interface PromptBuildOptions {
   contextMode?: PromptContextMode;
+  visualSourceManifest?: VisualSourceManifestV1 | null;
+  stageAttachmentInputs?: readonly StageAttachmentInput[];
 }
 
 /**
@@ -133,10 +138,21 @@ export async function buildPrompt(
   lines.push("</burnguard-research-context-v1>");
   lines.push("");
   appendDesignBriefContext(lines, projectOptions.design_brief);
+  await appendVisualSourceContext(lines, {
+    projectDir: project.project_dir,
+    attachments: context.attachments,
+    requestedPaths: userEvent.attachments ?? [],
+    selections: userEvent.visualSources,
+    prebuiltManifest: options.visualSourceManifest,
+    stageInputs: options.stageAttachmentInputs,
+  });
   appendReferenceLayoutContext(lines, {
     request: userEvent.text,
     attachments: context.attachments,
     requestedPaths: userEvent.attachments ?? [],
+    selections: userEvent.visualSources,
+    projectDir: project.project_dir,
+    stageInputs: options.stageAttachmentInputs,
   });
 
   // Structural summary of the entrypoint, when it's an HTML artifact we know
@@ -190,6 +206,8 @@ export async function buildPrompt(
       lines,
       context.attachments,
       userEvent.attachments,
+      project.project_dir,
+      options.stageAttachmentInputs,
     );
   }
 

--- a/packages/backend/src/harness/prompt-reference-layout.ts
+++ b/packages/backend/src/harness/prompt-reference-layout.ts
@@ -1,4 +1,6 @@
+import type { UploadedVisualSourceSelection } from "@bg/shared";
 import type { buildSessionContext } from "../services/context";
+import type { StageAttachmentInput } from "../services/stage-attachment-inputs";
 import { buildReferenceLayoutContext } from "../services/reference-layout";
 import { REFERENCE_LAYOUT_SKILL_MD } from "./skills/reference-layout-skill";
 
@@ -12,6 +14,9 @@ export function appendReferenceLayoutContext(
     readonly request: string;
     readonly attachments: SessionContext["attachments"];
     readonly requestedPaths: readonly string[];
+    readonly selections?: readonly UploadedVisualSourceSelection[];
+    readonly projectDir?: string;
+    readonly stageInputs?: readonly StageAttachmentInput[];
   },
 ): boolean {
   const context = buildReferenceLayoutContext(input);

--- a/packages/backend/src/harness/prompt-visual-sources.ts
+++ b/packages/backend/src/harness/prompt-visual-sources.ts
@@ -1,0 +1,39 @@
+import type { buildSessionContext } from "../services/context";
+import type { UploadedVisualSourceSelection, VisualSourceManifestV1 } from "@bg/shared";
+import { buildVisualSourceManifest } from "../services/visual-source-manifest";
+import { StageAttachmentInputError, type StageAttachmentInput } from "../services/stage-attachment-inputs";
+
+type SessionContext = NonNullable<Awaited<ReturnType<typeof buildSessionContext>>>;
+
+export async function appendVisualSourceContext(
+  lines: string[],
+  input: {
+    readonly projectDir: string;
+    readonly attachments: SessionContext["attachments"];
+    readonly requestedPaths: readonly string[];
+    readonly selections: readonly UploadedVisualSourceSelection[] | undefined;
+    readonly prebuiltManifest?: VisualSourceManifestV1 | null;
+    readonly stageInputs?: readonly StageAttachmentInput[];
+  },
+): Promise<void> {
+  const hasAssignedSource = input.attachments.some((attachment) => input.requestedPaths.includes(attachment.file_path) && attachment.turn_id !== null);
+  const manifest = input.prebuiltManifest === undefined
+    ? hasAssignedSource ? await buildVisualSourceManifest(input) : null
+    : input.prebuiltManifest;
+  if (manifest === null) return;
+  const promptManifest = input.stageInputs === undefined ? manifest : {
+    ...manifest,
+    sources: manifest.sources.map((source) => {
+      const stageInput = input.stageInputs?.find((candidate) => candidate.attachmentId === source.attachment_id);
+      if (stageInput === undefined) throw new StageAttachmentInputError();
+      return { ...source, managed_path: stageInput.sourcePath };
+    }),
+  };
+  lines.push("<burnguard-visual-sources-v1>");
+  lines.push(JSON.stringify(promptManifest));
+  lines.push("</burnguard-visual-sources-v1>");
+  if (manifest.sources.some((source) => source.role === "immutable_reference")) {
+    lines.push("Immutable visual references are read-only underlays: preserve each original file, hash, and provenance; never overwrite or copy it into authored output; keep every derived artifact separate.");
+  }
+  lines.push("");
+}

--- a/packages/backend/src/routes/artifacts.ts
+++ b/packages/backend/src/routes/artifacts.ts
@@ -122,11 +122,18 @@ artifactRoutes.post("/api/projects/:id/exports", async (c) => {
     if (error instanceof UpgradeContractError) return c.json(fail("invalid_export_options", "Export options are invalid", { path: error.path }), 400);
     throw error;
   }
-  const { enqueueProjectExport } = await import("../services/exports");
+  const { enqueueProjectExport, ExportServiceError } = await import("../services/exports");
   const { exportQaHooks } = await import("../services/export-qa-barrier");
-  const job = await enqueueProjectExport(projectId, format, options, exportQaHooks(c.req.header("x-bg-export-qa-barrier") ?? null));
-  if (job === null) return c.json(fail("export_create_failed", "Export job could not be created"), 500);
-  return c.json(ok(job satisfies ExportJob), 202);
+  try {
+    const job = await enqueueProjectExport(projectId, format, options, exportQaHooks(c.req.header("x-bg-export-qa-barrier") ?? null));
+    if (job === null) return c.json(fail("export_create_failed", "Export job could not be created"), 500);
+    return c.json(ok(job satisfies ExportJob), 202);
+  } catch (error) {
+    if (error instanceof ExportServiceError && error.code === "invalid_graphic_export_options") {
+      return c.json(fail(error.code, error.message), 400);
+    }
+    throw error;
+  }
 });
 
 artifactRoutes.post("/api/exports/qa/barriers", async (c) => {

--- a/packages/backend/src/routes/artifacts.ts
+++ b/packages/backend/src/routes/artifacts.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { UpgradeContractError, parseExportOptions } from "@bg/shared";
 import type {
   ApiErrorBody,
@@ -67,6 +67,19 @@ artifactRoutes.post("/api/projects/:id/refresh", async (c) => {
   }
   return c.json(ok(artifacts satisfies ArtifactSummary));
 });
+
+artifactRoutes.get("/api/projects/:id/design-audit", async (c) => designAuditResponse(c.req.param("id"), false, c.req.raw.signal, c));
+artifactRoutes.post("/api/projects/:id/design-audit/retry", async (c) => designAuditResponse(c.req.param("id"), true, c.req.raw.signal, c));
+
+async function designAuditResponse(projectId: string, force: boolean, signal: AbortSignal, c: Context) {
+  const { DesignAuditServiceError, getProjectDesignAudit } = await import("../services/design-audit");
+  try { return c.json(ok(await getProjectDesignAudit(projectId, force, signal))); }
+  catch (error) {
+    if (!(error instanceof DesignAuditServiceError)) throw error;
+    const status = error.code === "project_not_found" ? 404 : error.code === "stale_artifact_identity" ? 409 : 503;
+    return c.json(fail(error.code, error.message), status);
+  }
+}
 
 artifactRoutes.get("/api/projects/:id/exports", async (c) => {
   const projectId = c.req.param("id");

--- a/packages/backend/src/routes/design-directions.ts
+++ b/packages/backend/src/routes/design-directions.ts
@@ -1,0 +1,133 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { Hono } from "hono";
+import type { ApiErrorBody, ApiSuccess, DesignBriefV1, ProjectType } from "@bg/shared";
+import { getLatestProjectSession, getProjectDetail } from "../db/project-read-repository";
+import { projectsDir, resolveManagedPath } from "../lib/paths";
+import { PathBoundaryError, assertSafeName } from "../security/path-boundary";
+import { isUserTurnRunning } from "../services/turns";
+import { getLatestDirectionState } from "../services/design-direction-state";
+import { DesignDirectionWorkflow, DesignDirectionWorkflowError, directionPreviewPath } from "../services/design-direction-workflow";
+import { parseStoredProjectOptions } from "../services/project-options";
+
+let workflow = new DesignDirectionWorkflow();
+export const designDirectionRoutes = new Hono();
+
+export function replaceDesignDirectionWorkflowForTest(replacement: DesignDirectionWorkflow): () => void {
+  const previous = workflow;
+  workflow = replacement;
+  return () => { if (workflow === replacement) workflow = previous; };
+}
+
+type RouteContext = { readonly projectId: string; readonly sessionId: string; readonly projectDir: string; readonly projectName: string; readonly projectType: ProjectType; readonly designBrief: DesignBriefV1 | null };
+type RouteContextResult = RouteContext | "path_unavailable" | null;
+
+function ok<T>(data: T): ApiSuccess<T> { return { data }; }
+function fail(code: string, message: string, details?: unknown): ApiErrorBody { return { error: { code, message, details } }; }
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> { return typeof value === "object" && value !== null && !Array.isArray(value); }
+function isRevision(value: unknown): value is number { return typeof value === "number" && Number.isSafeInteger(value) && value >= 0; }
+function isText(value: unknown): value is string { return typeof value === "string" && value.length > 0; }
+
+async function context(projectId: string): Promise<RouteContextResult> {
+  const [project, session] = await Promise.all([getProjectDetail(projectId), getLatestProjectSession(projectId)]);
+  if (project === null || session === null) return null;
+  try {
+    return { projectId, sessionId: session.id, projectDir: resolveManagedPath(projectsDir, project.dir_path), projectName: project.name, projectType: project.type, designBrief: parseStoredProjectOptions(project.options_json).design_brief };
+  } catch (error) {
+    if (error instanceof PathBoundaryError) return "path_unavailable";
+    throw error;
+  }
+}
+
+function pathUnavailable(): Response { return Response.json(fail("project_path_unavailable", "Project directory is outside managed storage"), { status: 503 }); }
+
+function routeError(error: DesignDirectionWorkflowError): Response {
+  const conflict = error.code === "operation_active" || error.code === "generation_conflict" || error.code === "revision_conflict";
+  const status = conflict ? 409 : error.code === "state_not_found" ? 404 : 422;
+  return Response.json(fail(error.code, error.message), { status });
+}
+
+async function generationContext(projectId: string): Promise<{ readonly value?: RouteContext; readonly response?: Response }> {
+  const value = await context(projectId);
+  if (value === null) return { response: Response.json(fail("project_session_not_found", "Project or session not found"), { status: 404 }) };
+  if (value === "path_unavailable") return { response: pathUnavailable() };
+  const session = await getLatestProjectSession(projectId);
+  if (session?.status === "running" || isUserTurnRunning(value.sessionId)) return { response: Response.json(fail("session_busy", "Cannot generate directions while a user turn is running"), { status: 409 }) };
+  return { value };
+}
+
+designDirectionRoutes.get("/api/projects/:projectId/design-directions", async (c) => {
+  const value = await context(c.req.param("projectId"));
+  if (value === null) return c.json(fail("project_session_not_found", "Project or session not found"), 404);
+  if (value === "path_unavailable") return pathUnavailable();
+  return c.json(ok(await workflow.recover(value.sessionId)));
+});
+
+designDirectionRoutes.post("/api/projects/:projectId/design-directions/generate", async (c) => {
+  const result = await generationContext(c.req.param("projectId"));
+  if (result.response !== undefined) return result.response;
+  const value = result.value;
+  if (value === undefined) return c.json(fail("project_session_not_found", "Project or session not found"), 404);
+  try { const started = await workflow.generate(value); void started.completion; return c.json(ok(started.state), 202); }
+  catch (error) { if (error instanceof DesignDirectionWorkflowError) return routeError(error); throw error; }
+});
+
+designDirectionRoutes.post("/api/projects/:projectId/design-directions/cancel", async (c) => {
+  const value = await context(c.req.param("projectId"));
+  if (value === null) return c.json(fail("project_session_not_found", "Project or session not found"), 404);
+  if (value === "path_unavailable") return pathUnavailable();
+  const terminal = await workflow.cancel(value.sessionId);
+  if (terminal === null) return c.json(fail("operation_not_active", "No direction operation is active"), 409);
+  return c.json(ok(terminal), 202);
+});
+
+designDirectionRoutes.post("/api/projects/:projectId/design-directions/retry", async (c) => {
+  const result = await generationContext(c.req.param("projectId"));
+  if (result.response !== undefined) return result.response;
+  const value = result.value;
+  if (value === undefined) return c.json(fail("project_session_not_found", "Project or session not found"), 404);
+  try { const started = await workflow.retry(value); void started.completion; return c.json(ok(started.state), 202); }
+  catch (error) { if (error instanceof DesignDirectionWorkflowError) return routeError(error); throw error; }
+});
+
+designDirectionRoutes.post("/api/projects/:projectId/design-directions/select", async (c) => {
+  const value = await context(c.req.param("projectId"));
+  if (value === null) return c.json(fail("project_session_not_found", "Project or session not found"), 404);
+  if (value === "path_unavailable") return pathUnavailable();
+  const body = await c.req.json<unknown>().catch(() => null);
+  if (!isRecord(body) || !isText(body["generation_id"]) || !isRevision(body["expected_selection_revision"]) || !isText(body["direction_id"])) return c.json(fail("invalid_body", "Expected generation_id, expected_selection_revision, and direction_id"), 400);
+  try { return c.json(ok(await workflow.select(value.sessionId, body["generation_id"], body["expected_selection_revision"], body["direction_id"]))); }
+  catch (error) { if (error instanceof DesignDirectionWorkflowError) return routeError(error); throw error; }
+});
+
+designDirectionRoutes.post("/api/projects/:projectId/design-directions/undo-selection", async (c) => {
+  const value = await context(c.req.param("projectId"));
+  if (value === null) return c.json(fail("project_session_not_found", "Project or session not found"), 404);
+  if (value === "path_unavailable") return pathUnavailable();
+  const body = await c.req.json<unknown>().catch(() => null);
+  if (!isRecord(body) || !isText(body["generation_id"]) || !isRevision(body["expected_selection_revision"])) return c.json(fail("invalid_body", "Expected generation_id and expected_selection_revision"), 400);
+  try { return c.json(ok(await workflow.undo(value.sessionId, body["generation_id"], body["expected_selection_revision"]))); }
+  catch (error) { if (error instanceof DesignDirectionWorkflowError) return routeError(error); throw error; }
+});
+
+designDirectionRoutes.get("/api/projects/:projectId/design-directions/:generationId/:directionId/preview", async (c) => {
+  const value = await context(c.req.param("projectId"));
+  if (value === null) return c.json(fail("project_session_not_found", "Project or session not found"), 404);
+  if (value === "path_unavailable") return pathUnavailable();
+  try {
+    const generationId = assertSafeName(c.req.param("generationId"));
+    const directionId = assertSafeName(c.req.param("directionId"));
+    const state = await getLatestDirectionState(value.sessionId);
+    const slot = state?.generation_id === generationId ? state.directions.find((candidate) => candidate.id === directionId && candidate.status === "ready") : undefined;
+    if (slot === undefined) return c.json(fail("preview_not_found", "Preview is not available for the current state"), 404);
+    const bytes = await readFile(directionPreviewPath(value.projectDir, generationId, directionId));
+    const etag = `"${createHash("sha256").update(bytes).digest("hex")}"`;
+    const headers = { "Content-Type": "image/svg+xml", "Cache-Control": "private, no-cache", ETag: etag };
+    if (c.req.header("if-none-match") === etag) return c.body(null, 304, headers);
+    return c.body(bytes, 200, headers);
+  } catch (error) {
+    if (error instanceof PathBoundaryError) return c.json(fail("invalid_preview_id", "Preview identifier is invalid"), 400);
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return c.json(fail("preview_missing", "Preview file is missing"), 410);
+    throw error;
+  }
+});

--- a/packages/backend/src/routes/home-project-input.ts
+++ b/packages/backend/src/routes/home-project-input.ts
@@ -68,9 +68,12 @@ export function parseProjectInput(input: unknown): ParsedProjectInput {
     );
   }
   let optionsJson: string | null = null;
+  let graphicCanvasPresent = false;
   if (input["options"] !== undefined) {
     try {
-      optionsJson = JSON.stringify(parseProjectOptions(input["options"]));
+      const options = parseProjectOptions(input["options"]);
+      graphicCanvasPresent = options.graphic_canvas !== null;
+      optionsJson = JSON.stringify(options);
     } catch (error) {
       if (error instanceof UpgradeContractError) {
         throw new ProjectInputError(
@@ -81,6 +84,15 @@ export function parseProjectInput(input: unknown): ParsedProjectInput {
       }
       throw error;
     }
+  }
+  if ((type === "graphic") !== graphicCanvasPresent) {
+    throw new ProjectInputError(
+      "invalid_project_options",
+      type === "graphic"
+        ? "graphic projects require options.graphic_canvas"
+        : "graphic_canvas is only valid for graphic projects",
+      { path: "options.graphic_canvas" },
+    );
   }
   return {
     name: name.trim(),
@@ -102,6 +114,7 @@ function isProjectType(
   return (
     value === "prototype" ||
     value === "slide_deck" ||
+    value === "graphic" ||
     value === "from_template" ||
     value === "other"
   );

--- a/packages/backend/src/routes/home.ts
+++ b/packages/backend/src/routes/home.ts
@@ -21,6 +21,7 @@ import {
   parseProjectInput,
   ProjectInputError,
 } from "./home-project-input";
+import { serveProjectThumbnail } from "./project-thumbnail-handler";
 
 const VALID_PROJECT_TABS = new Set(["recent", "mine", "examples"]);
 const VALID_SYSTEM_STATUSES = new Set<DesignSystemStatus>([
@@ -101,6 +102,8 @@ homeRoutes.get("/api/projects", async (c) => {
   const result = await listHomeProjects(tab, limit, offset);
   return c.json(ok(result.items, { total: result.total, limit, offset }));
 });
+
+homeRoutes.get("/api/projects/:id/thumbnail", serveProjectThumbnail);
 
 homeRoutes.get("/api/design-systems", async (c) => {
   const status = (c.req.query("status") ?? "published") as DesignSystemStatus;

--- a/packages/backend/src/routes/project-thumbnail-handler.ts
+++ b/packages/backend/src/routes/project-thumbnail-handler.ts
@@ -1,0 +1,45 @@
+import type { ApiErrorBody } from "@bg/shared";
+import type { Context } from "hono";
+import { loadProjectThumbnail } from "../services/project-thumbnails";
+
+const THUMBNAIL_FAILURES = {
+  artifact_unavailable: {
+    status: 409,
+    message: "Project has no rendered artifact yet",
+  },
+  thumbnail_unavailable: {
+    status: 503,
+    message: "Thumbnail could not be rendered",
+  },
+} as const;
+
+export async function serveProjectThumbnail(context: Context) {
+  const id = context.req.param("id") ?? "";
+  const outcome = await loadProjectThumbnail(id);
+  switch (outcome.kind) {
+    case "not_found":
+      return context.json(fail("project_not_found", "Project not found", id), 404);
+    case "unavailable": {
+      const failure = THUMBNAIL_FAILURES[outcome.code];
+      return context.json(
+        fail(outcome.code, failure.message, id),
+        failure.status,
+      );
+    }
+    case "ready": {
+      const headers = {
+        "Content-Type": "image/png",
+        ETag: outcome.etag,
+        "Cache-Control": "private, no-cache",
+      };
+      if (context.req.header("if-none-match") === outcome.etag) {
+        return new Response(null, { status: 304, headers });
+      }
+      return new Response(outcome.bytes, { status: 200, headers });
+    }
+  }
+}
+
+function fail(code: string, message: string, id: string): ApiErrorBody {
+  return { error: { code, message, details: { id } } };
+}

--- a/packages/backend/src/routes/project.ts
+++ b/packages/backend/src/routes/project.ts
@@ -6,6 +6,7 @@ import { getSqlite } from "../db/sqlite-client";
 import { projectsDir, resolveManagedPath } from "../lib/paths";
 import { getLatestProjectSession, getProjectDetail } from "../db/project-read-repository";
 import { processProjectFilesystemSignal } from "../services/watchers";
+import { designDirectionRoutes } from "./design-directions";
 
 function ok<T>(data: T): ApiSuccess<T> {
   return { data };
@@ -20,6 +21,7 @@ function fail(
 }
 
 export const projectRoutes = new Hono();
+projectRoutes.route("/", designDirectionRoutes);
 
 projectRoutes.get("/api/projects/:id", async (c) => {
   const id = c.req.param("id");

--- a/packages/backend/src/routes/session.ts
+++ b/packages/backend/src/routes/session.ts
@@ -1,7 +1,16 @@
 import { ulid } from "ulid";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
-import type { ApiErrorBody, ApiSuccess, NormalizedEvent, UserEvent } from "@bg/shared";
+import {
+  VisualSourceContractError,
+  parseUploadedVisualSourceSelections,
+  parseVisualSourceUploadRequest,
+  type ApiErrorBody,
+  type ApiSuccess,
+  type NormalizedEvent,
+  type UserEvent,
+  type VisualSourceUploadRequestV1,
+} from "@bg/shared";
 import {
   insertNormalizedEvent,
   insertUserEvent,
@@ -14,7 +23,8 @@ import {
   getProjectDetail,
   getSessionInfo,
 } from "../db/seed";
-import { UnsupportedAttachmentKindError, saveSessionAttachments } from "../services/attachments";
+import { UnsupportedAttachmentKindError, rollbackSessionAttachments, saveSessionAttachments } from "../services/attachments";
+import { AttachmentRequestError, canonicalizeAttachmentRequest } from "../services/attachment-request";
 import { SUPPORTED_UPLOAD_KINDS } from "../services/upload-kind";
 import { broker, sequencedBroker } from "../services/broker";
 import { subscribeBeforeBackfill } from "../services/sequenced-event-replay";
@@ -29,7 +39,10 @@ import { appendSessionTrace } from "../services/trace";
 import {
   interruptUserTurn,
   isUserTurnRunning,
-  startUserTurn,
+  releaseUserTurnReservation,
+  reserveUserTurn,
+  startReservedUserTurn,
+  type UserTurnReservation,
   submitToolDecisionToTurn,
 } from "../services/turns";
 
@@ -76,16 +89,10 @@ sessionRoutes.post("/api/sessions/:id/events", async (c) => {
   if (!session) {
     return c.json(fail("session_not_found", "Session not found", { id }), 404);
   }
-  if (isUserTurnRunning(id)) {
-    return c.json(
-      fail("session_busy", "A turn is already running for this session", { id }),
-      409,
-    );
-  }
-
   const contentType = c.req.header("content-type") ?? "";
   let payload: UserEvent | null = null;
   let requestedOperationId: string | undefined;
+  let reservation: UserTurnReservation | null = null;
 
   if (contentType.includes("application/json")) {
     const body = await c.req.json<unknown>().catch(() => null);
@@ -94,13 +101,20 @@ sessionRoutes.post("/api/sessions/:id/events", async (c) => {
       body.type === "user.message" &&
       typeof body.text === "string"
     ) {
-      payload = {
-        type: "user.message",
-        text: body.text,
-        attachments: Array.isArray(body.attachments)
-          ? body.attachments.filter((value): value is string => typeof value === "string")
-          : undefined,
-      };
+      let visualSources;
+      try { visualSources = parseUploadedVisualSourceSelections(body.visualSources); }
+      catch (error) {
+        if (error instanceof VisualSourceContractError) return c.json(fail(error.code, error.code === "unsupported_visual_source" ? "URL, web, and stock sources are unsupported" : "Visual source metadata is invalid"), error.code === "unsupported_visual_source" ? 415 : 400);
+        throw error;
+      }
+      if (body.attachments !== undefined && (!Array.isArray(body.attachments) || !body.attachments.every((value) => typeof value === "string"))) return c.json(fail("invalid_attachments", "Attachment selection is invalid"), 400);
+      try {
+        const canonical = await canonicalizeAttachmentRequest({ sessionId: id, requestedPaths: body.attachments ?? [], selections: visualSources });
+        payload = { type: "user.message", text: body.text, attachments: [...canonical.paths], visualSources: canonical.selections };
+      } catch (error) {
+        if (error instanceof AttachmentRequestError) return c.json(fail(error.code, "Attachment selection is invalid"), 400);
+        throw error;
+      }
       if (body.operation_id !== undefined) {
         if (typeof body.operation_id !== "string" || process.env.BG_ARTIFACT_QA !== "1" || body.operation_id !== process.env.BG_ARTIFACT_TURN_OPERATION_ID) return c.json(fail("invalid_operation_id", "Scoped operation identity is invalid"), 400);
         try { requestedOperationId = assertSafeName(body.operation_id); }
@@ -116,9 +130,21 @@ sessionRoutes.post("/api/sessions/:id/events", async (c) => {
         .getAll("files")
         .filter((value): value is File => value instanceof File);
       let attachmentPaths: string[];
+      let uploadSources: VisualSourceUploadRequestV1;
       try {
-        attachmentPaths = await saveSessionAttachments(id, fileEntries);
+        uploadSources = parseVisualSourceUploadRequest(form.get("visual_sources"), fileEntries.length);
+        reservation = reserveUserTurn(id);
+        if (reservation === null) return c.json(fail("session_busy", "A turn is already running for this session", { id }), 409);
+        attachmentPaths = await saveSessionAttachments(id, fileEntries.map((file, index) => ({
+          file,
+          role: uploadSources.sources[index]?.role ?? "ordinary_content",
+          roleExplicit: uploadSources.explicit,
+        })));
       } catch (error) {
+        if (reservation !== null) releaseUserTurnReservation(reservation);
+        if (error instanceof VisualSourceContractError) {
+          return c.json(fail(error.code, error.code === "unsupported_visual_source" ? "URL, web, and stock sources are unsupported" : "Visual source metadata is invalid"), error.code === "unsupported_visual_source" ? 415 : 400);
+        }
         if (error instanceof UnsupportedAttachmentKindError) {
           return c.json(
             fail(error.code, "Unsupported source kind", {
@@ -134,11 +160,16 @@ sessionRoutes.post("/api/sessions/:id/events", async (c) => {
           400,
         );
       }
-      payload = {
-        type: "user.message",
-        text,
-        attachments: attachmentPaths,
-      };
+      const selections = attachmentPaths.map((attachmentPath, index) => ({ source_type: "uploaded_attachment" as const, attachment_path: attachmentPath, role: uploadSources.sources[index]?.role ?? "ordinary_content" }));
+      try {
+        const canonical = await canonicalizeAttachmentRequest({ sessionId: id, requestedPaths: attachmentPaths, selections });
+        payload = { type: "user.message", text, attachments: [...canonical.paths], visualSources: canonical.selections };
+      } catch (error) {
+        await rollbackSessionAttachments(id, attachmentPaths);
+        if (reservation !== null) releaseUserTurnReservation(reservation);
+        if (error instanceof AttachmentRequestError) return c.json(fail(error.code, "Attachment selection is invalid"), 400);
+        throw error;
+      }
     }
   }
 
@@ -149,7 +180,8 @@ sessionRoutes.post("/api/sessions/:id/events", async (c) => {
     );
   }
 
-  const turn = startUserTurn(id, payload, requestedOperationId);
+  reservation ??= reserveUserTurn(id, requestedOperationId);
+  const turn = reservation === null ? null : startReservedUserTurn(reservation, payload);
   if (!turn) {
     return c.json(
       fail("session_busy", "A turn is already running for this session", { id }),

--- a/packages/backend/src/routes/session.ts
+++ b/packages/backend/src/routes/session.ts
@@ -14,7 +14,8 @@ import {
   getProjectDetail,
   getSessionInfo,
 } from "../db/seed";
-import { saveSessionAttachments } from "../services/attachments";
+import { UnsupportedAttachmentKindError, saveSessionAttachments } from "../services/attachments";
+import { SUPPORTED_UPLOAD_KINDS } from "../services/upload-kind";
 import { broker, sequencedBroker } from "../services/broker";
 import { subscribeBeforeBackfill } from "../services/sequenced-event-replay";
 import {
@@ -118,6 +119,15 @@ sessionRoutes.post("/api/sessions/:id/events", async (c) => {
       try {
         attachmentPaths = await saveSessionAttachments(id, fileEntries);
       } catch (error) {
+        if (error instanceof UnsupportedAttachmentKindError) {
+          return c.json(
+            fail(error.code, "Unsupported source kind", {
+              files: error.fileNames,
+              supported_kinds: SUPPORTED_UPLOAD_KINDS,
+            }),
+            415,
+          );
+        }
         const message = error instanceof Error ? error.message : String(error);
         return c.json(
           fail("invalid_attachments", "Attachment upload rejected", { message }),

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -152,7 +152,7 @@ export function classifyApiRoute(pathname: string, method: string): ApiRouteDoma
     if (/\/draws(?:\/|$)/.test(pathname) && (method === "GET" || method === "PUT")) return "managed-files";
     if (/\/fs(?:\/|$)/.test(pathname) && method === "GET" && !pathname.endsWith("/undo-info")) return "managed-files";
     if (/\/(?:fs|operations)(?:\/|$)/.test(pathname)) return "artifact-operations";
-    if (/\/(?:files|artifacts|refresh|exports)(?:\/|$)/.test(pathname)) return "artifacts";
+    if (/\/(?:files|artifacts|refresh|exports|design-audit)(?:\/|$)/.test(pathname)) return "artifacts";
     return "project";
   }
   return "not-found";

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -146,6 +146,7 @@ export function classifyApiRoute(pathname: string, method: string): ApiRouteDoma
   if (pathname.startsWith("/api/runtime")) return "runtime";
   if (pathname.startsWith("/api/settings/")) return "settings";
   if (pathname === "/api/settings" || pathname.startsWith("/api/backends") || pathname.startsWith("/api/home") || pathname === "/api/projects") return "home";
+  if (method === "GET" && /^\/api\/projects\/[^/]+\/thumbnail$/.test(pathname)) return "home";
   if (pathname.startsWith("/api/projects")) {
     if (/\/checkpoints(?:\/|$)/.test(pathname)) return "session";
     if (/\/draws(?:\/|$)/.test(pathname) && (method === "GET" || method === "PUT")) return "managed-files";

--- a/packages/backend/src/services/artifact-coordinator.ts
+++ b/packages/backend/src/services/artifact-coordinator.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { ulid } from "ulid";
 import { applyHtmlNodePatch, fingerprintHtmlNode, type PatchHtmlNodeInput } from "./file-patch";
 import { inspectCanonicalTree, validateCanonicalTree, type CanonicalTreeManifest } from "./canonical-tree-manifest";
-import { diffManagedTrees, manifestEntry, materializeManagedTree, publishManagedTree, type ArtifactFileDiff } from "./artifact-tree-storage";
+import { ArtifactPublicationPolicyError, diffManagedTrees, manifestEntry, materializeManagedTree, publishManagedTree, type ArtifactFileDiff, type PublicationPolicy } from "./artifact-tree-storage";
 import { publishArtifactOperationEvent } from "./artifact-operation-events";
 import { beginArtifactPublication, endArtifactPublication } from "./artifact-publication-registry";
 import { replaceArtifactFileIndex, replaceArtifactFileIndexInTransaction } from "../db/artifact-file-index";
@@ -14,6 +14,8 @@ import { parsePersistedArtifactOperation, type PersistedArtifactOperationRow } f
 type OperationKind = "patch" | "turn" | "restore" | "undo" | "external" | "initialize";
 type CoordinatorFaults = {
   readonly beforeSnapshot?: () => void;
+  readonly beforePublishRead?: (relativePath: string) => void | Promise<void>;
+  readonly beforePublishSourceRead?: (relativePath: string) => void | Promise<void>;
   readonly afterPublishWrite?: (relativePath: string) => void;
   readonly beforeDatabaseCommit?: () => void;
   readonly beforeFileIndex?: () => void;
@@ -31,6 +33,7 @@ type RunOperation = {
   readonly parentOperationId?: string;
   readonly expectedFileHash?: string;
   readonly nodeFingerprint?: string;
+  readonly publicationPolicy?: PublicationPolicy;
 };
 type PatchOperation = {
   readonly projectId: string;
@@ -133,19 +136,30 @@ export class ArtifactCoordinator {
       this.prepareResult(id, resultRevision, result, diff);
       beginArtifactPublication(input.projectId);
       publicationStarted = true;
-      await publishManagedTree(stagePath, input.projectDir, this.faults.afterPublishWrite);
+      await publishManagedTree(stagePath, input.projectDir, this.faults.afterPublishWrite, {
+        ...input.publicationPolicy,
+        beforeSourceOpen: this.faults.beforePublishRead,
+        beforeSourceRead: this.faults.beforePublishSourceRead,
+      });
       await validateCanonicalTree(input.projectDir, result);
       this.faults.beforeDatabaseCommit?.();
       this.commit(id, input.projectId, input.expectedRevision, base.tree_digest, resultRevision, result);
     } catch (error) {
+      const securityFailure = error instanceof ArtifactPublicationPolicyError ||
+        (error instanceof Error && "code" in error && error.code === "immutable_reference_escaped");
       try {
-        await publishManagedTree(snapshotPath, input.projectDir);
+        if (!securityFailure) await publishManagedTree(snapshotPath, input.projectDir);
         await validateCanonicalTree(input.projectDir, base);
       } finally {
         if (publicationStarted) endArtifactPublication(input.projectId);
       }
       this.terminal(id, "failed", null, null);
+      if (securityFailure) {
+        await rm(ownedRoot, { recursive: true, force: true });
+        this.pruneFailedSecurityOperation(id);
+      }
       publishArtifactOperationEvent(this.db, { projectId: input.projectId, operationId: id, revision: input.expectedRevision, digest: base.tree_digest, outcome: "failed", diff: [] });
+      if (securityFailure) throw new ArtifactOperationError("immutable_reference_escaped", "immutable_reference_escaped");
       if (error instanceof ArtifactOperationError) throw error;
       throw new ArtifactOperationError("operation_failed", error instanceof Error ? error.message : "Artifact operation failed");
     }
@@ -255,6 +269,11 @@ export class ArtifactCoordinator {
       this.faults.beforeFileIndex?.();
       replaceArtifactFileIndexInTransaction(this.db, projectId, result);
     })();
+  }
+
+  private pruneFailedSecurityOperation(id: string): void {
+    const now = Date.now();
+    this.db.prepare("UPDATE artifact_operations SET retention_json=json_set(retention_json,'$.replayable',json('false'),'$.retained_until',?,'$.pruned_at',?,'$.prune_reason','immutable_reference_escaped'),updated_at=? WHERE id=? AND status='failed'").run(now, now, now, id);
   }
 
   private terminal(id: string, status: "cancelled" | "failed" | "recovered", revision: number | null, digest: string | null): void {

--- a/packages/backend/src/services/artifact-tree-storage.ts
+++ b/packages/backend/src/services/artifact-tree-storage.ts
@@ -1,7 +1,9 @@
-import { mkdir, readFile, readdir, rename, rm, unlink, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { mkdir, open, readFile, readdir, rename, rm, unlink, writeFile, type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import type { CanonicalTreeEntry, CanonicalTreeManifest } from "./canonical-tree-manifest";
-import { inspectCanonicalTree, validateCanonicalTree } from "./canonical-tree-manifest";
+import { DEFAULT_CANONICAL_TREE_LIMITS, inspectCanonicalTree, validateCanonicalTree } from "./canonical-tree-manifest";
 
 export type ArtifactFileDiff = {
   readonly path: string;
@@ -11,6 +13,18 @@ export type ArtifactFileDiff = {
   readonly before_bytes: number;
   readonly after_bytes: number;
 };
+
+export type PublicationPolicy = {
+  readonly forbiddenSha256?: ReadonlySet<string>;
+  readonly beforeSourceOpen?: (relativePath: string) => void | Promise<void>;
+  readonly beforeSourceRead?: (relativePath: string) => void | Promise<void>;
+};
+
+export class ArtifactPublicationPolicyError extends Error {
+  readonly name = "ArtifactPublicationPolicyError";
+  readonly code = "immutable_reference_escaped" as const;
+  constructor() { super("immutable_reference_escaped"); }
+}
 
 export async function materializeManagedTree(source: string, destination: string): Promise<CanonicalTreeManifest> {
   const manifest = await inspectCanonicalTree(source);
@@ -33,14 +47,7 @@ export function diffManagedTrees(before: CanonicalTreeManifest, after: Canonical
     const previous = beforeByPath.get(filePath);
     const next = afterByPath.get(filePath);
     if (previous?.sha256 === next?.sha256 && previous?.size === next?.size) continue;
-    changes.push({
-      path: filePath,
-      action: previous === undefined ? "created" : next === undefined ? "deleted" : "edited",
-      before_hash: previous?.sha256 ?? null,
-      after_hash: next?.sha256 ?? null,
-      before_bytes: previous?.size ?? 0,
-      after_bytes: next?.size ?? 0,
-    });
+    changes.push({ path: filePath, action: previous === undefined ? "created" : next === undefined ? "deleted" : "edited", before_hash: previous?.sha256 ?? null, after_hash: next?.sha256 ?? null, before_bytes: previous?.size ?? 0, after_bytes: next?.size ?? 0 });
   }
   return changes;
 }
@@ -49,23 +56,69 @@ export async function publishManagedTree(
   source: string,
   destination: string,
   afterWrite?: (relativePath: string) => void,
+  policy: PublicationPolicy = {},
 ): Promise<CanonicalTreeManifest> {
   const sourceManifest = await inspectCanonicalTree(source);
-  const destinationManifest = await inspectCanonicalTree(destination);
-  const sourcePaths = new Set(sourceManifest.files.map((file) => file.path));
-  for (const file of [...destinationManifest.files].reverse()) {
-    if (!sourcePaths.has(file.path)) await unlink(path.join(destination, file.path));
-  }
-  for (const file of sourceManifest.files) {
-    const target = path.join(destination, file.path);
-    await mkdir(path.dirname(target), { recursive: true });
-    const temporary = path.join(path.dirname(target), `.${path.basename(target)}.${crypto.randomUUID()}.tmp`);
-    await writeFile(temporary, await readFile(path.join(source, file.path)));
-    await rename(temporary, target);
-    afterWrite?.(file.path);
+  const opened = await openPublicationSources(source, sourceManifest, policy);
+  try {
+    const destinationManifest = await inspectCanonicalTree(destination);
+    const sourcePaths = new Set(sourceManifest.files.map((file) => file.path));
+    for (const file of [...destinationManifest.files].reverse()) {
+      if (!sourcePaths.has(file.path)) await unlink(path.join(destination, file.path));
+    }
+    for (const candidate of opened) {
+      const target = path.join(destination, candidate.file.path);
+      await mkdir(path.dirname(target), { recursive: true });
+      const temporary = path.join(path.dirname(target), `.${path.basename(target)}.${crypto.randomUUID()}.tmp`);
+      await writeFile(temporary, candidate.bytes);
+      await rename(temporary, target);
+      afterWrite?.(candidate.file.path);
+    }
+  } finally {
+    await Promise.all(opened.map((candidate) => candidate.handle.close()));
   }
   await removeEmptyManagedDirectories(destination);
   return validateCanonicalTree(destination, sourceManifest);
+}
+
+async function openPublicationSources(
+  source: string,
+  manifest: CanonicalTreeManifest,
+  policy: PublicationPolicy,
+): Promise<readonly { readonly file: CanonicalTreeEntry; readonly handle: FileHandle; readonly bytes: Uint8Array }[]> {
+  const opened: { file: CanonicalTreeEntry; handle: FileHandle; bytes: Uint8Array }[] = [];
+  try {
+    for (const file of manifest.files) {
+      await policy.beforeSourceOpen?.(file.path);
+      const handle = await open(path.join(source, file.path), constants.O_RDONLY | constants.O_NOFOLLOW);
+      opened.push({ file, handle, bytes: new Uint8Array() });
+      const before = await handle.stat();
+      if (!before.isFile() || before.size !== file.size || before.size > DEFAULT_CANONICAL_TREE_LIMITS.bytes) throw new Error("Publication source identity changed");
+      await policy.beforeSourceRead?.(file.path);
+      const bytes = await readHandleBytes(handle, file.size);
+      const after = await handle.stat();
+      if (after.dev !== before.dev || after.ino !== before.ino || after.size !== before.size || bytes.byteLength !== file.size) throw new Error("Publication source identity changed");
+      const digest = createHash("sha256").update(bytes).digest("hex");
+      if (policy.forbiddenSha256?.has(digest)) throw new ArtifactPublicationPolicyError();
+      if (digest !== file.sha256) throw new Error("Publication source identity changed");
+      opened[opened.length - 1] = { file, handle, bytes };
+    }
+    return opened;
+  } catch (error) {
+    await Promise.all(opened.map((candidate) => candidate.handle.close()));
+    throw error;
+  }
+}
+
+async function readHandleBytes(handle: FileHandle, size: number): Promise<Uint8Array> {
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  while (offset < size) {
+    const { bytesRead } = await handle.read(bytes, offset, size - offset, offset);
+    if (bytesRead === 0) break;
+    offset += bytesRead;
+  }
+  return offset === size ? bytes : bytes.subarray(0, offset);
 }
 
 export function manifestEntry(manifest: CanonicalTreeManifest, relativePath: string): CanonicalTreeEntry | null {
@@ -82,9 +135,7 @@ async function removeEmptyManagedDirectories(root: string, current = root): Prom
 }
 
 function isExcluded(name: string): boolean {
-  return name === ".meta" || name === ".attachments" || name === ".git" || name === ".omc" || name === ".claude";
+  return name === ".meta" || name === ".attachments" || name === ".burnguard-inputs" || name === ".git" || name === ".omc" || name === ".claude";
 }
 
-function compareText(left: string, right: string): number {
-  return left < right ? -1 : left > right ? 1 : 0;
-}
+function compareText(left: string, right: string): number { return left < right ? -1 : left > right ? 1 : 0; }

--- a/packages/backend/src/services/attachment-request.ts
+++ b/packages/backend/src/services/attachment-request.ts
@@ -1,0 +1,55 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { UploadedVisualSourceSelection } from "@bg/shared";
+import { listSessionAttachments } from "../db/attachments";
+import { getAttachmentContext } from "../db/attachment-context";
+import { resolveWithin } from "../security/path-boundary";
+
+export class AttachmentRequestError extends Error {
+  readonly name = "AttachmentRequestError";
+  readonly code = "invalid_attachments";
+  constructor() { super("invalid_attachments"); }
+}
+
+export async function canonicalizeAttachmentRequest(input: {
+  readonly sessionId: string;
+  readonly requestedPaths: readonly string[];
+  readonly selections?: readonly UploadedVisualSourceSelection[];
+}): Promise<{ readonly paths: readonly string[]; readonly selections: readonly UploadedVisualSourceSelection[] }> {
+  if (new Set(input.requestedPaths).size !== input.requestedPaths.length) fail();
+  const context = getAttachmentContext(input.sessionId);
+  if (context === null) fail();
+  const rows = await listSessionAttachments(input.sessionId);
+  const attachmentsDir = resolveWithin(context.project_dir, ".attachments");
+  const selected: typeof rows = [];
+  for (const requestedPath of input.requestedPaths) {
+    if (/\r|\n|\0/u.test(requestedPath) || /^https?:\/\//iu.test(requestedPath)) fail();
+    const row = rows.find((candidate) => candidate.file_path === requestedPath);
+    if (row === undefined || row.turn_id !== null || row.sha256 === null) fail();
+    try {
+      const canonical = resolveWithin(attachmentsDir, path.basename(row.file_path));
+      if (canonical !== row.file_path || path.dirname(canonical) !== attachmentsDir) fail();
+      const bytes = await readFile(canonical);
+      if (bytes.byteLength !== row.size_bytes || createHash("sha256").update(bytes).digest("hex") !== row.sha256) fail();
+    } catch (error) {
+      if (error instanceof AttachmentRequestError) throw error;
+      fail();
+    }
+    selected.push(row);
+  }
+  const explicit = input.selections ?? [];
+  if (explicit.length > 0) {
+    if (explicit.length !== selected.length || new Set(explicit.map((item) => item.attachment_path)).size !== explicit.length) fail();
+    for (const row of selected) {
+      const selection = explicit.find((item) => item.attachment_path === row.file_path);
+      if (selection === undefined || selection.role !== row.source_role) fail();
+    }
+  }
+  return {
+    paths: selected.map((row) => row.file_path),
+    selections: selected.map((row) => ({ source_type: "uploaded_attachment", attachment_path: row.file_path, role: row.source_role })),
+  };
+}
+
+function fail(): never { throw new AttachmentRequestError(); }

--- a/packages/backend/src/services/attachments.ts
+++ b/packages/backend/src/services/attachments.ts
@@ -6,9 +6,24 @@ import { assertSafeName, resolveWithin } from "../security/path-boundary";
 import { inferUploadKind } from "./upload-kind";
 export { attachmentExtractedTextPath, attachmentSummaryPath } from "./attachment-paths";
 
-const MAX_ATTACHMENT_COUNT = 8;
-const MAX_ATTACHMENT_BYTES_PER_FILE = 10 * 1024 * 1024;
-const MAX_ATTACHMENT_BYTES_TOTAL = 25 * 1024 * 1024;
+/** Authoritative intake limits. The composer mirrors these for early feedback only. */
+export const ATTACHMENT_LIMITS = {
+  maxCount: 8,
+  maxBytesPerFile: 10 * 1024 * 1024,
+  maxBytesTotal: 25 * 1024 * 1024,
+} as const;
+
+/** Raised when an upload's kind is one `inferUploadKind` cannot resolve to an extractor. */
+export class UnsupportedAttachmentKindError extends Error {
+  readonly name = "UnsupportedAttachmentKindError";
+  readonly code = "unsupported_file_kind";
+  readonly fileNames: readonly string[];
+
+  constructor(fileNames: readonly string[]) {
+    super(`unsupported_file_kind:${fileNames.join(",")}`);
+    this.fileNames = fileNames;
+  }
+}
 
 export async function saveSessionAttachments(sessionId: string, files: File[]) {
   const context = getAttachmentContext(sessionId);
@@ -16,14 +31,21 @@ export async function saveSessionAttachments(sessionId: string, files: File[]) {
     throw new Error("session_not_found");
   }
 
-  if (files.length > MAX_ATTACHMENT_COUNT) {
-    throw new Error(`attachment_limit_exceeded:${MAX_ATTACHMENT_COUNT}`);
+  if (files.length > ATTACHMENT_LIMITS.maxCount) {
+    throw new Error(`attachment_limit_exceeded:${ATTACHMENT_LIMITS.maxCount}`);
   }
 
   const totalBytes = files.reduce((total, file) => total + file.size, 0);
-  const oversized = files.find((file) => file.size > MAX_ATTACHMENT_BYTES_PER_FILE);
-  if (oversized !== undefined) throw new Error(`attachment_too_large:${oversized.name || "attachment"}:${MAX_ATTACHMENT_BYTES_PER_FILE}`);
-  if (totalBytes > MAX_ATTACHMENT_BYTES_TOTAL) throw new Error(`attachment_total_too_large:${MAX_ATTACHMENT_BYTES_TOTAL}`);
+  const oversized = files.find((file) => file.size > ATTACHMENT_LIMITS.maxBytesPerFile);
+  if (oversized !== undefined) throw new Error(`attachment_too_large:${oversized.name || "attachment"}:${ATTACHMENT_LIMITS.maxBytesPerFile}`);
+  if (totalBytes > ATTACHMENT_LIMITS.maxBytesTotal) throw new Error(`attachment_total_too_large:${ATTACHMENT_LIMITS.maxBytesTotal}`);
+
+  // Kind gate runs before any write so a batch containing a source the
+  // extractor cannot process persists nothing at all.
+  const unsupported = files.filter((file) => inferUploadKind(file.name || "attachment", file.type) === null);
+  if (unsupported.length > 0) {
+    throw new UnsupportedAttachmentKindError(unsupported.map((file) => file.name || "attachment"));
+  }
 
   const attachmentsDir = resolveWithin(context.project_dir, ".attachments");
   await mkdir(attachmentsDir, { recursive: true });
@@ -41,21 +63,18 @@ export async function saveSessionAttachments(sessionId: string, files: File[]) {
     const sha256 = createHash("sha256").update(buffer).digest("hex");
 
     await writeFile(absolutePath, buffer);
-    const uploadKind = inferUploadKind(file.name || storedName, file.type);
-    if (uploadKind) {
-      const manifestPath = resolveWithin(
-        context.project_dir,
-        ".attachments",
-        assertSafeName(`${storedName}.summary.json`),
-      );
-      const extractedTextPath = resolveWithin(
-        context.project_dir,
-        ".attachments",
-        assertSafeName(`${storedName}.extracted.md`),
-      );
-      const { extractAttachmentUpload } = await import("./attachment-extraction");
-      await extractAttachmentUpload({ sourcePath: absolutePath, manifestPath, extractedTextPath, originalName: file.name || storedName });
-    }
+    const manifestPath = resolveWithin(
+      context.project_dir,
+      ".attachments",
+      assertSafeName(`${storedName}.summary.json`),
+    );
+    const extractedTextPath = resolveWithin(
+      context.project_dir,
+      ".attachments",
+      assertSafeName(`${storedName}.extracted.md`),
+    );
+    const { extractAttachmentUpload } = await import("./attachment-extraction");
+    await extractAttachmentUpload({ sourcePath: absolutePath, manifestPath, extractedTextPath, originalName: file.name || storedName });
 
     insertAttachmentRecord({
       sessionId,

--- a/packages/backend/src/services/attachments.ts
+++ b/packages/backend/src/services/attachments.ts
@@ -1,10 +1,13 @@
 import { createHash } from "node:crypto";
-import { mkdir, writeFile } from "node:fs/promises";
+import type { VisualSourceRole } from "@bg/shared";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { ulid } from "ulid";
 import { getAttachmentContext, insertAttachmentRecord } from "../db/attachment-context";
+import { getSqlite } from "../db/sqlite-client";
 import { assertSafeName, resolveWithin } from "../security/path-boundary";
 import { inferUploadKind } from "./upload-kind";
-export { attachmentExtractedTextPath, attachmentSummaryPath } from "./attachment-paths";
+import { attachmentExtractedTextPath, attachmentSummaryPath } from "./attachment-paths";
+export { attachmentExtractedTextPath, attachmentSummaryPath };
 
 /** Authoritative intake limits. The composer mirrors these for early feedback only. */
 export const ATTACHMENT_LIMITS = {
@@ -25,7 +28,14 @@ export class UnsupportedAttachmentKindError extends Error {
   }
 }
 
-export async function saveSessionAttachments(sessionId: string, files: File[]) {
+export type AttachmentUpload = File | {
+  readonly file: File;
+  readonly role: VisualSourceRole;
+  readonly roleExplicit?: boolean;
+};
+
+export async function saveSessionAttachments(sessionId: string, uploads: readonly AttachmentUpload[]) {
+  const files = uploads.map((upload) => upload instanceof File ? upload : upload.file);
   const context = getAttachmentContext(sessionId);
   if (!context) {
     throw new Error("session_not_found");
@@ -50,44 +60,68 @@ export async function saveSessionAttachments(sessionId: string, files: File[]) {
   const attachmentsDir = resolveWithin(context.project_dir, ".attachments");
   await mkdir(attachmentsDir, { recursive: true });
   const records: string[] = [];
+  const writtenPaths: string[] = [];
 
-  for (const file of files) {
-    const base = sanitize(file.name || "attachment");
-    const storedName = assertSafeName(`${ulid()}-${base}`);
-    const absolutePath = resolveWithin(
-      context.project_dir,
-      ".attachments",
-      storedName,
-    );
-    const buffer = Buffer.from(await file.arrayBuffer());
-    const sha256 = createHash("sha256").update(buffer).digest("hex");
+  try {
+    for (const [index, file] of files.entries()) {
+      const upload = uploads[index];
+      const sourceRole = upload instanceof File ? "ordinary_content" : upload.role;
+      const sourceRoleExplicit = upload instanceof File ? false : upload.roleExplicit ?? true;
+      const base = sanitize(file.name || "attachment");
+      const storedName = assertSafeName(`${ulid()}-${base}`);
+      const absolutePath = resolveWithin(
+        context.project_dir,
+        ".attachments",
+        storedName,
+      );
+      const buffer = Buffer.from(await file.arrayBuffer());
+      const sha256 = createHash("sha256").update(buffer).digest("hex");
 
-    await writeFile(absolutePath, buffer);
-    const manifestPath = resolveWithin(
-      context.project_dir,
-      ".attachments",
-      assertSafeName(`${storedName}.summary.json`),
-    );
-    const extractedTextPath = resolveWithin(
-      context.project_dir,
-      ".attachments",
-      assertSafeName(`${storedName}.extracted.md`),
-    );
-    const { extractAttachmentUpload } = await import("./attachment-extraction");
-    await extractAttachmentUpload({ sourcePath: absolutePath, manifestPath, extractedTextPath, originalName: file.name || storedName });
+      await writeFile(absolutePath, buffer);
+      writtenPaths.push(absolutePath);
+      const manifestPath = resolveWithin(
+        context.project_dir,
+        ".attachments",
+        assertSafeName(`${storedName}.summary.json`),
+      );
+      const extractedTextPath = resolveWithin(
+        context.project_dir,
+        ".attachments",
+        assertSafeName(`${storedName}.extracted.md`),
+      );
+      const { extractAttachmentUpload } = await import("./attachment-extraction");
+      await extractAttachmentUpload({ sourcePath: absolutePath, manifestPath, extractedTextPath, originalName: file.name || storedName });
 
-    insertAttachmentRecord({
-      sessionId,
-      filePath: absolutePath,
-      mimeType: file.type || "application/octet-stream",
-      originalName: file.name || storedName,
-      sizeBytes: buffer.byteLength,
-      sha256,
-    });
-    records.push(absolutePath);
+      insertAttachmentRecord({
+        sessionId,
+        filePath: absolutePath,
+        mimeType: file.type || "application/octet-stream",
+        originalName: file.name || storedName,
+        sizeBytes: buffer.byteLength,
+        sha256,
+        sourceRole,
+        sourceRoleExplicit,
+      });
+      records.push(absolutePath);
+    }
+  } catch (error) {
+    await rollbackSessionAttachments(sessionId, writtenPaths);
+    throw error;
   }
 
   return records;
+}
+
+export async function rollbackSessionAttachments(sessionId: string, filePaths: readonly string[]): Promise<void> {
+  const db = getSqlite();
+  db.transaction(() => {
+    for (const filePath of filePaths) db.prepare("DELETE FROM attachments WHERE session_id=? AND file_path=? AND turn_id IS NULL").run(sessionId, filePath);
+  })();
+  await Promise.all(filePaths.flatMap((filePath) => [
+    rm(filePath, { force: true }),
+    rm(attachmentSummaryPath(filePath), { force: true }),
+    rm(attachmentExtractedTextPath(filePath), { force: true }),
+  ]));
 }
 
 function sanitize(value: string) {

--- a/packages/backend/src/services/canonical-tree-manifest.ts
+++ b/packages/backend/src/services/canonical-tree-manifest.ts
@@ -5,7 +5,7 @@ import { PathBoundaryError, resolveWithin } from "../security/path-boundary";
 
 const SHA256 = /^[0-9a-f]{64}$/;
 const OWNED_EPHEMERAL_FILES = new Set([".burnguard-publication", ".burnguard-catalog"]);
-const EXCLUDED_PROJECT_DIRECTORIES = new Set([".meta", ".attachments", ".git", ".omc", ".claude"]);
+const EXCLUDED_PROJECT_DIRECTORIES = new Set([".meta", ".attachments", ".burnguard-inputs", ".git", ".omc", ".claude"]);
 
 export type CanonicalTreeEntry = {
   readonly path: string;

--- a/packages/backend/src/services/checkpoints.ts
+++ b/packages/backend/src/services/checkpoints.ts
@@ -9,7 +9,7 @@ import { getSqlite } from "../db/sqlite-client";
 import { ArtifactCoordinator } from "./artifact-coordinator";
 import { materializeManagedTree } from "./artifact-tree-storage";
 
-const EXCLUDED_DIR_NAMES = new Set([".meta", ".attachments"]);
+const EXCLUDED_DIR_NAMES = new Set([".meta", ".attachments", ".burnguard-inputs"]);
 
 function snapshotDir(projectDir: string, turnId: string): string {
   return resolveWithin(

--- a/packages/backend/src/services/context.ts
+++ b/packages/backend/src/services/context.ts
@@ -3,6 +3,7 @@ import { listProjectComments } from "../db/comments";
 import { getSessionProject } from "../db/events";
 import { getDesignSystemDetail } from "../db/seed";
 import { indexProjectFiles, listIndexedProjectFiles } from "./files";
+import { getLatestDirectionState } from "./design-direction-state";
 
 export async function buildSessionContext(sessionId: string) {
   const project = await getSessionProject(sessionId);
@@ -12,13 +13,14 @@ export async function buildSessionContext(sessionId: string) {
 
   await indexProjectFiles(project.project_id);
 
-  const [designSystem, files, attachments, comments] = await Promise.all([
+  const [designSystem, files, attachments, comments, designDirectionState] = await Promise.all([
     project.design_system_id
       ? getDesignSystemDetail(project.design_system_id)
       : Promise.resolve(null),
     listIndexedProjectFiles(project.project_id),
     listSessionAttachments(sessionId),
     listProjectComments(project.project_id),
+    getLatestDirectionState(sessionId),
   ]);
 
   return {
@@ -27,6 +29,7 @@ export async function buildSessionContext(sessionId: string) {
     files,
     attachments,
     openComments: comments.filter((c) => c.resolved_at === null),
+    designDirectionState,
   };
 }
 

--- a/packages/backend/src/services/design-audit-dom.ts
+++ b/packages/backend/src/services/design-audit-dom.ts
@@ -1,0 +1,78 @@
+import type { Page } from "playwright-core";
+import type { DesignAuditCheckCode, DesignAuditSeverity, DesignAuditTargetedAction, DesignAuditUnknownReason } from "@bg/shared";
+
+export type DomAuditFinding = { readonly code: DesignAuditCheckCode; readonly severity: DesignAuditSeverity; readonly nodeId: string | null; readonly evidence: string; readonly measured?: number; readonly threshold?: number; readonly action: DesignAuditTargetedAction };
+export type DomAuditObservation = { readonly findings: readonly DomAuditFinding[]; readonly measurable: Readonly<Record<DesignAuditCheckCode, boolean>>; readonly unknownReasons: Readonly<Partial<Record<DesignAuditCheckCode, DesignAuditUnknownReason>>> };
+
+export async function inspectRenderedPage(page: Page): Promise<DomAuditObservation> {
+  await page.evaluate(async () => {
+    const pending = [...document.images].filter((image) => !image.complete);
+    await Promise.all(pending.map((image) => new Promise<void>((resolve) => {
+      const done = (): void => resolve();
+      image.addEventListener("load", done, { once: true }); image.addEventListener("error", done, { once: true });
+    })));
+  });
+  return page.evaluate(() => {
+    type Code = "text_overflow" | "element_overlap" | "minimum_text_size" | "contrast" | "narrow_width" | "duplicate_node_id" | "missing_image" | "token_usage";
+    type Severity = "must_fix" | "recommended";
+    type Action = "expand_or_reflow_text" | "separate_overlapping_elements" | "set_minimum_font_size" | "increase_color_contrast" | "repair_narrow_layout" | "assign_unique_node_ids" | "restore_image_reference" | "replace_literal_with_token";
+    type Reason = "no_measurable_candidates" | "unresolvable_rendering" | "tokens_not_exposed";
+    type Finding = { code: Code; severity: Severity; nodeId: string | null; evidence: string; measured?: number; threshold?: number; action: Action };
+    const findings: Finding[] = [];
+    const measurable: Record<Code, boolean> = { text_overflow: false, element_overlap: false, minimum_text_size: false, contrast: false, narrow_width: true, duplicate_node_id: true, missing_image: true, token_usage: false };
+    const unknownReasons: Partial<Record<Code, Reason>> = { text_overflow: "no_measurable_candidates", element_overlap: "no_measurable_candidates", minimum_text_size: "no_measurable_candidates", contrast: "no_measurable_candidates", token_usage: "tokens_not_exposed" };
+    const elements = [...document.querySelectorAll<HTMLElement>("body *")];
+    const visible = (element: HTMLElement): boolean => { const style = getComputedStyle(element); const rect = element.getBoundingClientRect(); return style.display !== "none" && style.visibility !== "hidden" && Number(style.opacity) > 0 && rect.width > 0 && rect.height > 0; };
+    const textBearing = (element: HTMLElement): boolean => visible(element) && [...element.childNodes].some((node) => node.nodeType === Node.TEXT_NODE && (node.textContent?.trim().length ?? 0) > 0);
+    const loadBearing = (element: HTMLElement): boolean => textBearing(element) || element instanceof HTMLImageElement || element.matches("button,a,input,select,textarea,[role=button]");
+    const id = (element: Element): string | null => element.getAttribute("data-bg-node-id");
+    const push = (element: Element | null, finding: Omit<Finding, "nodeId">): void => { findings.push({ ...finding, nodeId: element === null ? null : id(element), evidence: finding.evidence.slice(0, 500) }); };
+
+    const textElements = elements.filter(textBearing);
+    measurable.text_overflow = textElements.length > 0;
+    measurable.minimum_text_size = textElements.length > 0;
+    if (textElements.length > 0) { delete unknownReasons.text_overflow; delete unknownReasons.minimum_text_size; }
+    for (const element of textElements) {
+      const rect = element.getBoundingClientRect();
+      const canvas = element.closest<HTMLElement>("[data-slide]")?.getBoundingClientRect(); const bounds = canvas ?? { left: 0, right: document.documentElement.clientWidth, top: 0, bottom: document.documentElement.clientHeight };
+      if (element.scrollWidth > element.clientWidth + 1 || element.scrollHeight > element.clientHeight + 1 || rect.left < bounds.left - 1 || rect.right > bounds.right + 1 || rect.top < bounds.top - 1 || rect.bottom > bounds.bottom + 1) push(element, { code: "text_overflow", severity: "must_fix", evidence: `Text geometry ${Math.round(element.scrollWidth)}x${Math.round(element.scrollHeight)} exceeds ${Math.round(element.clientWidth)}x${Math.round(element.clientHeight)}`, action: "expand_or_reflow_text" });
+      const size = Number.parseFloat(getComputedStyle(element).fontSize);
+      if (Number.isFinite(size) && size < 12) push(element, { code: "minimum_text_size", severity: "recommended", evidence: `Rendered font size is ${size}px; minimum is 12px`, action: "set_minimum_font_size", measured: size, threshold: 12 });
+    }
+
+    const counts = new Map<string, number>();
+    for (const element of elements) { const nodeId = id(element); if (nodeId !== null) counts.set(nodeId, (counts.get(nodeId) ?? 0) + 1); }
+    for (const [nodeId, count] of [...counts].sort(([left], [right]) => left.localeCompare(right))) if (count > 1) push(document.querySelector(`[data-bg-node-id="${CSS.escape(nodeId)}"]`), { code: "duplicate_node_id", severity: "must_fix", evidence: `data-bg-node-id ${nodeId} occurs ${count} times`, action: "assign_unique_node_ids", measured: count, threshold: 1 });
+
+    const positioned = elements.filter((element) => visible(element) && loadBearing(element) && getComputedStyle(element).position !== "static" && id(element) !== null && counts.get(id(element) ?? "") === 1);
+    measurable.element_overlap = false;
+    for (let leftIndex = 0; leftIndex < positioned.length; leftIndex += 1) for (let rightIndex = leftIndex + 1; rightIndex < positioned.length; rightIndex += 1) {
+      const left = positioned[leftIndex]; const right = positioned[rightIndex];
+      if (left === undefined || right === undefined || left.parentElement !== right.parentElement) continue;
+      measurable.element_overlap = true; delete unknownReasons.element_overlap;
+      const a = left.getBoundingClientRect(); const b = right.getBoundingClientRect(); const width = Math.min(a.right, b.right) - Math.max(a.left, b.left); const height = Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top);
+      if (width > 1 && height > 1) push(left, { code: "element_overlap", severity: "recommended", evidence: `Overlaps sibling ${id(right) ?? "unknown"} by ${Math.round(width * height)}px2`, action: "separate_overlapping_elements", measured: Math.round(width * height), threshold: 0 });
+    }
+
+    const parseColor = (value: string): readonly [number, number, number, number] | null => { const match = value.match(/^rgba?\(\s*([\d.]+)[, ]+([\d.]+)[, ]+([\d.]+)(?:\s*[,/]\s*([\d.]+))?\s*\)$/u); return match?.[1] === undefined || match[2] === undefined || match[3] === undefined ? null : [Number(match[1]), Number(match[2]), Number(match[3]), match[4] === undefined ? 1 : Number(match[4])]; };
+    const luminance = (color: readonly [number, number, number, number]): number => { const channels = color.slice(0, 3).map((part) => { const value = part / 255; return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4; }); return 0.2126 * (channels[0] ?? 0) + 0.7152 * (channels[1] ?? 0) + 0.0722 * (channels[2] ?? 0); };
+    let contrastUnresolved = false;
+    for (const element of textElements) {
+      const style = getComputedStyle(element); const foreground = parseColor(style.color); let current: HTMLElement | null = element; let background: readonly [number, number, number, number] | null = null;
+      while (current !== null && background === null) { const currentStyle = getComputedStyle(current); if (currentStyle.backgroundImage !== "none") { contrastUnresolved = true; break; } const parsed = parseColor(currentStyle.backgroundColor); if (parsed !== null && parsed[3] > 0 && parsed[3] < 1) { contrastUnresolved = true; break; } if (parsed !== null && parsed[3] === 1) background = parsed; current = current.parentElement; }
+      if (foreground === null || foreground[3] !== 1 || background === null) { contrastUnresolved = true; continue; }
+      measurable.contrast = true; const first = luminance(foreground); const second = luminance(background); const ratio = (Math.max(first, second) + 0.05) / (Math.min(first, second) + 0.05); const size = Number.parseFloat(style.fontSize); const weight = Number.parseInt(style.fontWeight, 10); const threshold = size >= 24 || (size >= 18.66 && weight >= 700) ? 3 : 4.5;
+      if (ratio < threshold) push(element, { code: "contrast", severity: "must_fix", evidence: `Contrast ratio ${ratio.toFixed(2)} is below ${threshold.toFixed(1)}`, action: "increase_color_contrast", measured: Number(ratio.toFixed(2)), threshold });
+    }
+    if (contrastUnresolved) { measurable.contrast = false; unknownReasons.contrast = "unresolvable_rendering"; } else if (measurable.contrast) delete unknownReasons.contrast;
+
+    const viewport = document.documentElement.clientWidth; const overflow = Math.max(document.documentElement.scrollWidth, document.body.scrollWidth) - viewport;
+    if (viewport <= 375 && overflow > 1) push(null, { code: "narrow_width", severity: "must_fix", evidence: `Document exceeds narrow viewport by ${Math.round(overflow)}px`, action: "repair_narrow_layout", measured: Math.round(overflow), threshold: 0 });
+    if (viewport <= 375) for (const element of elements.filter((candidate) => visible(candidate) && loadBearing(candidate))) { const rect = element.getBoundingClientRect(); if (rect.left < -1 || rect.right > viewport + 1) push(element, { code: "narrow_width", severity: "must_fix", evidence: `Element escapes 375px viewport at ${Math.round(rect.left)}..${Math.round(rect.right)}`, action: "repair_narrow_layout" }); }
+
+    for (const image of document.images) if (!image.complete || image.naturalWidth === 0 || image.currentSrc.length === 0) { const raw = image.getAttribute("src") ?? "missing src"; let safe = raw; try { const url = new URL(raw, location.href); safe = url.protocol === "file:" ? raw : `${url.protocol}//${url.host}${url.pathname}`; } catch { safe = "invalid image reference"; } push(image, { code: "missing_image", severity: "must_fix", evidence: `Image reference failed: ${safe}`, action: "restore_image_reference" }); }
+    const rootStyle = getComputedStyle(document.documentElement); measurable.token_usage = [...rootStyle].some((name) => name.startsWith("--")); if (measurable.token_usage) delete unknownReasons.token_usage;
+    if (measurable.token_usage) for (const element of elements) { const inline = element.getAttribute("style") ?? ""; const match = inline.match(/(?:^|;)\s*(?:color|background(?:-color)?|border(?:-[\w-]+)?-color)\s*:\s*(#[0-9a-f]{3,8}|rgba?\([^;]+\)|hsla?\([^;]+\))/iu); if (match?.[1] !== undefined) push(element, { code: "token_usage", severity: "recommended", evidence: `Inline literal color ${match[1]} bypasses exposed design tokens`, action: "replace_literal_with_token" }); }
+    return { findings, measurable, unknownReasons };
+  });
+}

--- a/packages/backend/src/services/design-audit.ts
+++ b/packages/backend/src/services/design-audit.ts
@@ -9,8 +9,9 @@ import { CanonicalTreeManifestError, inspectCanonicalTree, type CanonicalTreeMan
 import { inspectRenderedPage, type DomAuditFinding, type DomAuditObservation } from "./design-audit-dom";
 import { fingerprintHtmlNode, FilePatchError } from "./file-patch";
 import { openRenderSession, RenderSessionError } from "./export-render-session";
+import { parseStoredProjectOptions } from "./project-options";
 
-export type AuditRenderedTreeInput = { readonly projectId: string; readonly projectDir: string; readonly entrypoint: string; readonly revision: number; readonly digest: string; readonly treeDigest?: string; readonly safeFix?: boolean; readonly deck?: boolean; readonly signal: AbortSignal };
+export type AuditRenderedTreeInput = { readonly projectId: string; readonly projectDir: string; readonly entrypoint: string; readonly revision: number; readonly digest: string; readonly treeDigest?: string; readonly safeFix?: boolean; readonly deck?: boolean; readonly canvas?: { readonly width: number; readonly height: number }; readonly signal: AbortSignal };
 export class DesignAuditServiceError extends Error {
   readonly name = "DesignAuditServiceError";
   constructor(readonly code: "project_not_found" | "project_path_unavailable" | "stale_artifact_identity" | "audit_unavailable", message: string) { super(message); }
@@ -21,13 +22,16 @@ export async function auditRenderedTree(input: AuditRenderedTreeInput): Promise<
   const expectedTreeDigest = input.treeDigest ?? input.digest;
   if (manifest.tree_digest !== expectedTreeDigest) throw new DesignAuditServiceError("stale_artifact_identity", "Artifact identity changed before audit");
   const observations: DomAuditObservation[] = [];
-  for (const viewport of [{ width: 1280, height: 900, dpr: 1 }, { width: 375, height: 812, dpr: 1 }] as const) {
+  const viewports = input.canvas === undefined
+    ? [{ width: 1280, height: 900, dpr: 1 }, { width: 375, height: 812, dpr: 1 }] as const
+    : [{ width: input.canvas.width, height: input.canvas.height, dpr: 1 }] as const;
+  for (const viewport of viewports) {
     const session = await openRenderSession({ stagedDir: input.projectDir, entrypoint: input.entrypoint, viewport, deck: input.deck ?? false, strict: false, signal: input.signal });
     try { observations.push(await inspectRenderedPage(session.page)); } finally { await session.close(); }
   }
   const current = await inspectCanonicalTree(input.projectDir);
   if (current.tree_digest !== expectedTreeDigest) throw new DesignAuditServiceError("stale_artifact_identity", "Artifact identity changed during audit");
-  const desktop = observations[0]; const narrow = observations[1];
+  const desktop = observations[0]; const narrow = observations[1] ?? desktop;
   if (desktop === undefined || narrow === undefined) throw new DesignAuditServiceError("audit_unavailable", "Rendered audit observations are unavailable");
   const desktopFindings = desktop.findings.filter((finding) => finding.code !== "narrow_width"); const desktopKeys = new Set(desktopFindings.map((finding) => `${finding.code}:${finding.nodeId ?? ""}`));
   const directNarrow = narrow.findings.filter((finding) => finding.code === "narrow_width"); const directNarrowNodes = new Set(directNarrow.flatMap((finding) => finding.nodeId === null ? [] : [finding.nodeId]));
@@ -57,7 +61,10 @@ export async function getProjectDesignAudit(projectId: string, force = false, si
     if (cached !== null && cached.project_id === projectId && cached.artifact_revision === project.current_revision && cached.artifact_digest === project.current_digest) return cached;
   }
   let result: DesignAuditResult;
-  try { result = await auditRenderedTree({ projectId, projectDir, entrypoint: project.entrypoint, revision: project.current_revision, digest: project.current_digest, deck: project.type === "slide_deck", signal }); }
+  const graphicCanvas = project.type === "graphic"
+    ? parseStoredProjectOptions(project.options_json).graphic_canvas ?? undefined
+    : undefined;
+  try { result = await auditRenderedTree({ projectId, projectDir, entrypoint: project.entrypoint, revision: project.current_revision, digest: project.current_digest, deck: project.type === "slide_deck", ...(graphicCanvas === undefined ? {} : { canvas: graphicCanvas }), signal }); }
   catch (error) { if (error instanceof RenderSessionError || error instanceof CanonicalTreeManifestError) throw new DesignAuditServiceError("audit_unavailable", "Rendered audit is unavailable"); throw error; }
   const after = await getProjectDetail(projectId);
   if (after === null || after.current_revision !== result.artifact_revision || after.current_digest !== result.artifact_digest) throw new DesignAuditServiceError("stale_artifact_identity", "Artifact identity changed during audit");

--- a/packages/backend/src/services/design-audit.ts
+++ b/packages/backend/src/services/design-audit.ts
@@ -1,0 +1,98 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { DESIGN_AUDIT_CHECK_CODES, DesignAuditContractError, parseDesignAuditResult, type DesignAuditCheck, type DesignAuditCheckCode, type DesignAuditFinding, type DesignAuditResult } from "@bg/shared";
+import { getProjectDetail } from "../db/project-read-repository";
+import { projectsDir, resolveManagedPath } from "../lib/paths";
+import { PathBoundaryError, resolveWithin } from "../security/path-boundary";
+import { CanonicalTreeManifestError, inspectCanonicalTree, type CanonicalTreeManifest } from "./canonical-tree-manifest";
+import { inspectRenderedPage, type DomAuditFinding, type DomAuditObservation } from "./design-audit-dom";
+import { fingerprintHtmlNode, FilePatchError } from "./file-patch";
+import { openRenderSession, RenderSessionError } from "./export-render-session";
+
+export type AuditRenderedTreeInput = { readonly projectId: string; readonly projectDir: string; readonly entrypoint: string; readonly revision: number; readonly digest: string; readonly treeDigest?: string; readonly safeFix?: boolean; readonly deck?: boolean; readonly signal: AbortSignal };
+export class DesignAuditServiceError extends Error {
+  readonly name = "DesignAuditServiceError";
+  constructor(readonly code: "project_not_found" | "project_path_unavailable" | "stale_artifact_identity" | "audit_unavailable", message: string) { super(message); }
+}
+
+export async function auditRenderedTree(input: AuditRenderedTreeInput): Promise<DesignAuditResult> {
+  const manifest = await inspectCanonicalTree(input.projectDir);
+  const expectedTreeDigest = input.treeDigest ?? input.digest;
+  if (manifest.tree_digest !== expectedTreeDigest) throw new DesignAuditServiceError("stale_artifact_identity", "Artifact identity changed before audit");
+  const observations: DomAuditObservation[] = [];
+  for (const viewport of [{ width: 1280, height: 900, dpr: 1 }, { width: 375, height: 812, dpr: 1 }] as const) {
+    const session = await openRenderSession({ stagedDir: input.projectDir, entrypoint: input.entrypoint, viewport, deck: input.deck ?? false, strict: false, signal: input.signal });
+    try { observations.push(await inspectRenderedPage(session.page)); } finally { await session.close(); }
+  }
+  const current = await inspectCanonicalTree(input.projectDir);
+  if (current.tree_digest !== expectedTreeDigest) throw new DesignAuditServiceError("stale_artifact_identity", "Artifact identity changed during audit");
+  const desktop = observations[0]; const narrow = observations[1];
+  if (desktop === undefined || narrow === undefined) throw new DesignAuditServiceError("audit_unavailable", "Rendered audit observations are unavailable");
+  const desktopFindings = desktop.findings.filter((finding) => finding.code !== "narrow_width"); const desktopKeys = new Set(desktopFindings.map((finding) => `${finding.code}:${finding.nodeId ?? ""}`));
+  const directNarrow = narrow.findings.filter((finding) => finding.code === "narrow_width"); const directNarrowNodes = new Set(directNarrow.flatMap((finding) => finding.nodeId === null ? [] : [finding.nodeId]));
+  const narrowDerived = narrow.findings.filter((finding) => (finding.code === "text_overflow" || finding.code === "element_overlap") && !desktopKeys.has(`${finding.code}:${finding.nodeId ?? ""}`) && (finding.nodeId === null || !directNarrowNodes.has(finding.nodeId))).map((finding): DomAuditFinding => ({ ...finding, code: "narrow_width", severity: "must_fix", action: "repair_narrow_layout", evidence: `Narrow viewport: ${finding.evidence}` }));
+  const raw = [...desktopFindings, ...directNarrow, ...narrowDerived];
+  const findings = await enrichFindings(raw.slice(0, 200), input, manifest);
+  const checks = DESIGN_AUDIT_CHECK_CODES.map((code) => buildCheck(code, findings, code === "narrow_width" ? narrow : desktop));
+  const overall = findings.some((finding) => finding.severity === "must_fix") ? "must_fix" : checks.every((check) => check.status === "pass") ? "ready" : "recommended";
+  return parseDesignAuditResult({ schema_version: 1, project_id: input.projectId, artifact_revision: input.revision, artifact_digest: input.digest, created_at: Date.now(), overall_status: overall, checks });
+}
+
+export async function getProjectDesignAudit(projectId: string, force = false, signal: AbortSignal = new AbortController().signal): Promise<DesignAuditResult> {
+  const project = await getProjectDetail(projectId);
+  if (project === null) throw new DesignAuditServiceError("project_not_found", "Project not found");
+  let projectDir: string;
+  try { projectDir = resolveManagedPath(projectsDir, project.dir_path); }
+  catch (error) { if (error instanceof PathBoundaryError) throw new DesignAuditServiceError("project_path_unavailable", "Project directory is outside managed storage"); throw error; }
+  let manifest: CanonicalTreeManifest;
+  try { manifest = await inspectCanonicalTree(projectDir); }
+  catch (error) { if (error instanceof CanonicalTreeManifestError) throw new DesignAuditServiceError("project_path_unavailable", "Project tree is unavailable for audit"); throw error; }
+  if (project.current_digest === null || project.current_revision < 0 || manifest.tree_digest !== project.current_digest) throw new DesignAuditServiceError("stale_artifact_identity", "Current artifact identity is unavailable or stale");
+  let cachePath: string;
+  try { cachePath = resolveWithin(projectDir, ".meta", "audits", `${project.current_revision}-${project.current_digest}.json`); }
+  catch (error) { if (error instanceof PathBoundaryError) throw new DesignAuditServiceError("project_path_unavailable", "Project audit cache is outside managed storage"); throw error; }
+  if (!force) {
+    const cached = await readCache(cachePath);
+    if (cached !== null && cached.project_id === projectId && cached.artifact_revision === project.current_revision && cached.artifact_digest === project.current_digest) return cached;
+  }
+  let result: DesignAuditResult;
+  try { result = await auditRenderedTree({ projectId, projectDir, entrypoint: project.entrypoint, revision: project.current_revision, digest: project.current_digest, deck: project.type === "slide_deck", signal }); }
+  catch (error) { if (error instanceof RenderSessionError || error instanceof CanonicalTreeManifestError) throw new DesignAuditServiceError("audit_unavailable", "Rendered audit is unavailable"); throw error; }
+  const after = await getProjectDetail(projectId);
+  if (after === null || after.current_revision !== result.artifact_revision || after.current_digest !== result.artifact_digest) throw new DesignAuditServiceError("stale_artifact_identity", "Artifact identity changed during audit");
+  await writeCache(cachePath, result);
+  return result;
+}
+
+function buildCheck(code: DesignAuditCheckCode, all: readonly DesignAuditFinding[], observation: DomAuditObservation): DesignAuditCheck {
+  const findings = all.filter((finding) => finding.check_code === code);
+  const status = findings.length > 0 ? "fail" : observation.measurable[code] ? "pass" : code === "token_usage" ? "skipped" : "unmeasurable";
+  const reason = status === "pass" || status === "fail" ? null : observation.unknownReasons[code] ?? "no_measurable_candidates";
+  return { code, status, reason, findings };
+}
+
+async function enrichFindings(raw: readonly DomAuditFinding[], input: AuditRenderedTreeInput, manifest: CanonicalTreeManifest): Promise<readonly DesignAuditFinding[]> {
+  const sorted = [...raw].sort((left, right) => `${DESIGN_AUDIT_CHECK_CODES.indexOf(left.code)}:${left.nodeId ?? ""}:${left.evidence}`.localeCompare(`${DESIGN_AUDIT_CHECK_CODES.indexOf(right.code)}:${right.nodeId ?? ""}:${right.evidence}`));
+  const htmlEntry = manifest.files.find((file) => file.path === input.entrypoint);
+  const html = htmlEntry === undefined ? null : await readFile(resolveWithin(input.projectDir, input.entrypoint), "utf8");
+  return sorted.map((finding, index) => {
+    const source = { rel_path: input.entrypoint, node_bg_id: finding.nodeId };
+    const base = { id: `${finding.code}:${createHash("sha256").update(`${input.entrypoint}\0${finding.nodeId ?? ""}\0${finding.evidence}\0${index}`).digest("hex").slice(0, 24)}`, check_code: finding.code, severity: finding.severity, source, evidence: finding.evidence, ...(finding.measured === undefined ? {} : { measured: finding.measured }), ...(finding.threshold === undefined ? {} : { threshold: finding.threshold }), targeted_action: finding.action };
+    if (input.safeFix === false || finding.code !== "minimum_text_size" || finding.nodeId === null || html === null || htmlEntry === undefined) return base;
+    try {
+      const node = fingerprintHtmlNode(html, finding.nodeId);
+      return { ...base, safe_fix: { kind: "patch_html_node" as const, rel_path: input.entrypoint, request: { expected_revision: input.revision, expected_artifact_digest: input.digest, expected_file_hash: htmlEntry.sha256, node_bg_id: finding.nodeId, node_fingerprint: node.fingerprint, styles: { "font-size": "12px" } } } };
+    } catch (error) { if (error instanceof FilePatchError) return base; throw error; }
+  });
+}
+
+async function readCache(cachePath: string): Promise<DesignAuditResult | null> {
+  try { return parseDesignAuditResult(JSON.parse(await readFile(cachePath, "utf8"))); }
+  catch (error) { if (error instanceof SyntaxError || error instanceof DesignAuditContractError || error instanceof Error && Reflect.get(error, "code") === "ENOENT") return null; throw error; }
+}
+async function writeCache(cachePath: string, result: DesignAuditResult): Promise<void> {
+  await mkdir(path.dirname(cachePath), { recursive: true }); const temporary = `${cachePath}.${process.pid}.${randomUUID()}.tmp`;
+  try { await writeFile(temporary, JSON.stringify(result)); await rename(temporary, cachePath); }
+  finally { await rm(temporary, { force: true }); }
+}

--- a/packages/backend/src/services/design-direction-renderer.ts
+++ b/packages/backend/src/services/design-direction-renderer.ts
@@ -1,0 +1,63 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { DesignDirectionLayout } from "@bg/shared";
+
+export type DirectionRenderInput = {
+  readonly layout: DesignDirectionLayout;
+  readonly title: string;
+  readonly summary: string;
+  readonly outline: readonly string[];
+  readonly outputPath: string;
+  readonly signal: AbortSignal;
+};
+
+export interface DesignDirectionRenderer {
+  render(input: DirectionRenderInput): Promise<void>;
+}
+
+const graphemeSegmenter = new Intl.Segmenter("ko", { granularity: "grapheme" });
+
+export class SvgDesignDirectionRenderer implements DesignDirectionRenderer {
+  async render(input: DirectionRenderInput): Promise<void> {
+    input.signal.throwIfAborted();
+    const svg = renderSvg(input);
+    await mkdir(path.dirname(input.outputPath), { recursive: true });
+    input.signal.throwIfAborted();
+    await writeFile(input.outputPath, svg, { encoding: "utf8", signal: input.signal });
+  }
+}
+
+function renderSvg(input: DirectionRenderInput): string {
+  const point0 = input.outline[0] ?? "핵심 문제";
+  const point1 = input.outline[1] ?? "해결 방향";
+  const point2 = input.outline[2] ?? "다음 단계";
+  switch (input.layout) {
+    case "editorial": {
+      const title = escapeXml(ellipsize(input.title, 13));
+      const summary = escapeXml(ellipsize(input.summary, 37));
+      const points = [escapeXml(ellipsize(`01  ${point0}`, 27)), escapeXml(ellipsize(`02  ${point1}`, 27)), escapeXml(ellipsize(`03  ${point2}`, 27))];
+      return `<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360"><rect width="640" height="360" fill="#F4EBDD"/><rect x="34" y="28" width="8" height="304" fill="#D64933"/><text data-run="title" data-width-budget="500" x="70" y="86" fill="#161411" font-family="serif" font-size="42" font-weight="700">${title}</text><text data-run="summary" data-width-budget="500" x="72" y="122" fill="#61594F" font-family="sans-serif" font-size="15">${summary}</text><line x1="72" y1="154" x2="594" y2="154" stroke="#161411"/><text data-run="point0" data-width-budget="500" x="72" y="205" fill="#161411" font-family="serif" font-size="20">${points[0]}</text><text data-run="point1" data-width-budget="500" x="72" y="255" fill="#161411" font-family="serif" font-size="20">${points[1]}</text><text data-run="point2" data-width-budget="500" x="72" y="305" fill="#D64933" font-family="serif" font-size="20">${points[2]}</text></svg>`;
+    }
+    case "modular": {
+      const title = escapeXml(ellipsize(input.title, 24));
+      const summary = escapeXml(ellipsize(input.summary, 17));
+      const points = [escapeXml(ellipsize(point0, 11)), escapeXml(ellipsize(point1, 11)), escapeXml(ellipsize(point2, 11))];
+      return `<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360"><rect width="640" height="360" fill="#0C1B33"/><text data-run="title" data-width-budget="560" x="32" y="52" fill="#F7FAFF" font-family="sans-serif" font-size="25" font-weight="700">${title}</text><rect x="32" y="76" width="368" height="108" rx="12" fill="#1E3A5F"/><text x="54" y="112" fill="#75E6DA" font-family="sans-serif" font-size="13">OVERVIEW</text><text data-run="summary" data-width-budget="320" x="54" y="151" fill="#FFFFFF" font-family="sans-serif" font-size="20">${summary}</text><rect x="416" y="76" width="192" height="252" rx="12" fill="#75E6DA"/><text data-run="point0" data-width-budget="148" x="438" y="116" fill="#0C1B33" font-family="sans-serif" font-size="14">${points[0]}</text><text data-run="point1" data-width-budget="148" x="438" y="176" fill="#0C1B33" font-family="sans-serif" font-size="14">${points[1]}</text><text data-run="point2" data-width-budget="148" x="438" y="236" fill="#0C1B33" font-family="sans-serif" font-size="14">${points[2]}</text><rect x="32" y="200" width="176" height="128" rx="12" fill="#F05D5E"/><rect x="224" y="200" width="176" height="128" rx="12" fill="#F7FAFF"/></svg>`;
+    }
+    case "narrative": {
+      const title = escapeXml(ellipsize(input.title, 15));
+      const summary = escapeXml(ellipsize(input.summary, 37));
+      const points = [escapeXml(ellipsize(point0, 11)), escapeXml(ellipsize(point1, 11)), escapeXml(ellipsize(point2, 12))];
+      return `<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360"><defs><linearGradient id="sky" x2="1" y2="1"><stop stop-color="#FFF5D6"/><stop offset="1" stop-color="#FFD4B8"/></linearGradient></defs><rect width="640" height="360" fill="url(#sky)"/><circle cx="520" cy="74" r="82" fill="#FF7A59" opacity=".8"/><path d="M64 270 C180 180 300 318 578 166" fill="none" stroke="#553C9A" stroke-width="7"/><circle cx="92" cy="250" r="15" fill="#553C9A"/><circle cx="310" cy="264" r="15" fill="#553C9A"/><circle cx="552" cy="177" r="15" fill="#553C9A"/><text data-run="title" data-width-budget="500" x="44" y="62" fill="#30264A" font-family="sans-serif" font-size="36" font-weight="800">${title}</text><text data-run="summary" data-width-budget="500" x="46" y="94" fill="#6B5876" font-family="sans-serif" font-size="15">${summary}</text><text data-run="point0" data-width-budget="150" x="52" y="320" fill="#30264A" font-family="sans-serif" font-size="14">${points[0]}</text><text data-run="point1" data-width-budget="150" x="245" y="294" fill="#30264A" font-family="sans-serif" font-size="14">${points[1]}</text><text data-run="point2" data-width-budget="160" x="430" y="235" fill="#30264A" font-family="sans-serif" font-size="14">${points[2]}</text></svg>`;
+    }
+  }
+}
+
+function ellipsize(value: string, maximumGraphemes: number): string {
+  const graphemes = Array.from(graphemeSegmenter.segment(value), (part) => part.segment);
+  return graphemes.length <= maximumGraphemes ? value : `${graphemes.slice(0, maximumGraphemes - 1).join("")}…`;
+}
+
+function escapeXml(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&apos;");
+}

--- a/packages/backend/src/services/design-direction-state.ts
+++ b/packages/backend/src/services/design-direction-state.ts
@@ -1,0 +1,21 @@
+import { ulid } from "ulid";
+import { parseDesignDirectionState, type DesignDirectionState, type NormalizedEvent } from "@bg/shared";
+import { insertNormalizedEvent, listSessionEvents } from "../db/events";
+import { broker, sequencedBroker } from "./broker";
+
+export async function getLatestDirectionState(sessionId: string): Promise<DesignDirectionState | null> {
+  const events = await listSessionEvents(sessionId);
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index]?.event;
+    if (event?.type === "design.direction_state") return parseDesignDirectionState(event.state);
+  }
+  return null;
+}
+
+export async function publishDirectionState(sessionId: string, state: DesignDirectionState): Promise<void> {
+  const parsed = parseDesignDirectionState(state);
+  const event: NormalizedEvent = { id: ulid(), ts: parsed.updated_at, type: "design.direction_state", state: parsed };
+  const persisted = await insertNormalizedEvent(sessionId, event);
+  broker.publish(sessionId, event);
+  sequencedBroker.publish(sessionId, persisted);
+}

--- a/packages/backend/src/services/design-direction-workflow.ts
+++ b/packages/backend/src/services/design-direction-workflow.ts
@@ -1,0 +1,167 @@
+import path from "node:path";
+import { ulid } from "ulid";
+import type { DesignBriefV1, DesignDirectionSlot, DesignDirectionState, ProjectType } from "@bg/shared";
+import { assertSafeName, resolveWithin } from "../security/path-boundary";
+import {
+  activeDirectionGeneration,
+  activeDirectionSignal,
+  beginDirectionOperation,
+  cancelDirectionOperation,
+  finishDirectionOperation,
+  isDirectionOperationActive,
+} from "./direction-operation-registry";
+import { SvgDesignDirectionRenderer, type DesignDirectionRenderer } from "./design-direction-renderer";
+import { getLatestDirectionState, publishDirectionState } from "./design-direction-state";
+
+export const DIRECTION_INTERRUPTION_ERROR = "Direction generation was interrupted; retry unfinished directions.";
+export const DIRECTION_CANCELLATION_ERROR = "Direction generation was cancelled; retry this direction.";
+
+export class DesignDirectionWorkflowError extends Error {
+  readonly name = "DesignDirectionWorkflowError";
+  constructor(readonly code: "operation_active" | "operation_capacity" | "state_not_found" | "generation_conflict" | "revision_conflict" | "direction_not_ready" | "nothing_to_retry" | "nothing_to_undo" | "timestamp_overflow", message = code) { super(message); }
+}
+
+type ProjectSession = { readonly projectId: string; readonly sessionId: string; readonly projectDir: string; readonly projectName: string; readonly projectType: ProjectType; readonly designBrief: DesignBriefV1 | null };
+type StartedGeneration = { readonly state: DesignDirectionState; readonly completion: Promise<DesignDirectionState> };
+type ActiveCompletion = { readonly generationId: string; readonly promise: Promise<DesignDirectionState> };
+
+export class DesignDirectionWorkflow {
+  private readonly activeCompletions = new Map<string, ActiveCompletion>();
+
+  constructor(private readonly renderer: DesignDirectionRenderer = new SvgDesignDirectionRenderer(), private readonly now: () => number = Date.now, private readonly id: () => string = ulid) {}
+
+  async generate(input: ProjectSession): Promise<StartedGeneration> {
+    const generationId = assertSafeName(this.id());
+    const state = this.initialState(input, generationId);
+    return this.start(input, state, state.directions.map((slot) => slot.id));
+  }
+
+  async retry(input: ProjectSession): Promise<StartedGeneration> {
+    const current = await this.requiredState(input.sessionId);
+    const retryIds = current.directions.filter((slot) => slot.status === "failed" || slot.status === "cancelled").map((slot) => slot.id);
+    if (retryIds.length === 0) throw new DesignDirectionWorkflowError("nothing_to_retry");
+    const state = this.snapshot(current, {
+      status: "loading",
+      directions: current.directions.map((slot) => retryIds.includes(slot.id) ? { ...slot, status: "pending", preview_url: null, error: null } : slot),
+      error: null,
+    });
+    return this.start(input, state, retryIds);
+  }
+
+  async cancel(sessionId: string): Promise<DesignDirectionState | null> {
+    const generationId = activeDirectionGeneration(sessionId);
+    const completion = this.activeCompletions.get(sessionId);
+    if (generationId === null || completion?.generationId !== generationId || !cancelDirectionOperation(sessionId)) return null;
+    return completion.promise;
+  }
+
+  async recover(sessionId: string): Promise<DesignDirectionState | null> {
+    const current = await getLatestDirectionState(sessionId);
+    if (current === null || current.status !== "loading" || activeDirectionGeneration(sessionId) === current.generation_id) return current;
+    const directions = current.directions.map((slot) => slot.status === "pending" ? { ...slot, status: "failed" as const, preview_url: null, error: DIRECTION_INTERRUPTION_ERROR } : slot);
+    const recovered = this.snapshot(current, { status: directions.some((slot) => slot.status === "ready") ? "partial" : "failed", directions, error: DIRECTION_INTERRUPTION_ERROR });
+    await publishDirectionState(sessionId, recovered);
+    return recovered;
+  }
+
+  async select(sessionId: string, generationId: string, revision: number, directionId: string): Promise<DesignDirectionState> {
+    const current = await this.requiredState(sessionId);
+    this.checkIdentity(current, generationId, revision);
+    if (!current.directions.some((slot) => slot.id === directionId && slot.status === "ready")) throw new DesignDirectionWorkflowError("direction_not_ready");
+    const selected = this.snapshot(current, { selected_id: directionId, selection_revision: current.selection_revision + 1, selection_history: [...current.selection_history, current.selected_id] });
+    await publishDirectionState(sessionId, selected);
+    return selected;
+  }
+
+  async undo(sessionId: string, generationId: string, revision: number): Promise<DesignDirectionState> {
+    const current = await this.requiredState(sessionId);
+    this.checkIdentity(current, generationId, revision);
+    const prior = current.selection_history.at(-1);
+    if (prior === undefined) throw new DesignDirectionWorkflowError("nothing_to_undo");
+    const undone = this.snapshot(current, { selected_id: prior, selection_revision: current.selection_revision + 1, selection_history: current.selection_history.slice(0, -1) });
+    await publishDirectionState(sessionId, undone);
+    return undone;
+  }
+
+  private async start(input: ProjectSession, state: DesignDirectionState, targetIds: readonly string[]): Promise<StartedGeneration> {
+    if (isDirectionOperationActive(input.sessionId)) throw new DesignDirectionWorkflowError("operation_active");
+    const controller = beginDirectionOperation(input.sessionId, state.generation_id);
+    if (controller === null) throw new DesignDirectionWorkflowError("operation_capacity");
+    await publishDirectionState(input.sessionId, state);
+    let resolveCompletion: (value: DesignDirectionState) => void = () => {};
+    let rejectCompletion: (error: unknown) => void = () => {};
+    const deferredCompletion = new Promise<DesignDirectionState>((resolve, reject) => { resolveCompletion = resolve; rejectCompletion = reject; });
+    const completion = deferredCompletion.finally(() => this.finishCompletion(input.sessionId, state.generation_id));
+    this.activeCompletions.set(input.sessionId, { generationId: state.generation_id, promise: completion });
+    void this.run(input, state, targetIds).then(resolveCompletion, rejectCompletion);
+    return { state, completion };
+  }
+
+  private async run(input: ProjectSession, started: DesignDirectionState, targetIds: readonly string[]): Promise<DesignDirectionState> {
+    let state = started;
+    for (const targetId of targetIds) {
+      const slot = state.directions.find((candidate) => candidate.id === targetId);
+      if (slot === undefined) continue;
+      let replacement: DesignDirectionSlot;
+      if (started.generation_id !== activeDirectionGeneration(input.sessionId)) break;
+      const signal = this.operationSignal(input.sessionId, state.generation_id);
+      try {
+        const outputPath = directionPreviewPath(input.projectDir, state.generation_id, slot.id);
+        await this.renderer.render({ layout: slot.layout_key, title: slot.title, summary: slot.summary, outline: state.content_outline, outputPath, signal });
+        signal.throwIfAborted();
+        replacement = { ...slot, status: "ready", preview_url: previewUrl(input.projectId, state.generation_id, slot.id), error: null };
+      } catch (error) {
+        if (signal.aborted) replacement = { ...slot, status: "cancelled", preview_url: null, error: DIRECTION_CANCELLATION_ERROR };
+        else replacement = { ...slot, status: "failed", preview_url: null, error: error instanceof Error ? error.message : String(error) };
+      }
+      let directions = state.directions.map((candidate) => candidate.id === slot.id ? replacement : candidate);
+      if (replacement.status === "cancelled") directions = directions.map((candidate) => candidate.status === "pending" ? { ...candidate, status: "cancelled", preview_url: null, error: DIRECTION_CANCELLATION_ERROR } : candidate);
+      state = this.snapshot(state, { directions, status: aggregateStatus(directions), error: aggregateError(directions) });
+      await publishDirectionState(input.sessionId, state);
+      if (replacement.status === "cancelled") break;
+    }
+    return state;
+  }
+
+  private finishCompletion(sessionId: string, generationId: string): void {
+    if (this.activeCompletions.get(sessionId)?.generationId === generationId) this.activeCompletions.delete(sessionId);
+    finishDirectionOperation(sessionId, generationId);
+  }
+
+  private operationSignal(sessionId: string, generationId: string): AbortSignal {
+    const signal = activeDirectionSignal(sessionId, generationId);
+    if (signal === null) throw new DesignDirectionWorkflowError("generation_conflict");
+    return signal;
+  }
+
+  private initialState(input: ProjectSession, generationId: string): DesignDirectionState {
+    return { schema_version: 1, project_id: input.projectId, session_id: input.sessionId, generation_id: generationId, status: "loading", content_outline: contentOutline(input), directions: slotFixtures(), selected_id: null, selection_revision: 0, selection_history: [], error: null, updated_at: this.now() };
+  }
+
+  private snapshot(current: DesignDirectionState, changes: Partial<DesignDirectionState>): DesignDirectionState {
+    const updatedAt = Math.max(this.now(), current.updated_at + 1);
+    if (!Number.isSafeInteger(updatedAt)) throw new DesignDirectionWorkflowError("timestamp_overflow");
+    return { ...current, ...changes, updated_at: updatedAt };
+  }
+  private async requiredState(sessionId: string): Promise<DesignDirectionState> { const state = await getLatestDirectionState(sessionId); if (state === null) throw new DesignDirectionWorkflowError("state_not_found"); return state; }
+  private checkIdentity(state: DesignDirectionState, generationId: string, revision: number): void { if (state.generation_id !== generationId) throw new DesignDirectionWorkflowError("generation_conflict"); if (state.selection_revision !== revision) throw new DesignDirectionWorkflowError("revision_conflict"); }
+}
+
+function contentOutline(input: ProjectSession): readonly string[] {
+  if (input.designBrief === null) return [`${input.projectName}의 핵심 문제`, "근거와 해결 방향", "명확한 다음 행동"];
+  return [
+    `목표: ${input.designBrief.objective}`,
+    `대상: ${input.designBrief.audience}`,
+    `산출물: ${input.projectType} · ${input.designBrief.output_type} · ${input.designBrief.output_size}`,
+  ];
+}
+
+function slotFixtures(): readonly DesignDirectionSlot[] { return [
+  { id: "editorial", order: 0, layout_key: "editorial", title: "편집 서사", summary: "강한 제목과 여백으로 메시지를 압축합니다.", style_facts: ["비대칭 편집 그리드", "세리프 대형 제목", "크림과 적색 팔레트"], status: "pending", preview_url: null, error: null },
+  { id: "modular", order: 1, layout_key: "modular", title: "모듈 시스템", summary: "정보를 비교 가능한 카드 체계로 정리합니다.", style_facts: ["12열 카드 그리드", "산세리프 정보 위계", "남색과 민트 팔레트"], status: "pending", preview_url: null, error: null },
+  { id: "narrative", order: 2, layout_key: "narrative", title: "흐름 서사", summary: "시작부터 결론까지 시선의 경로를 만듭니다.", style_facts: ["곡선형 진행 구조", "단계별 강조 문구", "복숭아와 보라 팔레트"], status: "pending", preview_url: null, error: null },
+]; }
+function aggregateStatus(slots: readonly DesignDirectionSlot[]): DesignDirectionState["status"] { if (slots.some((slot) => slot.status === "pending")) return "loading"; if (slots.some((slot) => slot.status === "cancelled")) return "cancelled"; if (slots.every((slot) => slot.status === "ready")) return "ready"; if (slots.some((slot) => slot.status === "ready")) return "partial"; return "failed"; }
+function aggregateError(slots: readonly DesignDirectionSlot[]): string | null { return slots.find((slot) => slot.error !== null)?.error ?? null; }
+export function directionPreviewPath(projectDir: string, generationId: string, directionId: string): string { return resolveWithin(projectDir, ".meta", "directions", assertSafeName(generationId), `${assertSafeName(directionId)}.svg`); }
+function previewUrl(projectId: string, generationId: string, directionId: string): string { return `/api/projects/${encodeURIComponent(projectId)}/design-directions/${encodeURIComponent(generationId)}/${encodeURIComponent(directionId)}/preview`; }

--- a/packages/backend/src/services/direction-operation-registry.ts
+++ b/packages/backend/src/services/direction-operation-registry.ts
@@ -1,0 +1,38 @@
+type ActiveDirectionOperation = {
+  readonly generationId: string;
+  readonly controller: AbortController;
+};
+
+const MAX_ACTIVE_OPERATIONS = 64;
+const activeOperations = new Map<string, ActiveDirectionOperation>();
+
+export function isDirectionOperationActive(sessionId: string): boolean {
+  return activeOperations.has(sessionId);
+}
+
+export function activeDirectionGeneration(sessionId: string): string | null {
+  return activeOperations.get(sessionId)?.generationId ?? null;
+}
+
+export function activeDirectionSignal(sessionId: string, generationId: string): AbortSignal | null {
+  const operation = activeOperations.get(sessionId);
+  return operation?.generationId === generationId ? operation.controller.signal : null;
+}
+
+export function beginDirectionOperation(sessionId: string, generationId: string): AbortController | null {
+  if (activeOperations.has(sessionId) || activeOperations.size >= MAX_ACTIVE_OPERATIONS) return null;
+  const controller = new AbortController();
+  activeOperations.set(sessionId, { generationId, controller });
+  return controller;
+}
+
+export function cancelDirectionOperation(sessionId: string): boolean {
+  const operation = activeOperations.get(sessionId);
+  if (operation === undefined) return false;
+  operation.controller.abort();
+  return true;
+}
+
+export function finishDirectionOperation(sessionId: string, generationId: string): void {
+  if (activeOperations.get(sessionId)?.generationId === generationId) activeOperations.delete(sessionId);
+}

--- a/packages/backend/src/services/export-browser-registry.ts
+++ b/packages/backend/src/services/export-browser-registry.ts
@@ -1,15 +1,28 @@
 type CloseBrowser = () => Promise<void>;
+export type ExportBrowserClosePolicy = { readonly gracefulDeadlineMs: number };
+const DEFAULT_CLOSE_POLICY: ExportBrowserClosePolicy = { gracefulDeadlineMs: 5_000 };
 const active = new Map<symbol, CloseBrowser>();
 
-export type ExportBrowserOwner = { readonly release: () => void };
+export type ExportBrowserOwner = { readonly close: () => Promise<void>; readonly release: () => void };
 
-export function registerExportBrowser(close: CloseBrowser): ExportBrowserOwner {
-  const id = Symbol("export-browser"); active.set(id, close); return { release: () => { active.delete(id); } };
+export function registerExportBrowser(closeBrowser: CloseBrowser, policy: ExportBrowserClosePolicy = DEFAULT_CLOSE_POLICY): ExportBrowserOwner {
+  const id = Symbol("export-browser"); let closing: Promise<void> | null = null;
+  const close = async (): Promise<void> => { closing ??= terminateBrowser(closeBrowser, policy); try { await closing; } finally { active.delete(id); } };
+  active.set(id, close); return { close, release: () => { active.delete(id); } };
 }
 
+export function activeExportBrowserCount(): number { return active.size; }
+
 export async function closeActiveExportBrowsers(): Promise<void> {
-  const owners = [...active.entries()]; for (const [id] of owners) active.delete(id);
-  const failures: unknown[] = [];
-  await Promise.all(owners.map(async ([, close]) => { try { await close(); } catch (error) { failures.push(error); } }));
+  const owners = [...active.values()]; const failures: unknown[] = [];
+  await Promise.all(owners.map(async (close) => { try { await close(); } catch (error) { failures.push(error); } }));
   if (failures.length > 0) throw new AggregateError(failures, "Failed to close active export browsers");
+}
+
+async function terminateBrowser(close: CloseBrowser, policy: ExportBrowserClosePolicy): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | null = null; const deadline = new Promise<"deadline">((resolve) => { timeout = setTimeout(() => resolve("deadline"), policy.gracefulDeadlineMs); timeout.unref(); }); let result: "closed" | "deadline";
+  try { result = await Promise.race([close().then(() => "closed" as const), deadline]); }
+  catch (error) { try { await close(); } catch (forceError) { throw new AggregateError([error, forceError], "Chromium graceful and forced close both failed"); } throw error; }
+  finally { if (timeout !== null) clearTimeout(timeout); }
+  if (result === "deadline") await close();
 }

--- a/packages/backend/src/services/export-handoff.ts
+++ b/packages/backend/src/services/export-handoff.ts
@@ -1,7 +1,7 @@
 import { copyFile, cp, mkdir, readdir } from "node:fs/promises";
 import path from "node:path";
 
-const HANDOFF_EXCLUDED_TOP_LEVEL = new Set([".meta", ".attachments"]);
+const HANDOFF_EXCLUDED_TOP_LEVEL = new Set([".meta", ".attachments", ".burnguard-inputs"]);
 
 /**
  * Recursively copies a staged project directory into the handoff

--- a/packages/backend/src/services/export-handoff.ts
+++ b/packages/backend/src/services/export-handoff.ts
@@ -91,7 +91,7 @@ export interface HandoffSpec {
   project: {
     id: string;
     name: string;
-    type: "prototype" | "slide_deck" | "from_template" | "other";
+    type: "prototype" | "slide_deck" | "graphic" | "from_template" | "other";
     entrypoint: string;
   };
   viewport: { width: number; height: number };

--- a/packages/backend/src/services/export-render-session.ts
+++ b/packages/backend/src/services/export-render-session.ts
@@ -13,7 +13,7 @@ export class RenderSessionError extends Error {
   constructor(readonly code: "chromium_not_installed" | "render_failed" | "deck_not_ready" | "render_aborted", message: string, readonly findings: readonly RenderFinding[] = []) { super(message); }
 }
 
-export async function openRenderSession(input: { readonly stagedDir: string; readonly entrypoint: string; readonly viewport: RenderViewport; readonly deck: boolean; readonly signal: AbortSignal; readonly onPhase?: (phase: RenderPhase) => void }): Promise<RenderSession> {
+export async function openRenderSession(input: { readonly stagedDir: string; readonly entrypoint: string; readonly viewport: RenderViewport; readonly deck: boolean; readonly signal: AbortSignal; readonly strict?: boolean; readonly onPhase?: (phase: RenderPhase) => void }): Promise<RenderSession> {
   if (input.signal.aborted) throw new RenderSessionError("render_aborted", "Render was cancelled");
   const browser = await launchChromium(input.signal); const owner = registerExportBrowser(() => browser.close()); const findings: RenderFinding[] = []; let abort: (() => void) | null = null;
   try {
@@ -21,7 +21,7 @@ export async function openRenderSession(input: { readonly stagedDir: string; rea
     page.on("console", (message) => { if (message.type() === "error") findings.push({ code: "console_error", path: message.text() }); });
     page.on("pageerror", (error) => findings.push({ code: "page_error", path: error.message })); page.on("requestfailed", (request) => findings.push({ code: "request_failed", path: request.url() }));
     await page.route("**/*", async (route) => { const url = new URL(route.request().url()); if (url.protocol === "file:" || url.protocol === "data:") await route.continue(); else { findings.push({ code: "remote_request", path: sanitizeUrl(url) }); await route.abort("blockedbyclient"); } });
-    abort = (): void => { void browser.close(); }; input.signal.addEventListener("abort", abort, { once: true }); input.onPhase?.("browser_ready");
+    abort = (): void => { void owner.close(); }; input.signal.addEventListener("abort", abort, { once: true }); input.onPhase?.("browser_ready");
     const htmlPath = resolveWithin(input.stagedDir, input.entrypoint); await page.goto(`${pathToFileURL(htmlPath)}${input.deck ? "?print=1" : ""}`, { waitUntil: "load", timeout: 30_000 }); input.onPhase?.("navigated");
     await page.evaluate(async () => { if (document.readyState !== "complete") await new Promise<void>((resolve) => addEventListener("load", () => resolve(), { once: true })); await document.fonts.ready; });
     const state = await page.evaluate(() => {
@@ -30,10 +30,10 @@ export async function openRenderSession(input: { readonly stagedDir: string; rea
     });
     for (const font of state.fonts) findings.push({ code: "font_error", path: font });
     if (input.deck && (state.slideCount === 0 || !state.owned || !state.geometry)) throw new RenderSessionError("deck_not_ready", "Owned deck runtime did not produce finite slide geometry", findings);
-    if (findings.length > 0) throw new RenderSessionError("render_failed", "Render emitted browser errors", findings); input.onPhase?.("content_ready"); let closed = false;
-    return { browser, context, page, findings, close: async () => { if (closed) return; closed = true; if (abort !== null) input.signal.removeEventListener("abort", abort); owner.release(); await browser.close(); } };
+    if ((input.strict ?? true) && findings.length > 0) throw new RenderSessionError("render_failed", "Render emitted browser errors", findings); input.onPhase?.("content_ready"); let closed = false;
+    return { browser, context, page, findings, close: async () => { if (closed) return; closed = true; if (abort !== null) input.signal.removeEventListener("abort", abort); await owner.close(); } };
   } catch (error) {
-    if (abort !== null) input.signal.removeEventListener("abort", abort); owner.release(); await browser.close().catch((closeError) => { if (!(error instanceof Error)) throw closeError; });
+    if (abort !== null) input.signal.removeEventListener("abort", abort); try { await owner.close(); } catch (closeError) { throw new AggregateError([error, closeError], "Render failed and Chromium cleanup failed"); }
     if (input.signal.aborted) throw new RenderSessionError("render_aborted", "Render was cancelled", findings); if (error instanceof RenderSessionError) throw error; throw new RenderSessionError("render_failed", error instanceof Error ? error.message : String(error), findings);
   }
 }

--- a/packages/backend/src/services/exports.ts
+++ b/packages/backend/src/services/exports.ts
@@ -25,6 +25,7 @@ import type { ExportValidation } from "./export-receipt-validation";
 import { openRenderSession } from "./export-render-session";
 import { auditRenderedTree } from "./design-audit";
 import { prepareSlideDeckExport } from "./export-stage";
+import { parseStoredProjectOptions } from "./project-options";
 import { zipDirectory } from "./zip";
 
 const RENDERER_CONTRACT = "burnguard-export/1|playwright-core@1.62.1|pdfjs-dist@5.4.149";
@@ -34,7 +35,7 @@ export type ExportHooks = { readonly phase?: (attemptId: string, phase: ExportPh
 
 export class ExportServiceError extends Error {
   readonly name = "ExportServiceError";
-  constructor(readonly code: "project_not_found" | "source_changed" | "format_requires_deck" | "attempt_not_found" | "design_audit_failed", message: string) { super(message); }
+  constructor(readonly code: "project_not_found" | "source_changed" | "format_requires_deck" | "attempt_not_found" | "design_audit_failed" | "invalid_graphic_export_options", message: string) { super(message); }
 }
 
 export async function enqueueProjectExport(projectId: string, format: ExportFormat, options: ExportOptions, hooks: ExportHooks = {}) {
@@ -76,7 +77,10 @@ async function runExport(input: RunInput): Promise<void> {
     await materializeManagedTree(source, renderRoot); await validateCanonicalTree(renderRoot, live);
     if (context.project.type === "slide_deck") await prepareSlideDeckExport(renderRoot, context.project.entrypoint);
     const renderManifest = await inspectCanonicalTree(renderRoot);
-    const audit = await auditRenderedTree({ projectId: context.identity.projectId, projectDir: renderRoot, entrypoint: context.project.entrypoint, revision: context.identity.revision, digest: context.identity.digest, treeDigest: renderManifest.tree_digest, safeFix: false, deck: context.project.type === "slide_deck", signal: input.controller.signal });
+    const graphicCanvas = context.project.type === "graphic"
+      ? parseStoredProjectOptions(context.project.options_json).graphic_canvas ?? undefined
+      : undefined;
+    const audit = await auditRenderedTree({ projectId: context.identity.projectId, projectDir: renderRoot, entrypoint: context.project.entrypoint, revision: context.identity.revision, digest: context.identity.digest, treeDigest: renderManifest.tree_digest, safeFix: false, deck: context.project.type === "slide_deck", ...(graphicCanvas === undefined ? {} : { canvas: graphicCanvas }), signal: input.controller.signal });
     const auditUnknowns = audit.checks.filter((check) => check.reason !== null).map((check) => ({ code: `design_audit:${check.code}:${check.status}`, path: null }));
     const auditFindings = audit.checks.flatMap((check) => check.findings.map((finding) => ({ code: finding.check_code, path: finding.source.rel_path }))).slice(0, 200 - auditUnknowns.length);
     recordExportAuditFindings(db, input.attemptId, [...auditFindings, ...auditUnknowns]);
@@ -124,6 +128,20 @@ async function renderOutput(input: RunInput, renderRoot: string, outputPath: str
 async function exportContext(projectId: string, format: ExportFormat, options: ExportOptions): Promise<Context> {
   let project = await getProjectDetail(projectId); if (project === null) throw new ExportServiceError("project_not_found", "Project not found");
   if ((format === "pdf" || format === "pptx") && project.type !== "slide_deck") throw new ExportServiceError("format_requires_deck", "Format requires a slide deck");
+  if (project.type === "graphic" && format === "png") {
+    const canvas = parseStoredProjectOptions(project.options_json).graphic_canvas;
+    if (
+      canvas === null ||
+      options.png_width !== canvas.width ||
+      options.png_height !== canvas.height ||
+      options.png_dpr !== 1
+    ) {
+      throw new ExportServiceError(
+        "invalid_graphic_export_options",
+        "Graphic PNG options must exactly match the persisted canvas at DPR 1",
+      );
+    }
+  }
   const source = resolveManagedPath(projectsDir, project.dir_path); if (project.current_digest === null) { await new ArtifactCoordinator(getSqlite()).initialize(project.id, source); project = await getProjectDetail(projectId); }
   if (project === null || project.current_digest === null) throw new ExportServiceError("source_changed", "Stable project identity unavailable");
   const designSystemDigest = await designDigest(project.design_system_id);

--- a/packages/backend/src/services/exports.ts
+++ b/packages/backend/src/services/exports.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { parse } from "node-html-parser";
 import type { ExportFormat, ExportOptions, ExportProgress, ExportStopReason } from "@bg/shared";
 import { getExportJob } from "../db/exports";
-import { createExportAuthority, createRetryAuthority, advanceExportAttempt, completeExportAttempt, failExportAttempt, requestExportCancellation, type ExportIdentity } from "../db/export-lifecycle-repository";
+import { createExportAuthority, createRetryAuthority, advanceExportAttempt, completeExportAttempt, failExportAttempt, recordExportAuditFindings, requestExportCancellation, type ExportIdentity } from "../db/export-lifecycle-repository";
 import { getProjectDetail } from "../db/project-read-repository";
 import { getSqlite } from "../db/sqlite-client";
 import { exportsDir, projectsDir, resolveManagedPath, systemsDir } from "../lib/paths";
@@ -23,6 +23,7 @@ import { renderDeckToPptx } from "./export-pptx-render";
 import { canonicalJson, parseExportReceipt, receiptDigest, sha256, type ExportReceipt } from "./export-receipt";
 import type { ExportValidation } from "./export-receipt-validation";
 import { openRenderSession } from "./export-render-session";
+import { auditRenderedTree } from "./design-audit";
 import { prepareSlideDeckExport } from "./export-stage";
 import { zipDirectory } from "./zip";
 
@@ -33,7 +34,7 @@ export type ExportHooks = { readonly phase?: (attemptId: string, phase: ExportPh
 
 export class ExportServiceError extends Error {
   readonly name = "ExportServiceError";
-  constructor(readonly code: "project_not_found" | "source_changed" | "format_requires_deck" | "attempt_not_found", message: string) { super(message); }
+  constructor(readonly code: "project_not_found" | "source_changed" | "format_requires_deck" | "attempt_not_found" | "design_audit_failed", message: string) { super(message); }
 }
 
 export async function enqueueProjectExport(projectId: string, format: ExportFormat, options: ExportOptions, hooks: ExportHooks = {}) {
@@ -74,7 +75,14 @@ async function runExport(input: RunInput): Promise<void> {
     if (live.tree_digest !== context.identity.digest) throw new ExportServiceError("source_changed", "Live project digest differs from stable identity");
     await materializeManagedTree(source, renderRoot); await validateCanonicalTree(renderRoot, live);
     if (context.project.type === "slide_deck") await prepareSlideDeckExport(renderRoot, context.project.entrypoint);
-    const renderManifest = await inspectCanonicalTree(renderRoot); await resolveStaticClosure(renderRoot, context.project.entrypoint, renderManifest);
+    const renderManifest = await inspectCanonicalTree(renderRoot);
+    const audit = await auditRenderedTree({ projectId: context.identity.projectId, projectDir: renderRoot, entrypoint: context.project.entrypoint, revision: context.identity.revision, digest: context.identity.digest, treeDigest: renderManifest.tree_digest, safeFix: false, deck: context.project.type === "slide_deck", signal: input.controller.signal });
+    const auditUnknowns = audit.checks.filter((check) => check.reason !== null).map((check) => ({ code: `design_audit:${check.code}:${check.status}`, path: null }));
+    const auditFindings = audit.checks.flatMap((check) => check.findings.map((finding) => ({ code: finding.check_code, path: finding.source.rel_path }))).slice(0, 200 - auditUnknowns.length);
+    recordExportAuditFindings(db, input.attemptId, [...auditFindings, ...auditUnknowns]);
+    const mustFixCount = audit.checks.flatMap((check) => check.findings).filter((finding) => finding.severity === "must_fix").length;
+    if (mustFixCount > 0) throw new ExportServiceError("design_audit_failed", `Design audit found ${mustFixCount} must-fix finding${mustFixCount === 1 ? "" : "s"}`);
+    await resolveStaticClosure(renderRoot, context.project.entrypoint, renderManifest);
     const inputDigest = sha256(canonicalJson({ schema_version: 1, project: context.identity, entrypoint: context.project.entrypoint, manifest: renderManifest }));
     advanceExportAttempt(db, { attemptId: input.attemptId, status: "running", stage: "rendering", inputClosureDigest: inputDigest, designSystemDigest: context.identity.designSystemDigest });
     emit(context.identity, input, "running", { stage: "rendering", completed: 2, total: 6 }, null); await input.hooks.phase?.(input.attemptId, "after_snapshot", input.controller.signal);
@@ -92,7 +100,7 @@ async function runExport(input: RunInput): Promise<void> {
     emit(context.identity, input, "validated", { stage: "complete", completed: 6, total: 6 }, null);
   } catch (error) {
     await rm(stageRoot, { recursive: true, force: true }); await rm(publishedRoot, { recursive: true, force: true });
-    const cancelled = input.controller.signal.aborted; const reason: ExportStopReason = cancelled ? "user_cancelled" : error instanceof ExportServiceError && error.code === "source_changed" ? "source_changed" : "render_failed";
+    const cancelled = input.controller.signal.aborted; const reason: ExportStopReason = cancelled ? "user_cancelled" : error instanceof ExportServiceError && error.code === "source_changed" ? "source_changed" : error instanceof ExportServiceError && error.code === "design_audit_failed" ? "validation_failed" : "render_failed";
     failExportAttempt(db, { jobId: input.jobId, attemptId: input.attemptId, status: cancelled ? "cancelled" : "failed", reason, message: error instanceof Error ? error.message : String(error) });
     emit(context.identity, input, cancelled ? "cancelled" : "failed", { stage: "rendering", completed: 2, total: 6 }, reason);
   }

--- a/packages/backend/src/services/immutable-attachment-guard.ts
+++ b/packages/backend/src/services/immutable-attachment-guard.ts
@@ -1,0 +1,173 @@
+import { createHash } from "node:crypto";
+import { lstat, open, type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import type { VisualSourceRole } from "@bg/shared";
+import { resolveWithin } from "../security/path-boundary";
+
+const MAX_CAPTURE_BYTES = 25 * 1024 * 1024;
+
+type AttachmentIdentity = {
+  readonly file_path: string;
+  readonly source_role: VisualSourceRole;
+  readonly size_bytes: number;
+  readonly sha256: string | null;
+};
+
+export type ImmutableSnapshot = {
+  readonly filePath: string;
+  readonly handle: FileHandle;
+  readonly device: number;
+  readonly inode: number;
+  readonly bytes: Uint8Array;
+  readonly sha256: string;
+};
+
+type ImmutableGuardErrorCode =
+  | "immutable_reference_mutated"
+  | "immutable_reference_path_unavailable";
+
+export class ImmutableReferenceMutationError extends Error {
+  readonly name = "ImmutableReferenceMutationError";
+  constructor(readonly code: ImmutableGuardErrorCode) { super(code); }
+}
+
+export async function captureImmutableAttachments(
+  attachments: readonly AttachmentIdentity[],
+): Promise<readonly ImmutableSnapshot[]> {
+  const immutable = attachments.filter(
+    (attachment) => attachment.source_role === "immutable_reference",
+  );
+  if (
+    immutable.reduce((total, attachment) => total + attachment.size_bytes, 0) >
+    MAX_CAPTURE_BYTES
+  ) throw new ImmutableReferenceMutationError("immutable_reference_mutated");
+
+  const snapshots: ImmutableSnapshot[] = [];
+  const opened: FileHandle[] = [];
+  try {
+    for (const attachment of immutable) {
+      let canonical: string;
+      try {
+        canonical = resolveManagedAttachment(attachment.file_path);
+      } catch {
+        throw new ImmutableReferenceMutationError(
+          "immutable_reference_path_unavailable",
+        );
+      }
+      const handle = await open(canonical, "r+");
+      opened.push(handle);
+      const identity = await handle.stat();
+      const currentPath = await lstat(resolveManagedAttachment(attachment.file_path));
+      const bytes = await readHandleBytes(handle, identity.size);
+      const digest = createHash("sha256").update(bytes).digest("hex");
+      if (
+        canonical !== attachment.file_path ||
+        !identity.isFile() ||
+        currentPath.isSymbolicLink() ||
+        currentPath.dev !== identity.dev ||
+        currentPath.ino !== identity.ino ||
+        attachment.sha256 === null ||
+        identity.size !== attachment.size_bytes ||
+        digest !== attachment.sha256
+      ) {
+        throw new ImmutableReferenceMutationError("immutable_reference_mutated");
+      }
+      snapshots.push({
+        filePath: attachment.file_path,
+        handle,
+        device: identity.dev,
+        inode: identity.ino,
+        bytes,
+        sha256: digest,
+      });
+    }
+    return snapshots;
+  } catch (error) {
+    await Promise.all(opened.map((handle) => handle.close()));
+    if (error instanceof ImmutableReferenceMutationError) throw error;
+    throw new ImmutableReferenceMutationError(
+      "immutable_reference_path_unavailable",
+    );
+  }
+}
+
+export async function verifyImmutableAttachments(
+  snapshots: readonly ImmutableSnapshot[],
+): Promise<void> {
+  let failure: ImmutableReferenceMutationError | null = null;
+  try {
+    for (const snapshot of snapshots) {
+      const identity = await snapshot.handle.stat();
+      const current = await readHandleBytes(snapshot.handle, identity.size);
+      const mutated =
+        identity.dev !== snapshot.device ||
+        identity.ino !== snapshot.inode ||
+        createHash("sha256").update(current).digest("hex") !== snapshot.sha256;
+      if (mutated) await restoreHandle(snapshot);
+
+      let pathAvailable = false;
+      try {
+        const canonical = resolveManagedAttachment(snapshot.filePath);
+        const currentPath = await lstat(canonical);
+        pathAvailable =
+          canonical === snapshot.filePath &&
+          !currentPath.isSymbolicLink() &&
+          currentPath.dev === snapshot.device &&
+          currentPath.ino === snapshot.inode;
+      } catch {
+        pathAvailable = false;
+      }
+
+      if (!pathAvailable) {
+        failure ??= new ImmutableReferenceMutationError(
+          "immutable_reference_path_unavailable",
+        );
+      } else if (mutated) {
+        failure ??= new ImmutableReferenceMutationError(
+          "immutable_reference_mutated",
+        );
+      }
+    }
+  } finally {
+    await Promise.all(snapshots.map((snapshot) => snapshot.handle.close()));
+  }
+  if (failure !== null) throw failure;
+}
+
+function resolveManagedAttachment(filePath: string): string {
+  const projectDir = path.dirname(path.dirname(filePath));
+  return resolveWithin(
+    projectDir,
+    ".attachments",
+    path.basename(filePath),
+  );
+}
+
+async function readHandleBytes(
+  handle: FileHandle,
+  size: number,
+): Promise<Uint8Array> {
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  while (offset < size) {
+    const result = await handle.read(bytes, offset, size - offset, offset);
+    if (result.bytesRead === 0) break;
+    offset += result.bytesRead;
+  }
+  return offset === size ? bytes : bytes.subarray(0, offset);
+}
+
+async function restoreHandle(snapshot: ImmutableSnapshot): Promise<void> {
+  await snapshot.handle.truncate(0);
+  let offset = 0;
+  while (offset < snapshot.bytes.byteLength) {
+    const result = await snapshot.handle.write(
+      snapshot.bytes,
+      offset,
+      snapshot.bytes.byteLength - offset,
+      offset,
+    );
+    offset += result.bytesWritten;
+  }
+  await snapshot.handle.sync();
+}

--- a/packages/backend/src/services/managed-project-files.ts
+++ b/packages/backend/src/services/managed-project-files.ts
@@ -6,7 +6,7 @@ import { getProjectDetail } from "../db/project-read-repository";
 import { PathBoundaryError, assertSafeName, resolveWithin } from "../security/path-boundary";
 import { inspectCanonicalTree } from "./canonical-tree-manifest";
 
-const IGNORED_DIRS = new Set([".attachments", ".meta", ".git", ".omc", ".claude"]);
+const IGNORED_DIRS = new Set([".attachments", ".burnguard-inputs", ".meta", ".git", ".omc", ".claude"]);
 
 export async function indexProjectFiles(projectId: string) {
   const project = await getProjectDetail(projectId);

--- a/packages/backend/src/services/project-options.ts
+++ b/packages/backend/src/services/project-options.ts
@@ -1,7 +1,9 @@
 import {
   parseDesignBriefV1,
+  parseGraphicCanvasV1,
   UpgradeContractError,
   type DesignBriefV1,
+  type GraphicCanvasV1,
 } from "@bg/shared";
 import { isRecord } from "@bg/shared/contract-parser";
 
@@ -9,12 +11,14 @@ export type ProjectOptions = {
   readonly use_speaker_notes: boolean;
   readonly copy_as_is: boolean;
   readonly design_brief: DesignBriefV1 | null;
+  readonly graphic_canvas: GraphicCanvasV1 | null;
 };
 
 const DEFAULT_OPTIONS: ProjectOptions = {
   use_speaker_notes: false,
   copy_as_is: false,
   design_brief: null,
+  graphic_canvas: null,
 };
 
 export function parseProjectOptions(input: unknown): ProjectOptions {
@@ -26,9 +30,13 @@ export function parseProjectOptions(input: unknown): ProjectOptions {
     use_speaker_notes: optionalBoolean(input, "use_speaker_notes"),
     copy_as_is: optionalBoolean(input, "copy_as_is"),
     design_brief:
-      input["design_brief"] === undefined
+      input["design_brief"] === undefined || input["design_brief"] === null
         ? null
         : parseDesignBriefV1(input["design_brief"]),
+    graphic_canvas:
+      input["graphic_canvas"] === undefined || input["graphic_canvas"] === null
+        ? null
+        : parseGraphicCanvasOption(input["graphic_canvas"]),
   };
 }
 
@@ -45,6 +53,20 @@ export function parseStoredProjectOptions(
       error instanceof UpgradeContractError
     ) {
       return DEFAULT_OPTIONS;
+    }
+    throw error;
+  }
+}
+
+function parseGraphicCanvasOption(input: unknown): GraphicCanvasV1 {
+  try {
+    return parseGraphicCanvasV1(input);
+  } catch (error) {
+    if (error instanceof UpgradeContractError) {
+      throw new UpgradeContractError(
+        error.code,
+        `options.graphic_canvas.${error.path}`,
+      );
     }
     throw error;
   }

--- a/packages/backend/src/services/project-thumbnails.ts
+++ b/packages/backend/src/services/project-thumbnails.ts
@@ -1,0 +1,156 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm } from "node:fs/promises";
+import path from "node:path";
+import { getProjectDetail } from "../db/project-read-repository";
+import { projectsDir, resolveManagedPath } from "../lib/paths";
+import { PathBoundaryError, resolveWithin } from "../security/path-boundary";
+import { parsePng, PngValidationError } from "./export-png-validation";
+
+export const THUMBNAIL_WIDTH = 640;
+export const THUMBNAIL_HEIGHT = 360;
+
+/** Bumping this invalidates every cached thumbnail without touching artifacts. */
+const RENDERER_VERSION = 1;
+
+// Thumbnails live under `.meta`, the only project-owned sidecar root that the
+// canonical tree manifest, the watcher and the file index all exclude. Writing
+// them at the project root would change the artifact digest that keys them.
+const CACHE_SEGMENTS = [".meta", "thumbnails"] as const;
+
+export type ThumbnailRenderRequest = {
+  readonly stagedDir: string;
+  readonly entrypoint: string;
+  readonly outputPath: string;
+  readonly deck: boolean;
+  readonly signal: AbortSignal;
+};
+
+export type ThumbnailRenderer = (request: ThumbnailRenderRequest) => Promise<void>;
+
+export type ThumbnailIdentitySource = {
+  readonly id: string;
+  readonly current_revision: number;
+  readonly current_digest: string | null;
+};
+
+export type ThumbnailOutcome =
+  | { readonly kind: "ready"; readonly bytes: Uint8Array<ArrayBuffer>; readonly etag: string }
+  | { readonly kind: "not_found" }
+  | { readonly kind: "unavailable"; readonly code: "artifact_unavailable" | "thumbnail_unavailable" };
+
+/** Cache identity: project + artifact revision + artifact digest + renderer version. */
+export function projectThumbnailIdentity(project: ThumbnailIdentitySource): string | null {
+  if (project.current_digest === null) return null;
+  return createHash("sha256")
+    .update(`burnguard-thumbnail\n${RENDERER_VERSION}\n${project.id}\n${project.current_revision}\n${project.current_digest}`)
+    .digest("hex");
+}
+
+/** The read URL for a project thumbnail, or null while the project has no artifact digest. */
+export function projectThumbnailUrl(project: ThumbnailIdentitySource): string | null {
+  const identity = projectThumbnailIdentity(project);
+  if (identity === null) return null;
+  return `/api/projects/${encodeURIComponent(project.id)}/thumbnail?v=${identity}`;
+}
+
+export async function loadProjectThumbnail(
+  projectId: string,
+  render: ThumbnailRenderer = renderThumbnailWithChromium,
+  temporaryId: () => string = randomUUID,
+): Promise<ThumbnailOutcome> {
+  const project = await getProjectDetail(projectId);
+  if (project === null) return { kind: "not_found" };
+
+  const identity = projectThumbnailIdentity(project);
+  if (identity === null) return { kind: "unavailable", code: "artifact_unavailable" };
+
+  // The DB thumbnail_path is never trusted as a filesystem path: the cache
+  // location is derived from the managed projects root and the identity hash.
+  let projectDir: string;
+  let cachePath: string;
+  try {
+    projectDir = resolveManagedPath(projectsDir, project.dir_path);
+    cachePath = resolveWithin(projectDir, ...CACHE_SEGMENTS, `${identity}.png`);
+  } catch (error) {
+    if (error instanceof PathBoundaryError) return { kind: "unavailable", code: "thumbnail_unavailable" };
+    throw error;
+  }
+
+  const cached = await readThumbnailFile(cachePath);
+  if (cached !== null) return { kind: "ready", bytes: cached, etag: `"${identity}"` };
+
+  const rendered = await renderThumbnailFile({
+    request: {
+      stagedDir: projectDir,
+      entrypoint: project.entrypoint,
+      outputPath: cachePath,
+      deck: project.type === "slide_deck",
+      signal: new AbortController().signal,
+    },
+    render,
+    temporaryId,
+  });
+  if (rendered === null) return { kind: "unavailable", code: "thumbnail_unavailable" };
+  return { kind: "ready", bytes: rendered, etag: `"${identity}"` };
+}
+
+/** Renders into a sibling temporary file and publishes it with an atomic rename. */
+async function renderThumbnailFile(input: {
+  readonly request: ThumbnailRenderRequest;
+  readonly render: ThumbnailRenderer;
+  readonly temporaryId: () => string;
+}): Promise<Uint8Array<ArrayBuffer> | null> {
+  const cachePath = input.request.outputPath;
+  const temporaryPath = `${cachePath}.${process.pid}.${input.temporaryId()}.tmp`;
+  try {
+    await mkdir(path.dirname(cachePath), { recursive: true });
+    await input.render({ ...input.request, outputPath: temporaryPath });
+    const bytes = await readThumbnailFile(temporaryPath);
+    if (bytes === null) return null;
+    await rename(temporaryPath, cachePath);
+    return bytes;
+  } catch (error) {
+    if (error instanceof Error) return null;
+    throw error;
+  } finally {
+    await rm(temporaryPath, { force: true });
+  }
+}
+
+/** Returns the PNG bytes only when the file exists and carries the exact expected image. */
+async function readThumbnailFile(filePath: string): Promise<Uint8Array<ArrayBuffer> | null> {
+  let bytes: Uint8Array<ArrayBuffer>;
+  try {
+    bytes = Uint8Array.from(await readFile(filePath));
+  } catch (error) {
+    if (isMissingFile(error)) return null;
+    throw error;
+  }
+  try {
+    const header = parsePng(bytes);
+    return header.width === THUMBNAIL_WIDTH && header.height === THUMBNAIL_HEIGHT ? bytes : null;
+  } catch (error) {
+    if (error instanceof PngValidationError) return null;
+    throw error;
+  }
+}
+
+function isMissingFile(error: unknown): boolean {
+  return error instanceof Error && "code" in error && (error.code === "ENOENT" || error.code === "ENOTDIR");
+}
+
+// Imported lazily so the project list, which only builds thumbnail URLs, never
+// pulls playwright-core into the process.
+async function renderThumbnailWithChromium(request: ThumbnailRenderRequest): Promise<void> {
+  const { renderToPng } = await import("./export-png");
+  await renderToPng({
+    stagedDir: request.stagedDir,
+    entrypoint: request.entrypoint,
+    outputPath: request.outputPath,
+    width: THUMBNAIL_WIDTH,
+    height: THUMBNAIL_HEIGHT,
+    dpr: 1,
+    deck: request.deck,
+    signal: request.signal,
+  });
+}

--- a/packages/backend/src/services/reference-layout.ts
+++ b/packages/backend/src/services/reference-layout.ts
@@ -1,4 +1,5 @@
-import type { ReferenceLayoutContextV1 } from "@bg/shared";
+import path from "node:path";
+import type { ReferenceLayoutContextV1, UploadedVisualSourceSelection, VisualSourceRole } from "@bg/shared";
 import {
   hasReferenceLayoutIntent,
   isReferenceLayoutAttachment,
@@ -7,31 +8,42 @@ import {
   referenceLanguage,
 } from "./reference-layout-values";
 import { referenceExportConstraints } from "./reference-layout-export";
+import type { StageAttachmentInput } from "./stage-attachment-inputs";
 
 export type ReferenceLayoutAttachment = {
   readonly file_path: string;
   readonly mime_type: string;
   readonly original_name: string;
+  readonly source_role?: VisualSourceRole;
+  readonly source_role_explicit?: boolean;
 };
 
 export type ReferenceLayoutInput = {
   readonly request: string;
   readonly attachments: readonly ReferenceLayoutAttachment[];
   readonly requestedPaths: readonly string[];
+  readonly selections?: readonly UploadedVisualSourceSelection[];
+  readonly projectDir?: string;
+  readonly stageInputs?: readonly StageAttachmentInput[];
 };
 
 export function buildReferenceLayoutContext(
   input: ReferenceLayoutInput,
 ): ReferenceLayoutContextV1 | null {
   const requestDetected = hasReferenceLayoutIntent(input.request);
-  const selected = input.attachments.filter(
-    (attachment) =>
-      input.requestedPaths.includes(attachment.file_path) &&
-      isReferenceLayoutAttachment(attachment, requestDetected),
-  );
+  const selected = input.attachments.filter((attachment) => {
+    if (!input.requestedPaths.includes(attachment.file_path)) return false;
+    if (attachment.source_role === "immutable_reference") return true;
+    if (attachment.source_role_explicit === true) return false;
+    const explicit = input.selections?.find((selection) => selection.attachment_path === attachment.file_path);
+    return explicit?.role === "immutable_reference" || isReferenceLayoutAttachment(attachment, requestDetected);
+  });
   if (!requestDetected && selected.length === 0) return null;
 
   const reference = selected[0] ?? null;
+  const stageReference = reference === null ? undefined : input.stageInputs?.find((candidate) => candidate.attachmentPath === reference.file_path);
+  const relativeReference = reference === null || input.projectDir === undefined ? null : path.relative(input.projectDir, reference.file_path).replaceAll("\\", "/");
+  const referencePath = stageReference?.sourcePath ?? (relativeReference !== null && !relativeReference.startsWith("../") && relativeReference !== ".." ? relativeReference : reference?.file_path ?? null);
   const canvas = parseReferenceLayoutCanvas(input.request);
   return {
     schema_version: 1,
@@ -50,7 +62,7 @@ export function buildReferenceLayoutContext(
       reference === null
         ? null
         : {
-            attachment_path: reference.file_path,
+            attachment_path: referencePath ?? reference.file_path,
             original_name: reference.original_name,
             mime_type: reference.mime_type,
             role: "immutable_underlay",

--- a/packages/backend/src/services/research-purpose.ts
+++ b/packages/backend/src/services/research-purpose.ts
@@ -95,7 +95,8 @@ function creationMode(input: ResearchPurposeInput): CreationMode {
   switch (input.projectType) {
     case "from_template": return "template";
     case "prototype":
-    case "slide_deck": return input.hasCapturedFiles ? "existing" : "blank";
+    case "slide_deck":
+    case "graphic": return input.hasCapturedFiles ? "existing" : "blank";
     case "other": return "other";
   }
 }

--- a/packages/backend/src/services/stage-attachment-inputs.ts
+++ b/packages/backend/src/services/stage-attachment-inputs.ts
@@ -1,0 +1,142 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import path from "node:path";
+import type { VisualSourceRole } from "@bg/shared";
+import { assertSafeName } from "../security/path-boundary";
+import type { ImmutableSnapshot } from "./immutable-attachment-guard";
+import {
+  readManagedFile,
+  readOptionalManagedFile,
+  StageAttachmentInputError,
+  type MaterializationHooks,
+  writePrivateFile,
+} from "./stage-input-file-io";
+export { StageAttachmentInputError } from "./stage-input-file-io";
+
+const MAX_SOURCE_BYTES = 10 * 1024 * 1024;
+const MAX_EXTRACTED_TEXT_BYTES = 5 * 1024 * 1024;
+
+export type StageAttachmentInput = {
+  readonly attachmentId: string;
+  readonly attachmentPath: string;
+  readonly sourcePath: string;
+  readonly extractedTextPath: string | null;
+  readonly immutable: boolean;
+  readonly sourceSha256: string;
+  readonly sourceSize: number;
+};
+
+export type StageAttachment = {
+  readonly id: string;
+  readonly file_path: string;
+  readonly original_name: string;
+  readonly size_bytes: number;
+  readonly sha256: string | null;
+  readonly source_role: VisualSourceRole;
+};
+
+export function redactPrivateAttachmentPaths<T>(value: T, sources: readonly StageAttachmentInput[]): T {
+  const replacements = sources.flatMap((source) => {
+    const safeSource = `.attachments/${path.basename(source.attachmentPath)}`;
+    const paths: readonly (readonly [string, string])[] = [
+      [source.sourcePath, safeSource],
+      [path.dirname(source.sourcePath), ".attachments"],
+      [path.dirname(path.dirname(source.sourcePath)), "[private-operation]"],
+      ...(source.extractedTextPath === null ? [] : [[source.extractedTextPath, `${safeSource}.extracted.md`] as const]),
+    ];
+    return paths.flatMap(([privatePath, safePath]) => privatePath.includes("\\")
+      ? [[privatePath, safePath] as const, [privatePath.replaceAll("\\", "/"), safePath] as const]
+      : [[privatePath, safePath] as const]);
+  }).sort((left, right) => right[0].length - left[0].length);
+  const redactText = (text: string): string => replacements.reduce((safe, [privatePath, safePath]) => safe.replaceAll(privatePath, safePath), text);
+  const visit = (item: unknown): unknown => {
+    if (typeof item === "string") return redactText(item);
+    if (Array.isArray(item)) return item.map(visit);
+    if (item !== null && typeof item === "object") {
+      const entries = Object.entries(item);
+      const reserved = new Set(entries.filter(([key]) => redactText(key) === key).map(([key]) => key));
+      const used = new Set<string>();
+      let privateKey = 1;
+      return Object.fromEntries(entries.map(([key, nested]) => {
+        let safeKey = key;
+        if (redactText(key) !== key) {
+          do {
+            safeKey = privateKey === 1 ? "[private-input-path]" : `[private-input-path:${privateKey}]`;
+            privateKey += 1;
+          } while (reserved.has(safeKey) || used.has(safeKey));
+        }
+        used.add(safeKey);
+        return [safeKey, visit(nested)];
+      }));
+    }
+    return item;
+  };
+  return visit(value) as T;
+}
+
+export async function withPrivateAttachmentInputs<T>(
+  input: {
+    readonly operationDir: string;
+    readonly projectDir: string;
+    readonly attachments: readonly StageAttachment[];
+    readonly requestedPaths: readonly string[];
+    readonly immutableSnapshots: readonly ImmutableSnapshot[];
+    readonly hooks?: MaterializationHooks;
+  },
+  run: (sources: readonly StageAttachmentInput[]) => Promise<T>,
+): Promise<T> {
+  const privateDirectory = await mkdtemp(path.join(input.operationDir, "inputs-"));
+  let callbackStarted = false;
+  try {
+    const sources: StageAttachmentInput[] = [];
+    for (const requestedPath of input.requestedPaths) {
+      const attachment = input.attachments.find((candidate) => candidate.file_path === requestedPath);
+      if (attachment === undefined || attachment.sha256 === null || attachment.size_bytes > MAX_SOURCE_BYTES) throw new StageAttachmentInputError();
+      const safeOriginal = attachment.original_name.replace(/[^A-Za-z0-9_.-]+/gu, "_").slice(-80) || "attachment";
+      const fileName = assertSafeName(`${attachment.id}-${safeOriginal}`);
+      const immutable = input.immutableSnapshots.find((snapshot) => snapshot.filePath === attachment.file_path);
+      const sourceBytes = immutable?.bytes ?? await readManagedFile({
+        projectDir: input.projectDir,
+        filePath: attachment.file_path,
+        maximumBytes: MAX_SOURCE_BYTES,
+        expectedSize: attachment.size_bytes,
+        expectedSha256: attachment.sha256,
+        kind: "source",
+        hooks: input.hooks,
+      });
+      const sourceSha256 = createHash("sha256").update(sourceBytes).digest("hex");
+      if (sourceBytes.byteLength !== attachment.size_bytes || sourceSha256 !== attachment.sha256) throw new StageAttachmentInputError();
+      const sourcePath = path.join(privateDirectory, fileName);
+      await writePrivateFile(sourcePath, sourceBytes);
+      const extractedTextPath = await materializeExtractedText({
+        privateDirectory,
+        projectDir: input.projectDir,
+        attachmentPath: attachment.file_path,
+        fileName,
+        hooks: input.hooks,
+      });
+      sources.push({ attachmentId: attachment.id, attachmentPath: attachment.file_path, sourcePath, extractedTextPath, immutable: attachment.source_role === "immutable_reference", sourceSha256, sourceSize: sourceBytes.byteLength });
+    }
+    callbackStarted = true;
+    return await run(sources);
+  } catch (error) {
+    if (callbackStarted || error instanceof StageAttachmentInputError) throw error;
+    throw new StageAttachmentInputError();
+  } finally {
+    await rm(privateDirectory, { recursive: true, force: true });
+  }
+}
+
+async function materializeExtractedText(input: {
+  readonly privateDirectory: string;
+  readonly projectDir: string;
+  readonly attachmentPath: string;
+  readonly fileName: string;
+  readonly hooks?: MaterializationHooks;
+}): Promise<string | null> {
+  const bytes = await readOptionalManagedFile({ projectDir: input.projectDir, filePath: `${input.attachmentPath}.extracted.md`, maximumBytes: MAX_EXTRACTED_TEXT_BYTES, kind: "extracted", hooks: input.hooks });
+  if (bytes === null) return null;
+  const target = path.join(input.privateDirectory, `${input.fileName}.extracted.md`);
+  await writePrivateFile(target, bytes);
+  return target;
+}

--- a/packages/backend/src/services/stage-input-file-io.ts
+++ b/packages/backend/src/services/stage-input-file-io.ts
@@ -1,0 +1,87 @@
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { open, type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { resolveWithin } from "../security/path-boundary";
+
+export type MaterializationHooks = {
+  readonly afterOpen?: (kind: "source" | "extracted") => Promise<void>;
+};
+
+export class StageAttachmentInputError extends Error {
+  readonly name = "StageAttachmentInputError";
+  readonly code = "stage_attachment_input_invalid";
+  constructor() { super("stage_attachment_input_invalid"); }
+}
+
+type ManagedReadInput = {
+  readonly projectDir: string;
+  readonly filePath: string;
+  readonly maximumBytes: number;
+  readonly expectedSize?: number;
+  readonly expectedSha256?: string;
+  readonly kind: "source" | "extracted";
+  readonly hooks?: MaterializationHooks;
+};
+
+export async function readManagedFile(input: ManagedReadInput): Promise<Uint8Array> {
+  const bytes = await readManagedFileOrNull(input, false);
+  if (bytes === null) throw new StageAttachmentInputError();
+  return bytes;
+}
+
+export async function readOptionalManagedFile(input: ManagedReadInput): Promise<Uint8Array | null> {
+  return await readManagedFileOrNull(input, true);
+}
+
+async function readManagedFileOrNull(input: ManagedReadInput, optional: boolean): Promise<Uint8Array | null> {
+  const canonical = resolveManagedPath(input.projectDir, input.filePath);
+  if (canonical !== input.filePath) throw new StageAttachmentInputError();
+  let handle: FileHandle | null = null;
+  try {
+    try {
+      handle = await open(canonical, constants.O_RDONLY | constants.O_NOFOLLOW);
+    } catch (error) {
+      if (optional && error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+      throw error;
+    }
+    const before = await handle.stat();
+    if (!before.isFile() || before.size > input.maximumBytes || (input.expectedSize !== undefined && before.size !== input.expectedSize)) throw new StageAttachmentInputError();
+    await input.hooks?.afterOpen?.(input.kind);
+    const bytes = await readHandleBytes(handle, before.size);
+    const after = await handle.stat();
+    if (after.dev !== before.dev || after.ino !== before.ino || after.size !== before.size || bytes.byteLength !== before.size || (input.expectedSha256 !== undefined && createHash("sha256").update(bytes).digest("hex") !== input.expectedSha256)) throw new StageAttachmentInputError();
+    return bytes;
+  } finally {
+    await handle?.close();
+  }
+}
+
+function resolveManagedPath(projectDir: string, filePath: string): string {
+  return resolveWithin(projectDir, ".attachments", path.basename(filePath));
+}
+
+export async function writePrivateFile(filePath: string, bytes: Uint8Array): Promise<void> {
+  const handle = await open(filePath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW, 0o400);
+  try {
+    let offset = 0;
+    while (offset < bytes.byteLength) {
+      const { bytesWritten } = await handle.write(bytes, offset, bytes.byteLength - offset, offset);
+      offset += bytesWritten;
+    }
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readHandleBytes(handle: FileHandle, size: number): Promise<Uint8Array> {
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  while (offset < size) {
+    const { bytesRead } = await handle.read(bytes, offset, size - offset, offset);
+    if (bytesRead === 0) break;
+    offset += bytesRead;
+  }
+  return offset === size ? bytes : bytes.subarray(0, offset);
+}

--- a/packages/backend/src/services/turn-error-sanitizer.ts
+++ b/packages/backend/src/services/turn-error-sanitizer.ts
@@ -1,0 +1,59 @@
+import type { NormalizedEvent, TurnErrorCode } from "@bg/shared";
+import { PathBoundaryError } from "../security/path-boundary";
+
+const COPY: Readonly<Record<TurnErrorCode, string>> = {
+  backend_unavailable: "선택한 작업 도구를 사용할 수 없어요. 설치 상태를 확인해 주세요.",
+  path_unavailable: "프로젝트 파일에 안전하게 접근할 수 없어요. 다시 시도해 주세요.",
+  immutable_reference_mutated: "읽기 전용 참조 파일이 변경되어 작업을 중단했어요.",
+  immutable_reference_path_unavailable: "읽기 전용 참조 파일에 안전하게 접근할 수 없어 작업을 중단했어요.",
+  immutable_reference_escaped: "읽기 전용 참조 파일은 결과물에 복사할 수 없어요.",
+  private_input_unavailable: "첨부 파일을 안전하게 준비하지 못했어요. 다시 시도해 주세요.",
+  publication_failed: "결과물을 안전하게 저장하지 못했어요. 다시 시도해 주세요.",
+  operation_conflict: "다른 작업이 진행 중이에요. 잠시 후 다시 시도해 주세요.",
+  operation_cancelled: "작업이 취소되었어요.",
+  turn_failed: "요청을 처리하지 못했어요. 다시 시도해 주세요.",
+};
+
+export function sanitizeTurnEvent(event: NormalizedEvent, cause?: unknown): NormalizedEvent {
+  if (event.type !== "status.error") return event;
+  const code = turnErrorCode(cause, event.code ?? event.message);
+  return { ...event, code, message: COPY[code] };
+}
+
+export function turnErrorCode(error: unknown, fallback?: string): TurnErrorCode {
+  if (error instanceof PathBoundaryError) return "path_unavailable";
+  return knownCode(errorCode(error)) ??
+    knownCode(error instanceof Error ? error.message : undefined) ??
+    knownCode(fallback) ??
+    "turn_failed";
+}
+
+function knownCode(candidate: string | undefined): TurnErrorCode | undefined {
+  switch (candidate) {
+    case "backend_unavailable":
+    case "immutable_reference_mutated":
+    case "immutable_reference_path_unavailable":
+    case "immutable_reference_escaped":
+    case "operation_conflict":
+    case "operation_cancelled":
+    case "publication_failed":
+    case "turn_failed":
+      return candidate;
+    case "stage_attachment_input_invalid":
+    case "private_input_unavailable":
+      return "private_input_unavailable";
+    case "invalid_name":
+    case "outside_root":
+    case "invalid_path":
+    case "path_unavailable":
+    case "project_path_unavailable":
+      return "path_unavailable";
+    default:
+      return undefined;
+  }
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("code" in error)) return undefined;
+  return typeof error.code === "string" ? error.code : undefined;
+}

--- a/packages/backend/src/services/turns.ts
+++ b/packages/backend/src/services/turns.ts
@@ -19,6 +19,7 @@ import { detectBackends } from "./backends";
 import { buildPrompt } from "../harness/prompt-builder";
 import { runAdapterTurn } from "../adapters/registry";
 import { loadConfig } from "../config";
+import { isDirectionOperationActive } from "./direction-operation-registry";
 
 type ToolDecision = Extract<UserEvent, { type: "user.tool_decision" }>;
 
@@ -118,7 +119,7 @@ export function submitToolDecisionToTurn(
 }
 
 export function startUserTurn(sessionId: string, payload: Extract<UserEvent, { type: "user.message" }>, requestedOperationId?: string) {
-  if (activeTurns.has(sessionId)) return null;
+  if (activeTurns.has(sessionId) || isDirectionOperationActive(sessionId)) return null;
   const activeTurn: ActiveTurn = { abortController: new AbortController(), interrupted: false, decisionQueue: [], decisionHandler: null };
   const turnId = ulid();
   const operationId = requestedOperationId ?? ulid();

--- a/packages/backend/src/services/turns.ts
+++ b/packages/backend/src/services/turns.ts
@@ -1,4 +1,5 @@
 import { readdir } from "node:fs/promises";
+import path from "node:path";
 import { ulid } from "ulid";
 import type { NormalizedEvent, UserEvent } from "@bg/shared";
 import { assignAttachmentsToTurn } from "../db/attachments";
@@ -20,10 +21,15 @@ import { buildPrompt } from "../harness/prompt-builder";
 import { runAdapterTurn } from "../adapters/registry";
 import { loadConfig } from "../config";
 import { isDirectionOperationActive } from "./direction-operation-registry";
+import { buildVisualSourceManifest } from "./visual-source-manifest";
+import { captureImmutableAttachments, verifyImmutableAttachments } from "./immutable-attachment-guard";
+import { redactPrivateAttachmentPaths, withPrivateAttachmentInputs } from "./stage-attachment-inputs";
+import { sanitizeTurnEvent } from "./turn-error-sanitizer";
 
 type ToolDecision = Extract<UserEvent, { type: "user.tool_decision" }>;
 
 interface ActiveTurn {
+  readonly reservationId: string;
   abortController: AbortController;
   interrupted: boolean;
   /**
@@ -46,14 +52,24 @@ async function listDirSafe(dir: string): Promise<string[] | string> {
   }
 }
 
-async function persistAndPublish(sessionId: string, event: NormalizedEvent) {
-  const persisted = await insertNormalizedEvent(sessionId, event);
+export async function persistAndPublish(sessionId: string, event: NormalizedEvent, cause?: unknown) {
+  if (cause !== undefined) {
+    console.error("[turn] error diagnostic", cause);
+    await appendSessionTrace(sessionId, { level: "turn_error_diagnostic", error: diagnosticError(cause) });
+  }
+  const safeEvent = sanitizeTurnEvent(event, cause);
+  const persisted = await insertNormalizedEvent(sessionId, safeEvent);
   await appendSessionTrace(sessionId, {
     level: "event",
-    event,
+    event: safeEvent,
   });
-  broker.publish(sessionId, event);
+  broker.publish(sessionId, safeEvent);
   sequencedBroker.publish(sessionId, persisted);
+}
+
+function diagnosticError(error: unknown): Readonly<Record<string, unknown>> {
+  if (!(error instanceof Error)) return { value: String(error) };
+  return { name: error.name, message: error.message, stack: error.stack, ...("code" in error ? { code: error.code } : {}) };
 }
 
 /**
@@ -118,19 +134,40 @@ export function submitToolDecisionToTurn(
   return "queued";
 }
 
-export function startUserTurn(sessionId: string, payload: Extract<UserEvent, { type: "user.message" }>, requestedOperationId?: string) {
+export type UserTurnReservation = {
+  readonly reservationId: string;
+  readonly sessionId: string;
+  readonly turnId: string;
+  readonly operationId: string;
+};
+
+export function reserveUserTurn(sessionId: string, requestedOperationId?: string): UserTurnReservation | null {
   if (activeTurns.has(sessionId) || isDirectionOperationActive(sessionId)) return null;
-  const activeTurn: ActiveTurn = { abortController: new AbortController(), interrupted: false, decisionQueue: [], decisionHandler: null };
-  const turnId = ulid();
-  const operationId = requestedOperationId ?? ulid();
+  const reservation = { reservationId: ulid(), sessionId, turnId: ulid(), operationId: requestedOperationId ?? ulid() };
+  activeTurns.set(sessionId, { reservationId: reservation.reservationId, abortController: new AbortController(), interrupted: false, decisionQueue: [], decisionHandler: null });
+  return reservation;
+}
+
+export function releaseUserTurnReservation(reservation: UserTurnReservation): void {
+  if (activeTurns.get(reservation.sessionId)?.reservationId === reservation.reservationId) activeTurns.delete(reservation.sessionId);
+}
+
+export function startReservedUserTurn(reservation: UserTurnReservation, payload: Extract<UserEvent, { type: "user.message" }>) {
+  const activeTurn = activeTurns.get(reservation.sessionId);
+  if (activeTurn?.reservationId !== reservation.reservationId) return null;
+  const { sessionId, turnId, operationId } = reservation;
   let resolvePrepared: () => void = () => {};
   let rejectPrepared: (error: unknown) => void = () => {};
   const prepared = new Promise<void>((resolve, reject) => { resolvePrepared = resolve; rejectPrepared = reject; });
-  activeTurns.set(sessionId, activeTurn);
   const promise = runUserTurnInternal(sessionId, payload, activeTurn, turnId, operationId, resolvePrepared)
     .catch((error: unknown) => { rejectPrepared(error); throw error; })
     .finally(() => activeTurns.delete(sessionId));
   return { promise, prepared, turnId, operationId };
+}
+
+export function startUserTurn(sessionId: string, payload: Extract<UserEvent, { type: "user.message" }>, requestedOperationId?: string) {
+  const reservation = reserveUserTurn(sessionId, requestedOperationId);
+  return reservation === null ? null : startReservedUserTurn(reservation, payload);
 }
 
 async function runUserTurnInternal(
@@ -141,11 +178,6 @@ async function runUserTurnInternal(
   operationId: string,
   onPrepared: () => void,
 ) {
-  const sessionContext = await buildSessionContext(sessionId);
-  if (!sessionContext) {
-    throw new Error("session_not_found");
-  }
-
   const session = await getSessionInfo(sessionId);
   if (!session) {
     throw new Error("session_not_found");
@@ -157,7 +189,14 @@ async function runUserTurnInternal(
     payload.attachments ?? [],
     turnId,
   );
-
+  const sessionContext = await buildSessionContext(sessionId);
+  if (!sessionContext) throw new Error("session_not_found");
+  const visualSources = await buildVisualSourceManifest({
+    projectDir: sessionContext.project.project_dir,
+    attachments: sessionContext.attachments,
+    requestedPaths: payload.attachments ?? [],
+    selections: payload.visualSources,
+  });
   await insertUserEvent(sessionId, payload);
   await appendSessionTrace(sessionId, {
     level: "input",
@@ -172,14 +211,16 @@ async function runUserTurnInternal(
   // (page reload, history fetch) renders the full conversation — not just
   // the agent side. `direction=up` user events are filtered out by
   // listSessionEvents, so without this the user bubble would disappear.
-  await persistAndPublish(sessionId, {
+  const userMessage: NormalizedEvent = {
     id: ulid(),
     ts: startTs,
     type: "chat.user_message",
     turnId,
     text: payload.text,
     attachmentCount,
-  });
+    ...(visualSources === null ? {} : { visualSources }),
+  };
+  await persistAndPublish(sessionId, userMessage);
 
   await persistAndPublish(sessionId, {
     id: ulid(),
@@ -195,6 +236,7 @@ async function runUserTurnInternal(
       id: ulid(),
       ts: Date.now(),
       type: "status.error",
+      code: "backend_unavailable",
       message: `${backendId} CLI not found on PATH. ${backend?.install_hint ?? "Install and retry."}`,
       recoverable: true,
     });
@@ -210,49 +252,63 @@ async function runUserTurnInternal(
 
   const binaryPath = backend.binary_path;
   const config = await loadConfig();
-  const prompt = await buildPrompt(sessionContext, payload, { contextMode: config.chat.contextMode });
-  await appendSessionTrace(sessionId, { level: "prompt_built", turnId, prompt_chars: prompt.length, context_mode: config.chat.contextMode, backend_id: backendId, binary: binaryPath });
   const projectDir = sessionContext.project.project_dir;
   const project = await getProjectDetail(sessionContext.project.project_id);
   if (project === null) throw new Error("project_not_found");
   const coordinator = new ArtifactCoordinator(getSqlite());
   const base = await coordinator.initialize(project.id, projectDir);
   let operationPrepared = false;
+  const terminalEvents: NormalizedEvent[] = [];
+  const selectedAttachments = sessionContext.attachments.filter((attachment) => payload.attachments?.includes(attachment.file_path) ?? false);
+  const forbiddenSha256 = new Set(selectedAttachments.filter((attachment) => attachment.source_role === "immutable_reference").flatMap((attachment) => attachment.sha256 === null ? [] : [attachment.sha256]));
   try {
     await coordinator.run({
       projectId: project.id, projectDir, kind: "turn", operationId,
       expectedRevision: project.current_revision, expectedArtifactDigest: base.tree_digest,
+      publicationPolicy: { forbiddenSha256 },
       onPrepared: () => { operationPrepared = true; onPrepared(); },
       mutate: async (stageDir) => {
         const waitsForInterrupt = process.env.BG_ARTIFACT_QA === "1" && operationId === process.env.BG_ARTIFACT_TURN_OPERATION_ID && process.env.BG_ARTIFACT_TURN_BARRIER === "abort";
         if (waitsForInterrupt && !activeTurn.abortController.signal.aborted) await new Promise<void>((resolve) => activeTurn.abortController.signal.addEventListener("abort", () => resolve(), { once: true }));
         if (activeTurn.abortController.signal.aborted) throw new ArtifactOperationError("operation_cancelled", "Turn was interrupted");
         await appendSessionTrace(sessionId, { level: "adapter_stage_dir", turnId, operationId, projectDir: stageDir });
-        await runAdapterTurn(backendId, {
-          sessionId, turnId, projectDir: stageDir, binaryPath, prompt,
-          signal: activeTurn.abortController.signal, userEvent: payload,
-          onEvent: async (event) => {
-            if (event.type === "file.changed") return;
-            await persistAndPublish(sessionId, event);
-            if (event.type === "usage.delta") await bumpSessionUsage(sessionId, { input: event.input, output: event.output, cached: event.cached ?? 0 });
-          },
-          onStderr: async (line) => { await appendSessionTrace(sessionId, { level: "stderr", turnId, line }); },
-          onDecision: (handler) => {
-            activeTurn.decisionHandler = handler;
-            for (const decision of activeTurn.decisionQueue.splice(0)) handler(decision);
-            return () => { if (activeTurn.decisionHandler === handler) activeTurn.decisionHandler = null; };
-          },
-        });
+        const immutableSnapshots = await captureImmutableAttachments(selectedAttachments);
+        try {
+          await withPrivateAttachmentInputs({ operationDir: path.dirname(stageDir), projectDir, attachments: sessionContext.attachments, requestedPaths: payload.attachments ?? [], immutableSnapshots }, async (stageInputs) => {
+            const prompt = await buildPrompt(sessionContext, payload, { contextMode: config.chat.contextMode, visualSourceManifest: visualSources, stageAttachmentInputs: stageInputs });
+            await appendSessionTrace(sessionId, { level: "prompt_built", turnId, prompt_chars: prompt.length, context_mode: config.chat.contextMode, backend_id: backendId, binary: binaryPath });
+            await runAdapterTurn(backendId, {
+              sessionId, turnId, projectDir: stageDir, binaryPath, prompt,
+              signal: activeTurn.abortController.signal, userEvent: payload,
+              onEvent: async (event) => {
+                if (event.type === "file.changed") return;
+                const safeEvent = redactPrivateAttachmentPaths(event, stageInputs);
+                if (safeEvent.type === "chat.message_end" || safeEvent.type === "status.idle") { terminalEvents.push(safeEvent); return; }
+                const eventError = event.type === "status.error" ? Object.assign(new Error(event.message), event.code === undefined ? {} : { code: event.code }) : undefined;
+                await persistAndPublish(sessionId, safeEvent, eventError);
+                if (safeEvent.type === "usage.delta") await bumpSessionUsage(sessionId, { input: safeEvent.input, output: safeEvent.output, cached: safeEvent.cached ?? 0 });
+              },
+              onStderr: async (line) => { await appendSessionTrace(sessionId, { level: "stderr", turnId, line }); },
+              onDecision: (handler) => {
+                activeTurn.decisionHandler = handler;
+                for (const decision of activeTurn.decisionQueue.splice(0)) handler(decision);
+                return () => { if (activeTurn.decisionHandler === handler) activeTurn.decisionHandler = null; };
+              },
+            });
+          });
+        } finally {
+          await verifyImmutableAttachments(immutableSnapshots);
+        }
         if (activeTurn.abortController.signal.aborted) throw new ArtifactOperationError("operation_cancelled", "Turn was interrupted");
       },
     });
+    for (const event of terminalEvents) await persistAndPublish(sessionId, event);
   } catch (error) {
     if (!operationPrepared) throw error;
     if (activeTurn.interrupted || activeTurn.abortController.signal.aborted) {
       await persistAndPublish(sessionId, { id: ulid(), ts: Date.now(), type: "status.idle", stopReason: "interrupted" });
     } else {
-      const message = error instanceof Error ? error.message : String(error);
-      await persistAndPublish(sessionId, { id: ulid(), ts: Date.now(), type: "status.error", message, recoverable: true });
+      await persistAndPublish(sessionId, { id: ulid(), ts: Date.now(), type: "status.error", message: "turn_failed", recoverable: true }, error);
       await persistAndPublish(sessionId, { id: ulid(), ts: Date.now(), type: "status.idle", stopReason: "error" });
     }
     await setSessionStatus(sessionId, "idle");

--- a/packages/backend/src/services/upload-kind.ts
+++ b/packages/backend/src/services/upload-kind.ts
@@ -1,6 +1,9 @@
 import path from "node:path";
 
-export type SupportedUploadKind = "pdf" | "pptx";
+/** The only source kinds the upload extractor can truthfully process. */
+export const SUPPORTED_UPLOAD_KINDS = ["pdf", "pptx"] as const;
+
+export type SupportedUploadKind = (typeof SUPPORTED_UPLOAD_KINDS)[number];
 
 export function inferUploadKind(fileName: string, contentType?: string | null): SupportedUploadKind | null {
   const extension = path.extname(fileName).toLowerCase();

--- a/packages/backend/src/services/visual-source-manifest.ts
+++ b/packages/backend/src/services/visual-source-manifest.ts
@@ -1,0 +1,99 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { readFile } from "node:fs/promises";
+import type {
+  UploadedVisualSourceSelection,
+  VisualSourceManifestEntry,
+  VisualSourceManifestV1,
+  VisualSourceRole,
+} from "@bg/shared";
+import { resolveWithin } from "../security/path-boundary";
+
+export type VisualSourceAttachment = {
+  readonly id: string;
+  readonly session_id: string;
+  readonly turn_id: string | null;
+  readonly file_path: string;
+  readonly mime_type: string;
+  readonly original_name: string;
+  readonly size_bytes: number;
+  readonly sha256: string | null;
+  readonly source_role: VisualSourceRole;
+  readonly source_role_explicit: boolean;
+};
+
+export class VisualSourceProvenanceError extends Error {
+  readonly name = "VisualSourceProvenanceError";
+  readonly code = "invalid_visual_source_provenance";
+  constructor() {
+    super("invalid_visual_source_provenance");
+  }
+}
+
+export async function buildVisualSourceManifest(input: {
+  readonly projectDir: string;
+  readonly attachments: readonly VisualSourceAttachment[];
+  readonly requestedPaths: readonly string[];
+  readonly selections: readonly UploadedVisualSourceSelection[] | undefined;
+}): Promise<VisualSourceManifestV1 | null> {
+  if (input.requestedPaths.length === 0) return null;
+  const selectedAttachments = input.requestedPaths.map((requestedPath) => input.attachments.find((attachment) => attachment.file_path === requestedPath));
+  if (selectedAttachments.some((attachment) => attachment === undefined)) fail();
+  const selections = input.selections === undefined || input.selections.length === 0
+    ? selectedAttachments.map((attachment) => ({ source_type: "uploaded_attachment" as const, attachment_path: attachment?.file_path ?? "", role: attachment?.source_role ?? "ordinary_content" }))
+    : input.selections;
+  const uniquePaths = new Set(selections.map((selection) => selection.attachment_path));
+  if (uniquePaths.size !== selections.length || selections.length !== input.requestedPaths.length) fail();
+  const sources: VisualSourceManifestEntry[] = [];
+  for (const selection of selections) {
+    const attachment = input.attachments.find((candidate) => candidate.file_path === selection.attachment_path);
+    if (attachment === undefined || attachment.source_role !== selection.role) fail();
+    try {
+      sources.push(await manifestEntry(input.projectDir, attachment));
+    } catch (error) {
+      if (error instanceof VisualSourceProvenanceError) throw error;
+      fail();
+    }
+  }
+  return { schema_version: 1, network_sources: "unsupported", sources };
+}
+
+async function manifestEntry(projectDir: string, attachment: VisualSourceAttachment): Promise<VisualSourceManifestEntry> {
+  if (attachment.turn_id === null || attachment.sha256 === null || !/^[a-f0-9]{64}$/u.test(attachment.sha256)) fail();
+  const attachmentsDir = resolveWithin(projectDir, ".attachments");
+  const managedPath = resolveWithin(attachmentsDir, path.basename(attachment.file_path));
+  if (managedPath !== attachment.file_path || path.dirname(managedPath) !== attachmentsDir) fail();
+  const bytes = await readFile(managedPath).catch(() => fail());
+  if (bytes.byteLength !== attachment.size_bytes || createHash("sha256").update(bytes).digest("hex") !== attachment.sha256) fail();
+  const common = {
+    source_type: "uploaded_attachment" as const,
+    attachment_id: attachment.id,
+    original_name: attachment.original_name,
+    mime_type: attachment.mime_type,
+    size_bytes: attachment.size_bytes,
+    preflight_verified_sha256: attachment.sha256,
+    managed_path: `.attachments/${path.basename(managedPath)}`,
+    role_origin: attachment.source_role_explicit ? "explicit" as const : "legacy_inferred" as const,
+    provenance: {
+      session_id: attachment.session_id,
+      turn_id: attachment.turn_id,
+      storage: "managed_attachment" as const,
+    },
+  };
+  if (attachment.source_role === "ordinary_content") return { ...common, role: "ordinary_content" };
+  return {
+    ...common,
+    role: "immutable_reference",
+    policy: {
+      original_file: "preserve",
+      original_hash: "preserve",
+      never_overwrite: true,
+      never_copy_into_authored_output: true,
+      derived_artifact: "separate",
+    },
+  };
+}
+
+function fail(): never {
+  throw new VisualSourceProvenanceError();
+}

--- a/packages/backend/src/services/watchers.ts
+++ b/packages/backend/src/services/watchers.ts
@@ -11,7 +11,7 @@ import {
   projectWatchers as watchers,
 } from "./watcher-registry";
 
-const IGNORED_TOP_LEVEL = new Set([".meta", ".attachments", ".git", ".omc", ".claude"]);
+const IGNORED_TOP_LEVEL = new Set([".meta", ".attachments", ".burnguard-inputs", ".git", ".omc", ".claude"]);
 const pendingSignals = new Set<string>();
 
 type ErrorAwareWatcher = FSWatcher & {

--- a/packages/backend/tests/artifact-operations.test.ts
+++ b/packages/backend/tests/artifact-operations.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, truncate, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { createHash } from "node:crypto";
 import { ArtifactCoordinator, ArtifactOperationError } from "../src/services/artifact-coordinator";
-import { inspectCanonicalTree } from "../src/services/canonical-tree-manifest";
+import { DEFAULT_CANONICAL_TREE_LIMITS, inspectCanonicalTree } from "../src/services/canonical-tree-manifest";
 import { parseArtifactReplay, parseArtifactRetention, parseArtifactSnapshot } from "../src/services/artifact-receipts";
 import { fingerprintHtmlNode } from "../src/services/file-patch";
 import { requireArtifactIdentity } from "../src/services/artifact-identity";
@@ -180,7 +181,65 @@ describe("artifact coordinator", () => {
     expect((await inspectCanonicalTree(root)).tree_digest).toBe(base.tree_digest);
     expect(await readFile(path.join(root, "index.html"), "utf8")).toContain("Old");
     expect(await readFile(path.join(root, "style.css"), "utf8")).toBe("old");
-    expect(db.query("SELECT status FROM artifact_operations WHERE json_extract(replay_json,'$.kind')!='initialize'").get()).toEqual({ status: "failed" });
+    expect(db.query("SELECT status,json_extract(retention_json,'$.replayable') replayable FROM artifact_operations WHERE json_extract(replay_json,'$.kind')!='initialize'").get()).toEqual({ status: "failed", replayable: 1 });
+    const failedPath = db.query<{ readonly path: string }, []>("SELECT json_extract(snapshot_json,'$.stage_path') path FROM artifact_operations WHERE json_extract(replay_json,'$.kind')!='initialize'").get()?.path;
+    expect(failedPath).toBeDefined();
+    expect(await readFile(path.join(failedPath ?? "missing", "index.html"), "utf8")).toBe("new");
+  });
+
+  test("Given a post-manifest candidate replacement exceeds the canonical byte bound When publishing Then it rejects before read allocation or destination write", async () => {
+    const sourceReads: string[] = [];
+    let publicationWrites = 0;
+    const operationId = "oversized-publication-source";
+    const coordinator = new ArtifactCoordinator(db, {
+      beforePublishRead: async (relativePath) => {
+        if (relativePath === "large.bin") await truncate(path.join(root, ".meta", "artifact-operations", operationId, "stage", relativePath), DEFAULT_CANONICAL_TREE_LIMITS.bytes + 1);
+      },
+      beforePublishSourceRead: (relativePath) => { sourceReads.push(relativePath); },
+      afterPublishWrite: () => { publicationWrites += 1; },
+    });
+    const base = await coordinator.initialize("p", root);
+
+    await expect(coordinator.run({ projectId: "p", projectDir: root, kind: "turn", operationId, expectedRevision: 0, expectedArtifactDigest: base.tree_digest, mutate: async (stage) => {
+      await writeFile(path.join(stage, "index.html"), "changed");
+      await writeFile(path.join(stage, "large.bin"), "small-before-publication");
+    } })).rejects.toMatchObject({ code: "operation_failed" });
+
+    expect(sourceReads).toEqual(["index.html"]);
+    expect(publicationWrites).toBe(0);
+    expect(await readFile(path.join(root, "index.html"), "utf8")).toContain("Old");
+    await expect(readFile(path.join(root, "large.bin"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("Given nested immutable bytes or a publication-time swap When publishing Then typed rejection writes no result bytes and prunes the failed operation", async () => {
+    const forbiddenBytes = new TextEncoder().encode("immutable-source");
+    const forbiddenHash = createHash("sha256").update(forbiddenBytes).digest("hex");
+    for (const swapAtPublication of [false, true]) {
+      const operationId = `security-${swapAtPublication}`;
+      let publishedWrites = 0;
+      const coordinator = new ArtifactCoordinator(db, {
+        ...(swapAtPublication ? { beforePublishRead: async (relativePath: string) => {
+          if (relativePath === "nested/output.bin") await writeFile(path.join(root, ".meta", "artifact-operations", operationId, "stage", relativePath), forbiddenBytes);
+        } } : {}),
+        afterPublishWrite: () => { publishedWrites += 1; },
+      });
+      const base = await coordinator.initialize("p", root);
+      await expect(coordinator.run({
+        projectId: "p", projectDir: root, kind: "turn", operationId,
+        expectedRevision: 0, expectedArtifactDigest: base.tree_digest,
+        publicationPolicy: { forbiddenSha256: new Set([forbiddenHash]) },
+        mutate: async (stage) => {
+          await writeFile(path.join(stage, "index.html"), "changed");
+          await mkdir(path.join(stage, "nested"), { recursive: true });
+          await writeFile(path.join(stage, "nested", "output.bin"), swapAtPublication ? "safe-content-000" : forbiddenBytes);
+        },
+      })).rejects.toMatchObject({ code: "immutable_reference_escaped" });
+      expect(publishedWrites).toBe(0);
+      expect(await readFile(path.join(root, "index.html"), "utf8")).toContain("Old");
+      await expect(readFile(path.join(root, "nested", "output.bin"))).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(readdir(path.join(root, ".meta", "artifact-operations", operationId))).rejects.toMatchObject({ code: "ENOENT" });
+      expect(db.query("SELECT status,json_extract(retention_json,'$.replayable') replayable FROM artifact_operations WHERE id=?").get(operationId)).toEqual({ status: "failed", replayable: 0 });
+    }
   });
 
   test("Given two same-base operations When the first owns authority Then the second conflicts and only one revision commits", async () => {

--- a/packages/backend/tests/attachment-intake.test.ts
+++ b/packages/backend/tests/attachment-intake.test.ts
@@ -1,0 +1,164 @@
+import { afterAll, afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { runMigrations } from "../src/db/migrate-local";
+import { insertAttachmentRecord } from "../src/db/attachment-context";
+import { getSqlite } from "../src/db/sqlite-client";
+import { sessionRoutes } from "../src/routes/session";
+import {
+  ATTACHMENT_LIMITS,
+  UnsupportedAttachmentKindError,
+  saveSessionAttachments,
+} from "../src/services/attachments";
+import { SUPPORTED_UPLOAD_KINDS, inferUploadKind } from "../src/services/upload-kind";
+
+// The real extractor shells out to Python. Mocked at its narrowest seam so the
+// intake gate — which runs entirely before extraction — is deterministic here.
+let extractorCalls: string[] = [];
+mock.module("../src/services/attachment-extraction", () => ({
+  extractAttachmentUpload: async (input: { readonly originalName: string }) => {
+    extractorCalls.push(input.originalName);
+  },
+}));
+
+const projectId = `attachment-intake-${process.pid}`;
+const sessionId = `${projectId}-session`;
+let root = "";
+
+function file(name: string, type = "", sizeBytes = 8): File {
+  const value = new File([new Uint8Array(Math.min(sizeBytes, 1024))], name, { type });
+  if (sizeBytes > 1024) Object.defineProperty(value, "size", { value: sizeBytes });
+  return value;
+}
+
+function attachmentRowCount(): number {
+  return getSqlite()
+    .query<{ readonly count: number }, [string]>("SELECT COUNT(*) count FROM attachments WHERE session_id=?")
+    .get(sessionId)?.count ?? 0;
+}
+
+async function storedFileNames(): Promise<readonly string[]> {
+  return await readdir(path.join(root, ".attachments")).catch(() => [] as string[]);
+}
+
+beforeAll(async () => {
+  await runMigrations();
+  root = await mkdtemp(path.join(tmpdir(), "burnguard-attachment-intake-"));
+  getSqlite()
+    .prepare("INSERT INTO projects(id,name,type,dir_path,entrypoint,backend_id,created_at,updated_at) VALUES (?,?,'prototype',?,'index.html','codex',1,1)")
+    .run(projectId, projectId, root);
+  getSqlite()
+    .prepare("INSERT INTO sessions(id,project_id,backend_id,status,created_at,updated_at,last_active_at) VALUES (?,?,'codex','idle',1,1,1)")
+    .run(sessionId, projectId);
+});
+
+afterEach(() => {
+  extractorCalls = [];
+});
+
+afterAll(async () => {
+  getSqlite().prepare("DELETE FROM attachments WHERE session_id=?").run(sessionId);
+  getSqlite().prepare("DELETE FROM projects WHERE id=?").run(projectId);
+  await rm(root, { recursive: true, force: true });
+  mock.restore();
+});
+
+describe("session attachment intake", () => {
+  test("Given a source kind the extractor cannot process When saving Then it throws a typed unsupported error and persists nothing", async () => {
+    const before = attachmentRowCount();
+
+    const failure = await saveSessionAttachments(sessionId, [file("notes.txt", "text/plain")]).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(UnsupportedAttachmentKindError);
+    expect(failure).toMatchObject({ code: "unsupported_file_kind", fileNames: ["notes.txt"] });
+    expect(attachmentRowCount()).toBe(before);
+    expect(await storedFileNames()).toEqual([]);
+    expect(extractorCalls).toEqual([]);
+  });
+
+  test("Given a batch mixing supported and unsupported kinds When saving Then the whole batch is rejected before any write", async () => {
+    const before = attachmentRowCount();
+
+    const failure = await saveSessionAttachments(sessionId, [
+      file("deck.pdf", "application/pdf"),
+      file("archive.zip", "application/zip"),
+    ]).then(() => null, (error: unknown) => error);
+
+    expect(failure).toMatchObject({ code: "unsupported_file_kind", fileNames: ["archive.zip"] });
+    expect(attachmentRowCount()).toBe(before);
+    expect(await storedFileNames()).toEqual([]);
+    expect(extractorCalls).toEqual([]);
+  });
+
+  test("Given a supported source kind When saving Then it is persisted and handed to the extractor", async () => {
+    const before = attachmentRowCount();
+
+    const saved = await saveSessionAttachments(sessionId, [file("deck.pdf", "application/pdf")]);
+
+    expect(saved).toHaveLength(1);
+    expect(attachmentRowCount()).toBe(before + 1);
+    expect((await storedFileNames()).some((name) => name.endsWith("-deck.pdf"))).toBe(true);
+    expect(extractorCalls).toEqual(["deck.pdf"]);
+  });
+
+  test("Given previously stored unsupported attachments When a new upload is rejected Then the stored rows survive", async () => {
+    const legacyPath = path.join(root, ".attachments", "legacy-note.txt");
+    insertAttachmentRecord({
+      sessionId,
+      filePath: legacyPath,
+      mimeType: "text/plain",
+      originalName: "legacy-note.txt",
+      sizeBytes: 4,
+      sha256: "deadbeef",
+    });
+
+    await saveSessionAttachments(sessionId, [file("legacy-note.txt", "text/plain")]).catch(() => null);
+
+    const legacy = getSqlite()
+      .query<{ readonly file_path: string }, [string]>("SELECT file_path FROM attachments WHERE session_id=? AND original_name='legacy-note.txt'")
+      .all(sessionId);
+    expect(legacy).toEqual([{ file_path: legacyPath }]);
+  });
+
+  test("Given batches past the count and size limits When saving Then the existing limit errors still fire", async () => {
+    const tooMany = Array.from({ length: ATTACHMENT_LIMITS.maxCount + 1 }, (_, i) => file(`deck-${i}.pdf`, "application/pdf"));
+    await expect(saveSessionAttachments(sessionId, tooMany)).rejects.toThrow(/attachment_limit_exceeded/);
+
+    const oversized = file("huge.pdf", "application/pdf", ATTACHMENT_LIMITS.maxBytesPerFile + 1);
+    await expect(saveSessionAttachments(sessionId, [oversized])).rejects.toThrow(/attachment_too_large/);
+
+    const overTotal = Array.from({ length: 3 }, (_, i) => file(`big-${i}.pdf`, "application/pdf", 9 * 1024 * 1024));
+    await expect(saveSessionAttachments(sessionId, overTotal)).rejects.toThrow(/attachment_total_too_large/);
+  });
+
+  test("Given the upload kind extractor When asked what it can process Then only its declared kinds are accepted", () => {
+    expect([...SUPPORTED_UPLOAD_KINDS]).toEqual(["pdf", "pptx"]);
+    expect(inferUploadKind("deck.pdf", null)).toBe("pdf");
+    expect(inferUploadKind("deck.pptx", null)).toBe("pptx");
+    expect(inferUploadKind("notes.txt", "text/plain")).toBeNull();
+    expect(inferUploadKind("image.png", "image/png")).toBeNull();
+  });
+});
+
+describe("session events multipart route", () => {
+  test("Given an unsupported upload When posted as multipart Then the route answers a structured typed error", async () => {
+    const before = attachmentRowCount();
+    const form = new FormData();
+    form.set("type", "user.message");
+    form.set("text", "이 파일 좀 봐줘");
+    form.append("files", file("notes.txt", "text/plain"));
+
+    const response = await sessionRoutes.request(`http://local/api/sessions/${sessionId}/events`, { method: "POST", body: form });
+    const body = (await response.json()) as { readonly error: { readonly code: string; readonly details: { readonly files: readonly string[]; readonly supported_kinds: readonly string[] } } };
+
+    expect(response.status).toBe(415);
+    expect(body.error.code).toBe("unsupported_file_kind");
+    expect(body.error.details.files).toEqual(["notes.txt"]);
+    expect(body.error.details.supported_kinds).toEqual(["pdf", "pptx"]);
+    expect(attachmentRowCount()).toBe(before);
+  });
+});

--- a/packages/backend/tests/attachment-intake.test.ts
+++ b/packages/backend/tests/attachment-intake.test.ts
@@ -16,9 +16,11 @@ import { SUPPORTED_UPLOAD_KINDS, inferUploadKind } from "../src/services/upload-
 // The real extractor shells out to Python. Mocked at its narrowest seam so the
 // intake gate — which runs entirely before extraction — is deterministic here.
 let extractorCalls: string[] = [];
+let extractorFailureName: string | null = null;
 mock.module("../src/services/attachment-extraction", () => ({
   extractAttachmentUpload: async (input: { readonly originalName: string }) => {
     extractorCalls.push(input.originalName);
+    if (input.originalName === extractorFailureName) throw new Error("malformed_attachment");
   },
 }));
 
@@ -55,6 +57,7 @@ beforeAll(async () => {
 
 afterEach(() => {
   extractorCalls = [];
+  extractorFailureName = null;
 });
 
 afterAll(async () => {
@@ -101,8 +104,28 @@ describe("session attachment intake", () => {
 
     expect(saved).toHaveLength(1);
     expect(attachmentRowCount()).toBe(before + 1);
+    expect(getSqlite().query<{ readonly source_role: string; readonly source_role_explicit: number }, [string]>("SELECT source_role,source_role_explicit FROM attachments WHERE file_path=?").get(saved[0] ?? "missing")).toEqual({ source_role: "ordinary_content", source_role_explicit: 0 });
     expect((await storedFileNames()).some((name) => name.endsWith("-deck.pdf"))).toBe(true);
     expect(extractorCalls).toEqual(["deck.pdf"]);
+  });
+
+  test("Given the second upload fails extraction When saving Then the complete batch leaves no rows or files", async () => {
+    const before = attachmentRowCount();
+    const beforeFiles = await storedFileNames();
+    extractorFailureName = "broken.pdf";
+
+    await expect(saveSessionAttachments(sessionId, [file("first.pdf", "application/pdf"), file("broken.pdf", "application/pdf")])).rejects.toThrow("malformed_attachment");
+
+    expect(attachmentRowCount()).toBe(before);
+    expect(await storedFileNames()).toEqual(beforeFiles);
+  });
+
+  test("Given an immutable visual upload When saving Then its durable role and SHA-256 provenance are stored", async () => {
+    const saved = await saveSessionAttachments(sessionId, [{ file: file("reference.pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation"), role: "immutable_reference" }]);
+
+    const row = getSqlite().query<{ readonly source_role: string; readonly source_role_explicit: number; readonly sha256: string }, [string]>("SELECT source_role,source_role_explicit,sha256 FROM attachments WHERE file_path=?").get(saved[0] ?? "missing");
+    expect(row).toMatchObject({ source_role: "immutable_reference", source_role_explicit: 1 });
+    expect(row?.sha256).toMatch(/^[a-f0-9]{64}$/u);
   });
 
   test("Given previously stored unsupported attachments When a new upload is rejected Then the stored rows survive", async () => {
@@ -145,6 +168,23 @@ describe("session attachment intake", () => {
 });
 
 describe("session events multipart route", () => {
+  test("Given URL-shaped visual metadata When posted with a supported upload Then it is rejected before any write", async () => {
+    const before = attachmentRowCount();
+    const form = new FormData();
+    form.set("type", "user.message");
+    form.set("text", "웹 이미지를 써줘");
+    form.set("visual_sources", JSON.stringify({ schema_version: 1, sources: [{ source_type: "url", url: "https://example.test/image" }] }));
+    form.append("files", file("deck.pdf", "application/pdf"));
+
+    const response = await sessionRoutes.request(`http://local/api/sessions/${sessionId}/events`, { method: "POST", body: form });
+    const body = (await response.json()) as { readonly error: { readonly code: string } };
+
+    expect(response.status).toBe(415);
+    expect(body.error.code).toBe("unsupported_visual_source");
+    expect(attachmentRowCount()).toBe(before);
+    expect(extractorCalls).toEqual([]);
+  });
+
   test("Given an unsupported upload When posted as multipart Then the route answers a structured typed error", async () => {
     const before = attachmentRowCount();
     const form = new FormData();

--- a/packages/backend/tests/checkpoints.test.ts
+++ b/packages/backend/tests/checkpoints.test.ts
@@ -21,7 +21,7 @@ import { getManagedExportJob } from "../src/db/managed-file-repository";
  * this test fails first.
  */
 
-const EXCLUDED = new Set([".meta", ".attachments"]);
+const EXCLUDED = new Set([".meta", ".attachments", ".burnguard-inputs"]);
 let projectSequence = 0;
 const projectIds: string[] = [];
 
@@ -97,11 +97,13 @@ describe("checkpoint snapshot / restore round-trip", () => {
     projectDir = mkdtempSync(path.join(tmpdir(), "bg-ckpt-test-"));
     mkdirSync(path.join(projectDir, ".meta"), { recursive: true });
     mkdirSync(path.join(projectDir, ".attachments"), { recursive: true });
+    mkdirSync(path.join(projectDir, ".burnguard-inputs"), { recursive: true });
     writeFileSync(path.join(projectDir, "index.html"), "<h1>v1</h1>", "utf8");
     writeFileSync(path.join(projectDir, "style.css"), "body { color: red; }", "utf8");
     mkdirSync(path.join(projectDir, "assets"), { recursive: true });
     writeFileSync(path.join(projectDir, "assets", "hero.svg"), "<svg/>", "utf8");
     writeFileSync(path.join(projectDir, ".attachments", "junk.bin"), "do-not-snapshot", "utf8");
+    writeFileSync(path.join(projectDir, ".burnguard-inputs", "source.pdf"), "do-not-snapshot", "utf8");
   });
 
   afterEach(() => {
@@ -109,13 +111,14 @@ describe("checkpoint snapshot / restore round-trip", () => {
     for (const projectId of projectIds.splice(0)) getSqlite().prepare("DELETE FROM projects WHERE id=?").run(projectId);
   });
 
-  test("snapshot excludes .meta and .attachments", () => {
+  test("snapshot excludes control and stage-input directories", () => {
     takeSnapshot(projectDir, "turn-1");
     const snapPath = snapshotDir(projectDir, "turn-1");
     expect(existsSync(path.join(snapPath, "index.html"))).toBe(true);
     expect(existsSync(path.join(snapPath, "style.css"))).toBe(true);
     expect(existsSync(path.join(snapPath, "assets", "hero.svg"))).toBe(true);
     expect(existsSync(path.join(snapPath, ".attachments"))).toBe(false);
+    expect(existsSync(path.join(snapPath, ".burnguard-inputs"))).toBe(false);
     expect(existsSync(path.join(snapPath, ".meta"))).toBe(false);
   });
 

--- a/packages/backend/tests/design-audit-contract.test.ts
+++ b/packages/backend/tests/design-audit-contract.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { DESIGN_AUDIT_CHECK_CODES, parseDesignAuditResult } from "@bg/shared";
+
+const digest = "a".repeat(64);
+const checks = DESIGN_AUDIT_CHECK_CODES.map((code) => ({ code, status: "pass", reason: null, findings: [] }));
+const valid = { schema_version: 1, project_id: "project", artifact_revision: 0, artifact_digest: digest, created_at: 1, overall_status: "ready", checks };
+
+describe("design audit result contract", () => {
+  test("Given the canonical eight checks When parsed Then identity and order are preserved", () => {
+    expect(parseDesignAuditResult(valid)).toEqual(valid);
+  });
+
+  test("Given malformed or inconsistent results When parsed Then each is rejected", () => {
+    const malformed: readonly unknown[] = [
+      { ...valid, extra: true },
+      { ...valid, artifact_digest: "bad" },
+      { ...valid, checks: checks.slice(1) },
+      { ...valid, checks: checks.map((check, index) => index === 0 ? { ...check, code: "contrast" } : check) },
+      { ...valid, overall_status: "ready", checks: checks.map((check, index) => index === 0 ? { ...check, status: "skipped" } : check) },
+      { ...valid, overall_status: "recommended", checks: checks.map((check, index) => index === 0 ? { ...check, status: "skipped", reason: null } : check) },
+      { ...valid, overall_status: "recommended", checks: checks.map((check, index) => index === 0 ? { ...check, status: "pass", reason: "no_measurable_candidates" } : check) },
+      { ...valid, overall_status: "recommended", checks: checks.map((check, index) => index === 0 ? { ...check, status: "unmeasurable", reason: "invented" } : check) },
+      { ...valid, overall_status: "recommended", checks: checks.map((check, index) => index === 0 ? { ...check, status: "fail", reason: null, findings: [] } : check) },
+    ];
+    for (const input of malformed) expect(() => parseDesignAuditResult(input)).toThrow();
+  });
+
+  test("Given a safe minimum-text patch When parsed Then all CAS fields remain exact", () => {
+    const finding = { id: "minimum_text_size:index.html:tiny", check_code: "minimum_text_size", severity: "recommended", source: { rel_path: "index.html", node_bg_id: "tiny" }, evidence: "Rendered font size is 9px; minimum is 12px", measured: 9, threshold: 12, targeted_action: "set_minimum_font_size", safe_fix: { kind: "patch_html_node", rel_path: "index.html", request: { expected_revision: 0, expected_artifact_digest: digest, expected_file_hash: "b".repeat(64), node_bg_id: "tiny", node_fingerprint: "c".repeat(64), styles: { "font-size": "12px" } } } };
+    const input = { ...valid, overall_status: "recommended", checks: checks.map((check) => check.code === "minimum_text_size" ? { ...check, status: "fail", reason: null, findings: [finding] } : check) };
+    expect(parseDesignAuditResult(input).checks[2]?.findings[0]).toEqual(finding);
+  });
+});

--- a/packages/backend/tests/design-audit-export.test.ts
+++ b/packages/backend/tests/design-audit-export.test.ts
@@ -1,0 +1,41 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir, rm, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { SequencedEventEnvelope } from "@bg/shared";
+import { getExportAttemptDetail, getExportJob } from "../src/db/exports";
+import { runMigrations } from "../src/db/migrate-local";
+import { getSqlite } from "../src/db/sqlite-client";
+import { projectsDir } from "../src/lib/paths";
+import { ArtifactCoordinator } from "../src/services/artifact-coordinator";
+import { sequencedBroker } from "../src/services/broker";
+import { activeExportBrowserCount } from "../src/services/export-browser-registry";
+import { enqueueProjectExport } from "../src/services/exports";
+
+const prefix = `audit-export-${process.pid}`;
+const projects = [{ id: `${prefix}-blocked`, session: `${prefix}-blocked-session`, html: `<!doctype html><html><head><style>:root{--ink:#111}body{background:#fff;color:#aaa}.a,.b{position:absolute;width:80px}.a{left:10px}.b{left:120px}</style></head><body><p class="a" data-bg-node-id="a">Low contrast</p><p class="b" data-bg-node-id="b">Text</p></body></html>` }, { id: `${prefix}-recommended`, session: `${prefix}-recommended-session`, html: `<!doctype html><html><head><style>body{background:#fff;color:#111}.a,.b{position:absolute;width:80px}.a{left:10px}.b{left:120px}</style></head><body><p class="a" data-bg-node-id="a" style="font-size:9px">Small</p><p class="b" data-bg-node-id="b">Text</p></body></html>` }, { id: `${prefix}-ready`, session: `${prefix}-ready-session`, html: `<!doctype html><html lang="ko"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><style>:root{--paper:#fff;--ink:#111;--accent:#1647d8}*{box-sizing:border-box}html,body{margin:0;background:var(--paper);color:var(--ink);font-family:Arial,sans-serif}.stage{position:relative;min-height:700px;padding:24px}.a,.b{position:absolute;top:100px;width:120px;height:40px}.a{left:24px}.b{left:180px}</style></head><body><main class="stage" data-bg-node-id="ready-stage"><p data-bg-node-id="ready-copy">모든 검사를 통과하는 준비 상태</p><div class="a" data-bg-node-id="ready-a">측정 후보 A</div><div class="b" data-bg-node-id="ready-b">측정 후보 B</div></main></body></html>` }] as const;
+
+beforeAll(async () => {
+  await runMigrations();
+  for (const project of projects) { const root = path.join(projectsDir, project.id); await mkdir(root, { recursive: true }); await writeFile(path.join(root, "index.html"), project.html); getSqlite().prepare("INSERT INTO projects(id,name,type,dir_path,entrypoint,backend_id,created_at,updated_at) VALUES (?,?,'prototype',?,'index.html','codex',1,1)").run(project.id, project.id, root); getSqlite().prepare("INSERT INTO sessions(id,project_id,backend_id,status,created_at,updated_at,last_active_at) VALUES (?,?,'codex','idle',1,1,1)").run(project.session, project.id); await new ArtifactCoordinator(getSqlite()).initialize(project.id, root); }
+});
+afterAll(async () => { for (const project of projects) { getSqlite().prepare("DELETE FROM projects WHERE id=?").run(project.id); await rm(path.join(projectsDir, project.id), { recursive: true, force: true }); } });
+
+function nextTerminal(sessionId: string): Promise<SequencedEventEnvelope> { return new Promise((resolve, reject) => { const timeout = setTimeout(() => { unsubscribe(); reject(new TypeError("export terminal event timed out")); }, 60_000); const unsubscribe = sequencedBroker.subscribe(sessionId, (item) => { if (item.event.type !== "export.attempt" || item.event.status !== "failed" && item.event.status !== "validated") return; clearTimeout(timeout); unsubscribe(); resolve(item); }); }); }
+
+describe("pre-export design audit", () => {
+  test("Given must-fix contrast When exporting Then publication is blocked and findings persist", async () => {
+    const terminal = nextTerminal(projects[0].session); const started = await enqueueProjectExport(projects[0].id, "html_zip", {}); if (started === null || started.latest_attempt === null) throw new TypeError("export did not start"); await terminal; const job = await getExportJob(started.id); const attempt = await getExportAttemptDetail(started.latest_attempt.id);
+    expect(job?.status).toBe("failed"); expect(job?.output_path).toBeNull(); expect(job?.error_message).toContain("must-fix"); expect(attempt?.stop_reason).toBe("validation_failed"); expect(attempt?.findings.some((finding) => finding.code === "contrast")).toBeTrue();
+  }, 70_000);
+
+  test("Given only recommendations When exporting Then output publishes and findings remain", async () => {
+    const terminal = nextTerminal(projects[1].session); const started = await enqueueProjectExport(projects[1].id, "html_zip", {}); if (started === null || started.latest_attempt === null) throw new TypeError("export did not start"); await terminal; const job = await getExportJob(started.id); const attempt = await getExportAttemptDetail(started.latest_attempt.id);
+    expect(job?.error_message).toBeNull(); expect(job?.status).toBe("succeeded"); expect(job?.output_path).not.toBeNull(); expect(attempt?.findings.some((finding) => finding.code === "minimum_text_size")).toBeTrue(); expect(attempt?.findings).toContainEqual({ code: "design_audit:token_usage:skipped", path: null });
+  }, 70_000);
+
+  test("Given the all-eight-ready fixture When exporting HTML Then output publishes without findings", async () => {
+    const phases: string[] = []; const terminal = nextTerminal(projects[2].session); const started = await enqueueProjectExport(projects[2].id, "html_zip", {}, { phase: (_attemptId, phase) => { phases.push(phase); } });
+    if (started === null || started.latest_attempt === null) throw new TypeError("export did not start"); await terminal; const job = await getExportJob(started.id); const attempt = await getExportAttemptDetail(started.latest_attempt.id);
+    expect(job?.status).toBe("succeeded"); expect(job?.output_path).not.toBeNull(); if (job?.output_path === null || job?.output_path === undefined) throw new TypeError("export output is unavailable"); expect((await stat(job.output_path)).isFile()).toBeTrue(); expect(attempt?.findings).toEqual([]); expect(phases).toEqual(["after_snapshot", "after_partial_render", "after_render", "after_validation", "after_receipt", "after_publish_before_db"]); expect(activeExportBrowserCount()).toBe(0);
+  }, 70_000);
+});

--- a/packages/backend/tests/design-audit-render.test.ts
+++ b/packages/backend/tests/design-audit-render.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { inspectCanonicalTree } from "../src/services/canonical-tree-manifest";
+import { auditRenderedTree } from "../src/services/design-audit";
+
+const allPassFixture = `<!doctype html><html><head><style>:root{--ink:#111;--paper:#fff}html,body{margin:0;background:var(--paper);color:var(--ink)}.a,.b{position:absolute;width:100px;height:30px}.a{left:10px;top:10px}.b{left:150px;top:10px}</style></head><body><div class="a" data-bg-node-id="a">Alpha</div><div class="b" data-bg-node-id="b">Beta</div></body></html>`;
+const narrowFixture = `<!doctype html><html><head><style>:root{--ink:#111}html,body{margin:0;overflow:hidden;background:#fff;color:#111}.nclip{width:200px;height:30px}.one,.two{position:absolute;top:100px;width:80px;height:30px}.one{left:10px}.two{left:120px}@media(max-width:375px){.nclip{width:40px;height:18px;overflow:hidden;white-space:nowrap}.one,.two{left:10px}}</style></head><body><div class="nclip" data-bg-node-id="nclip">narrow clipping text</div><div class="one" data-bg-node-id="one">One</div><div class="two" data-bg-node-id="two">Two</div></body></html>`;
+const geometryFixture = `<!doctype html><html><head><style>:root{--ink:#111}body{margin:0;background:#fff;color:#111}.slide{position:relative;margin:100px 0 0 200px;width:300px;height:200px}.centered{position:absolute;left:20px;top:20px}.escaped{position:absolute;left:-20px;top:80px}</style></head><body><section class="slide" data-slide><div class="centered" data-bg-node-id="centered">Centered</div><div class="escaped" data-bg-node-id="escaped">Escaped</div></section></body></html>`;
+const translucentFixture = `<!doctype html><html><head><style>:root{--ink:#111}body{margin:0;background:#fff;color:#111}.layer{background:rgba(0,0,0,.2)}</style></head><body><div class="layer"><p data-bg-node-id="text">Opaque ancestor is not direct</p></div></body></html>`;
+const fixture = `<!doctype html><html><head><style>:root{--brand:#123456}body{margin:0;background:#fff;color:#777}.clip{width:40px;height:10px;overflow:hidden}.a,.b{position:absolute;left:20px;top:80px;width:100px;height:40px}.wide{width:500px}</style></head><body><div class="clip" data-bg-node-id="clip">clipped text</div><div class="a" data-bg-node-id="a">alpha</div><div class="b" data-bg-node-id="b">beta</div><p data-bg-node-id="tiny" style="font-size:9px;color:#777">tiny</p><div class="wide" data-bg-node-id="wide">wide</div><div data-bg-node-id="dup">one</div><div data-bg-node-id="dup">two</div><img data-bg-node-id="image" src="missing.png"><div data-bg-node-id="literal" style="color:#ff0000">literal</div><div data-bg-node-id="gradient" style="background:linear-gradient(red,blue);color:white">gradient</div></body></html>`;
+
+describe("rendered design auditor", () => {
+  test("Given measurable defects When audited Then all eight checks are truthful and ordered", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "bg-audit-render-"));
+    try {
+      await mkdir(root, { recursive: true }); await writeFile(path.join(root, "index.html"), fixture);
+      const manifest = await inspectCanonicalTree(root);
+      const result = await auditRenderedTree({ projectId: "fixture", projectDir: root, entrypoint: "index.html", revision: 0, digest: manifest.tree_digest, signal: new AbortController().signal });
+      expect(result.checks.map((check) => check.code)).toEqual(["text_overflow", "element_overlap", "minimum_text_size", "contrast", "narrow_width", "duplicate_node_id", "missing_image", "token_usage"]);
+      expect(result.overall_status).toBe("must_fix");
+      expect(result.checks.map((check) => [check.code, check.status])).toEqual([
+        ["text_overflow", "fail"], ["element_overlap", "fail"], ["minimum_text_size", "fail"], ["contrast", "fail"], ["narrow_width", "fail"], ["duplicate_node_id", "fail"], ["missing_image", "fail"], ["token_usage", "fail"],
+      ]);
+      const fix = result.checks[2]?.findings.find((finding) => finding.source.node_bg_id === "tiny")?.safe_fix;
+      expect(fix?.request.styles).toEqual({ "font-size": "12px" });
+      expect(JSON.stringify(result)).not.toContain(root);
+      expect(result.checks[3]?.findings.some((finding) => finding.source.node_bg_id === "gradient")).toBeFalse();
+    } finally { await rm(root, { recursive: true, force: true }); }
+  }, 60_000);
+
+  test("Given narrow-only clipping and overlap When audited Then narrow width fails without document overflow", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "bg-audit-narrow-"));
+    try {
+      await writeFile(path.join(root, "index.html"), narrowFixture); const manifest = await inspectCanonicalTree(root);
+      const result = await auditRenderedTree({ projectId: "narrow", projectDir: root, entrypoint: "index.html", revision: 0, digest: manifest.tree_digest, signal: new AbortController().signal }); const narrow = result.checks[4];
+      expect(narrow?.status).toBe("fail"); expect(narrow?.findings.map((finding) => finding.source.node_bg_id).sort()).toEqual(["nclip", "one"]); expect(narrow?.findings.every((finding) => finding.targeted_action === "repair_narrow_layout" && finding.severity === "must_fix")).toBeTrue(); expect(narrow?.findings.some((finding) => finding.source.node_bg_id === null)).toBeFalse();
+    } finally { await rm(root, { recursive: true, force: true }); }
+  }, 60_000);
+
+  test("Given an offset canvas When text is inside or escapes its edges Then geometry uses the canvas rect", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "bg-audit-geometry-"));
+    try {
+      await writeFile(path.join(root, "index.html"), geometryFixture); const manifest = await inspectCanonicalTree(root);
+      const result = await auditRenderedTree({ projectId: "geometry", projectDir: root, entrypoint: "index.html", revision: 0, digest: manifest.tree_digest, signal: new AbortController().signal }); const overflow = result.checks[0];
+      expect(overflow?.findings.some((finding) => finding.source.node_bg_id === "centered")).toBeFalse(); expect(overflow?.findings.some((finding) => finding.source.node_bg_id === "escaped")).toBeTrue();
+    } finally { await rm(root, { recursive: true, force: true }); }
+  }, 60_000);
+
+  test("Given a translucent intermediate background When contrast is audited Then it is explicitly unresolvable", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "bg-audit-translucent-"));
+    try {
+      await writeFile(path.join(root, "index.html"), translucentFixture); const manifest = await inspectCanonicalTree(root);
+      const result = await auditRenderedTree({ projectId: "translucent", projectDir: root, entrypoint: "index.html", revision: 0, digest: manifest.tree_digest, signal: new AbortController().signal }); const contrast = result.checks[3];
+      expect(contrast).toMatchObject({ status: "unmeasurable", reason: "unresolvable_rendering", findings: [] });
+    } finally { await rm(root, { recursive: true, force: true }); }
+  }, 60_000);
+
+  test("Given a fully measurable valid page When audited Then it is ready", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "bg-audit-pass-"));
+    try {
+      await writeFile(path.join(root, "index.html"), allPassFixture); const manifest = await inspectCanonicalTree(root);
+      const result = await auditRenderedTree({ projectId: "pass", projectDir: root, entrypoint: "index.html", revision: 0, digest: manifest.tree_digest, signal: new AbortController().signal });
+      expect(result.overall_status).toBe("ready"); expect(result.checks.every((check) => check.status === "pass")).toBeTrue();
+    } finally { await rm(root, { recursive: true, force: true }); }
+  }, 60_000);
+});

--- a/packages/backend/tests/design-audit-routes.test.ts
+++ b/packages/backend/tests/design-audit-routes.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { parseDesignAuditResult } from "@bg/shared";
+import { runMigrations } from "../src/db/migrate-local";
+import { getSqlite } from "../src/db/sqlite-client";
+import { projectsDir } from "../src/lib/paths";
+import { artifactOperationRoutes } from "../src/routes/artifact-operations";
+import { artifactRoutes } from "../src/routes/artifacts";
+import { ArtifactCoordinator } from "../src/services/artifact-coordinator";
+
+const projectId = `audit-route-${process.pid}`;
+const root = path.join(projectsDir, projectId);
+const html = `<!doctype html><html><head><style>:root{--text:#111}body{background:#fff;color:#111}</style></head><body><p data-bg-node-id="tiny" style="font-size:9px;color:var(--text)">Tiny</p></body></html>`;
+
+beforeAll(async () => {
+  await runMigrations(); await mkdir(root, { recursive: true }); await writeFile(path.join(root, "index.html"), html);
+  getSqlite().prepare("INSERT INTO projects(id,name,type,dir_path,entrypoint,backend_id,created_at,updated_at) VALUES (?,?,'prototype',?,'index.html','codex',1,1)").run(projectId, "Audit", root);
+  await new ArtifactCoordinator(getSqlite()).initialize(projectId, root);
+});
+afterAll(async () => { getSqlite().prepare("DELETE FROM projects WHERE id=?").run(projectId); await rm(root, { recursive: true, force: true }); });
+
+async function data(response: Response): Promise<unknown> { const value: unknown = await response.json(); return typeof value === "object" && value !== null ? Reflect.get(value, "data") : null; }
+
+describe("design audit routes and safe fix", () => {
+  test("Given a current project When fetched, fixed, rerun, and undone Then cache and coordinator identity remain coherent", async () => {
+    const firstResponse = await artifactRoutes.request(`http://local/api/projects/${projectId}/design-audit`);
+    expect(firstResponse.status).toBe(200); const first = parseDesignAuditResult(await data(firstResponse));
+    const cached = parseDesignAuditResult(await data(await artifactRoutes.request(`http://local/api/projects/${projectId}/design-audit`)));
+    expect(cached).toEqual(first);
+    const cachePath = path.join(root, ".meta", "audits", `${first.artifact_revision}-${first.artifact_digest}.json`);
+    await writeFile(cachePath, "{corrupt");
+    const regenerated = parseDesignAuditResult(await data(await artifactRoutes.request(`http://local/api/projects/${projectId}/design-audit`)));
+    expect(regenerated.artifact_digest).toBe(first.artifact_digest);
+    const finding = first.checks[2]?.findings[0]; const fix = finding?.safe_fix;
+    if (fix === undefined) throw new TypeError("minimum text safe fix missing");
+    const patch = await artifactOperationRoutes.request(`http://local/api/projects/${projectId}/fs/${fix.rel_path}`, { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify(fix.request) });
+    expect(patch.status).toBe(200); const patched = await data(patch); const revision = typeof patched === "object" && patched !== null ? Reflect.get(patched, "result_revision") : null; const digest = typeof patched === "object" && patched !== null ? Reflect.get(patched, "result_digest") : null; const operationId = typeof patched === "object" && patched !== null ? Reflect.get(patched, "operation_id") : null;
+    expect(revision).toBe(first.artifact_revision + 1); expect(digest).not.toBe(first.artifact_digest);
+    const rerun = parseDesignAuditResult(await data(await artifactRoutes.request(`http://local/api/projects/${projectId}/design-audit/retry`, { method: "POST" })));
+    expect(rerun.checks[2]?.findings).toHaveLength(0);
+    const undo = await artifactOperationRoutes.request(`http://local/api/projects/${projectId}/operations/${operationId}/undo`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ expected_revision: revision, expected_artifact_digest: digest }) });
+    expect(undo.status).toBe(200);
+    const restored = parseDesignAuditResult(await data(await artifactRoutes.request(`http://local/api/projects/${projectId}/design-audit/retry`, { method: "POST" })));
+    expect(restored.checks[2]?.findings).toHaveLength(1);
+  }, 90_000);
+
+  test("Given a nested audit-cache symlink When audited Then typed 503 prevents outside writes", async () => {
+    const id = `${projectId}-cache-link`; const projectRoot = path.join(projectsDir, id); const outside = await mkdtemp(path.join(tmpdir(), "bg-audit-cache-outside-"));
+    try {
+      await mkdir(path.join(projectRoot, ".meta"), { recursive: true }); await writeFile(path.join(projectRoot, "index.html"), html); getSqlite().prepare("INSERT INTO projects(id,name,type,dir_path,entrypoint,backend_id,created_at,updated_at) VALUES (?,?,'prototype',?,'index.html','codex',1,1)").run(id, "Cache link", projectRoot); await new ArtifactCoordinator(getSqlite()).initialize(id, projectRoot); await symlink(outside, path.join(projectRoot, ".meta", "audits"));
+      const response = await artifactRoutes.request(`http://local/api/projects/${id}/design-audit`); const body = JSON.stringify(await response.json());
+      expect(response.status).toBe(503); expect(body).toContain("project_path_unavailable"); expect(body).not.toContain(outside); expect((await Array.fromAsync(new Bun.Glob("**/*").scan({ cwd: outside }))).length).toBe(0);
+    } finally { getSqlite().prepare("DELETE FROM projects WHERE id=?").run(id); await rm(projectRoot, { recursive: true, force: true }); await rm(outside, { recursive: true, force: true }); }
+  });
+
+  test("Given escaped and symlinked DB project paths When audited Then typed 503 responses leak no private path", async () => {
+    const outside = await mkdtemp(path.join(tmpdir(), "bg-audit-outside-")); const linked = path.join(projectsDir, `${projectId}-linked`); const ids = [`${projectId}-outside`, `${projectId}-linked`] as const;
+    try {
+      await writeFile(path.join(outside, "index.html"), html); await symlink(outside, linked);
+      const insert = getSqlite().prepare("INSERT INTO projects(id,name,type,dir_path,entrypoint,backend_id,created_at,updated_at) VALUES (?,?,'prototype',?,'index.html','codex',1,1)"); insert.run(ids[0], "Outside", outside); insert.run(ids[1], "Linked", linked);
+      for (const id of ids) { const response = await artifactRoutes.request(`http://local/api/projects/${id}/design-audit`); expect(response.status).toBe(503); expect(JSON.stringify(await response.json())).not.toContain(outside); }
+    } finally { for (const id of ids) getSqlite().prepare("DELETE FROM projects WHERE id=?").run(id); await rm(linked, { force: true }); await rm(outside, { recursive: true, force: true }); }
+  });
+});

--- a/packages/backend/tests/design-brief-prompt.test.ts
+++ b/packages/backend/tests/design-brief-prompt.test.ts
@@ -7,14 +7,17 @@ type BuildContext = Parameters<typeof buildPrompt>[0];
 
 beforeAll(() => ensureLearningSchema(getSqlite()));
 
-function context(optionsJson: string | null): BuildContext {
+function context(
+  optionsJson: string | null,
+  projectType: BuildContext["project"]["project_type"] = "slide_deck",
+): BuildContext {
   return {
     project: {
       project_id: "brief-project",
       project_name: "분기 영업 보고서",
-      project_type: "slide_deck",
+      project_type: projectType,
       project_dir: "/tmp/brief-project",
-      entrypoint: "deck.html",
+      entrypoint: projectType === "slide_deck" ? "deck.html" : "index.html",
       options_json: optionsJson,
       current_revision: 0,
       current_digest: null,
@@ -58,6 +61,36 @@ describe("design brief prompt context", () => {
     expect(taggedJson(prompt, "burnguard-design-brief-v1")).toEqual(
       designBrief,
     );
+  });
+
+  test("Given a graphic project When the prompt is built Then exact one-artboard PNG delivery is explicit", async () => {
+    const prompt = await buildPrompt(
+      context(JSON.stringify({
+        graphic_canvas: { schema_version: 1, width: 1200, height: 628 },
+        design_brief: {
+          schema_version: 1,
+          output_type: "graphic",
+          audience: "SNS 방문자",
+          objective: "행사 참여를 안내한다",
+          content_source: "none",
+          locale: "ko-KR",
+          brand_mode: "none",
+          visual_mood: "friendly",
+          density: "balanced",
+          output_size: "custom",
+        },
+      }), "graphic"),
+      { type: "user.message", text: "행사 그래픽을 만들어줘" },
+    );
+
+    expect(taggedJson(prompt, "burnguard-graphic-output-v1")).toEqual({
+      schema_version: 1,
+      width_css_px: 1200,
+      height_css_px: 628,
+      artboard_count: 1,
+      delivery_format: "png",
+    });
+    expect(prompt).not.toContain("## Slide deck skill");
   });
 
   test("Given malformed project options When the prompt is built Then no partial brief leaks", async () => {

--- a/packages/backend/tests/design-direction-contract.test.ts
+++ b/packages/backend/tests/design-direction-contract.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { parseDesignDirectionState } from "@bg/shared";
+
+function validState(): unknown {
+  return {
+    schema_version: 1,
+    project_id: "project",
+    session_id: "session",
+    generation_id: "generation",
+    status: "ready",
+    content_outline: ["문제", "해결", "다음 단계"],
+    directions: [
+      { id: "editorial", order: 0, layout_key: "editorial", title: "편집 서사", summary: "큰 활자 중심", style_facts: ["비대칭 그리드", "세리프 제목"], status: "ready", preview_url: "/editorial.svg", error: null },
+      { id: "modular", order: 1, layout_key: "modular", title: "모듈 시스템", summary: "정보 카드 중심", style_facts: ["12열 그리드", "고대비 카드"], status: "ready", preview_url: "/modular.svg", error: null },
+      { id: "narrative", order: 2, layout_key: "narrative", title: "흐름 서사", summary: "단계별 이야기", style_facts: ["세로 흐름", "강조 인용"], status: "ready", preview_url: "/narrative.svg", error: null },
+    ],
+    selected_id: "editorial",
+    selection_revision: 1,
+    selection_history: [null],
+    error: null,
+    updated_at: 100,
+  };
+}
+
+describe("design direction state parser", () => {
+  test("rejects malformed state invariants", () => {
+    const mutations: readonly ((state: Record<string, unknown>) => void)[] = [
+      (state) => { state["status"] = "unknown"; },
+      (state) => { state["directions"] = []; },
+      (state) => { const slots = state["directions"]; if (Array.isArray(slots)) slots[1] = slots[0]; },
+      (state) => { const slots = state["directions"]; if (Array.isArray(slots) && typeof slots[1] === "object" && slots[1] !== null) slots[1] = { ...slots[1], layout_key: "editorial" }; },
+      (state) => { const slots = state["directions"]; if (Array.isArray(slots) && typeof slots[0] === "object" && slots[0] !== null) slots[0] = { ...slots[0], preview_url: null }; },
+      (state) => { const slots = state["directions"]; if (Array.isArray(slots) && typeof slots[0] === "object" && slots[0] !== null) slots[0] = { ...slots[0], status: "pending" }; },
+      (state) => { state["selected_id"] = "missing"; },
+      (state) => { state["selection_revision"] = 0; state["selection_history"] = [null]; },
+      (state) => { state["content_outline"] = ["   "]; },
+      (state) => { state["selection_revision"] = -1; },
+      (state) => { state["selection_revision"] = 1.5; },
+      (state) => { state["updated_at"] = -1; },
+      (state) => { state["updated_at"] = Number.POSITIVE_INFINITY; },
+    ];
+
+    for (const mutate of mutations) {
+      const state = structuredClone(validState());
+      if (typeof state !== "object" || state === null || Array.isArray(state)) throw new TypeError("fixture must be an object");
+      mutate(state);
+      expect(() => parseDesignDirectionState(state)).toThrow();
+    }
+  });
+
+  test("accepts an immutable ready state", () => {
+    expect(parseDesignDirectionState(validState())).toEqual(validState());
+  });
+});

--- a/packages/backend/tests/design-direction-renderer.test.ts
+++ b/packages/backend/tests/design-direction-renderer.test.ts
@@ -1,0 +1,68 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { parse } from "node-html-parser";
+import { SvgDesignDirectionRenderer } from "../src/services/design-direction-renderer";
+
+const root = await mkdtemp(path.join(tmpdir(), "burnguard-direction-renderer-"));
+const segmenter = new Intl.Segmenter("ko", { granularity: "grapheme" });
+const layouts = ["editorial", "modular", "narrative"] as const;
+const dynamicValues = {
+  title: '제목동적 & <안전> "검토" 👨‍👩‍👧‍👦 한글표현을아주길게반복하여오른쪽경계를검증합니다',
+  summary: '요약동적 & <안전> "검토" 🧑🏽‍💻 운영책임자에게복잡한현황과핵심의사결정을분명하게전달합니다',
+  point0: '첫째동적 & <안전> "검토" 🎯 사용자의핵심문제를충분히길게설명합니다',
+  point1: '둘째동적 & <안전> "검토" 🧩 해결방식과근거를충분히길게설명합니다',
+  point2: '셋째동적 & <안전> "검토" 🚀 다음행동과성과를충분히길게설명합니다',
+} as const;
+
+function graphemeCount(value: string): number {
+  return Array.from(segmenter.segment(value)).length;
+}
+
+afterAll(async () => { await rm(root, { recursive: true, force: true }); });
+
+describe("SVG design direction renderer", () => {
+  test("bounds every dynamic run and separates narrative callouts for long Korean content", async () => {
+    const violations: string[] = [];
+    for (const layout of layouts) {
+      const outputPath = path.join(root, `${layout}.svg`);
+      await new SvgDesignDirectionRenderer().render({
+        layout,
+        title: dynamicValues.title,
+        summary: dynamicValues.summary,
+        outline: [dynamicValues.point0, dynamicValues.point1, dynamicValues.point2],
+        outputPath,
+        signal: new AbortController().signal,
+      });
+      const svg = await readFile(outputPath, "utf8");
+      const document = parse(svg);
+      const dynamicRuns = document.querySelectorAll("text").filter((node) => Object.values(dynamicValues).some((value) => node.textContent.includes(value.slice(0, 4))));
+      if (dynamicRuns.length !== 5) violations.push(`${layout}:dynamic-count=${dynamicRuns.length}`);
+      for (const run of dynamicRuns) {
+        const source = Object.values(dynamicValues).find((value) => run.textContent.includes(value.slice(0, 4)));
+        if (source === undefined) continue;
+        if (graphemeCount(run.textContent) >= graphemeCount(source) || !run.textContent.endsWith("…")) violations.push(`${layout}:unbounded=${source.slice(0, 4)}`);
+        if ((run.textContent.includes("\u200D") && !run.textContent.includes("👨‍👩‍👧‍👦") && !run.textContent.includes("🧑🏽‍💻")) || (run.textContent.includes("🏽") && !run.textContent.includes("🧑🏽‍💻"))) violations.push(`${layout}:split-grapheme=${source.slice(0, 4)}`);
+        const x = Number(run.getAttribute("x"));
+        const fontSize = Number(run.getAttribute("font-size"));
+        const widthBudget = Number(run.getAttribute("data-width-budget"));
+        if (!Number.isFinite(x) || !Number.isFinite(fontSize) || !Number.isFinite(widthBudget) || widthBudget <= 0 || x + widthBudget > 640 || graphemeCount(run.textContent) * fontSize * 0.9 > widthBudget) violations.push(`${layout}:invalid-budget=${source.slice(0, 4)}`);
+      }
+      if (!svg.includes("&amp;") || !svg.includes("&lt;") || !svg.includes("&gt;") || !svg.includes("&quot;")) violations.push(`${layout}:xml-unescaped`);
+      if (layout === "narrative") {
+        const callouts = dynamicRuns.filter((node) => node.getAttribute("data-run")?.startsWith("point") === true || ["첫째동적", "둘째동적", "셋째동적"].some((marker) => node.textContent.includes(marker)));
+        const baselines = new Set(callouts.map((node) => node.getAttribute("y")));
+        if (callouts.length !== 3 || baselines.size !== 3) violations.push("narrative:overlapping-baselines");
+        const regions = callouts.map((node) => ({ x: Number(node.getAttribute("x")), width: Number(node.getAttribute("data-width-budget")) })).sort((left, right) => left.x - right.x);
+        for (let index = 1; index < regions.length; index += 1) {
+          const previous = regions[index - 1];
+          const current = regions[index];
+          if (previous === undefined || current === undefined || previous.x + previous.width > current.x) violations.push("narrative:overlapping-regions");
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/backend/tests/design-direction-routes.test.ts
+++ b/packages/backend/tests/design-direction-routes.test.ts
@@ -1,0 +1,164 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { isRecord, parseDesignDirectionState, type DesignDirectionState, type SequencedEventEnvelope } from "@bg/shared";
+import { runMigrations } from "../src/db/migrate-local";
+import { getSqlite } from "../src/db/sqlite-client";
+import { projectsDir } from "../src/lib/paths";
+import { designDirectionRoutes, replaceDesignDirectionWorkflowForTest } from "../src/routes/design-directions";
+import { projectRoutes } from "../src/routes/project";
+import { sequencedBroker } from "../src/services/broker";
+import { buildSessionContext } from "../src/services/context";
+import { buildPrompt } from "../src/harness/prompt-builder";
+import type { DesignDirectionRenderer, DirectionRenderInput } from "../src/services/design-direction-renderer";
+import { DesignDirectionWorkflow } from "../src/services/design-direction-workflow";
+
+const projectId = `direction-routes-${process.pid}`;
+const sessionId = `${projectId}-session`;
+const outsideProjectId = `${projectId}-outside`;
+const symlinkProjectId = `${projectId}-symlink`;
+let root = "";
+let outsideRoot = "";
+const jsonHeaders = { "content-type": "application/json" };
+
+beforeAll(async () => {
+  await runMigrations();
+  await mkdir(projectsDir, { recursive: true });
+  root = path.join(projectsDir, projectId);
+  outsideRoot = await mkdtemp(path.join(tmpdir(), "burnguard-direction-outside-"));
+  await mkdir(root, { recursive: true });
+  const options = JSON.stringify({ design_brief: { schema_version: 1, output_type: "prototype", audience: "처음 서비스를 검토하는 운영 책임자", objective: "복잡한 운영 현황을 한눈에 이해시키기", content_source: "none", locale: "ko-KR", brand_mode: "none", visual_mood: "formal", density: "balanced", output_size: "responsive" } });
+  const insertProject = getSqlite().prepare("INSERT INTO projects(id,name,type,dir_path,entrypoint,backend_id,options_json,created_at,updated_at) VALUES (?,?,'prototype',?,'index.html','codex',?,1,1)");
+  const insertSession = getSqlite().prepare("INSERT INTO sessions(id,project_id,backend_id,status,created_at,updated_at,last_active_at) VALUES (?,?,'codex','idle',1,1,1)");
+  insertProject.run(projectId, "경로 테스트", root, options);
+  insertSession.run(sessionId, projectId);
+  insertProject.run(outsideProjectId, "외부 경로", outsideRoot, null);
+  insertSession.run(`${outsideProjectId}-session`, outsideProjectId);
+  const symlinkPath = path.join(projectsDir, symlinkProjectId);
+  await symlink(outsideRoot, symlinkPath);
+  insertProject.run(symlinkProjectId, "심볼릭 링크", symlinkPath, null);
+  insertSession.run(`${symlinkProjectId}-session`, symlinkProjectId);
+});
+afterAll(async () => {
+  for (const id of [projectId, outsideProjectId, symlinkProjectId]) getSqlite().prepare("DELETE FROM projects WHERE id=?").run(id);
+  await rm(root, { recursive: true, force: true });
+  await rm(path.join(projectsDir, symlinkProjectId), { force: true });
+  await rm(outsideRoot, { recursive: true, force: true });
+});
+
+function request(route: string, method = "GET", body?: unknown, headers?: Readonly<Record<string, string>>): Promise<Response> {
+  return designDirectionRoutes.request(`http://local${route}`, { method, headers: body === undefined ? headers : { ...jsonHeaders, ...headers }, body: body === undefined ? undefined : JSON.stringify(body) });
+}
+
+class RouteProgressGateRenderer implements DesignDirectionRenderer {
+  private renderCount = 0;
+  private blockedWaiter: (() => void) | null = null;
+  nextBlockedCall(): Promise<void> { return new Promise((resolve) => { this.blockedWaiter = resolve; }); }
+  async render(input: DirectionRenderInput): Promise<void> {
+    this.renderCount += 1;
+    if (this.renderCount === 1) {
+      await mkdir(path.dirname(input.outputPath), { recursive: true });
+      await writeFile(input.outputPath, "<svg/>", { signal: input.signal });
+      return;
+    }
+    const waiter = this.blockedWaiter;
+    if (waiter === null) throw new TypeError("route renderer subscriber missing");
+    this.blockedWaiter = null;
+    waiter();
+    await new Promise<void>((resolve, reject) => input.signal.addEventListener("abort", () => reject(input.signal.reason), { once: true }));
+  }
+}
+
+function nextTerminalState(): Promise<DesignDirectionState> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => { unsubscribe(); reject(new TypeError("direction terminal event timed out")); }, 2_000);
+    const unsubscribe = sequencedBroker.subscribe(sessionId, (item: SequencedEventEnvelope) => {
+      if (item.event.type !== "design.direction_state" || item.event.state.status === "loading") return;
+      clearTimeout(timeout); unsubscribe(); resolve(item.event.state);
+    });
+  });
+}
+
+describe("design direction routes", () => {
+  test("generates state, selects, undoes, and serves validated SVG caching", async () => {
+    expect((await request("/api/projects/missing/design-directions")).status).toBe(404);
+    const terminalEvent = nextTerminalState();
+    const started = await request(`/api/projects/${projectId}/design-directions/generate`, "POST");
+    expect(started.status).toBe(202);
+    const ready = await terminalEvent;
+    expect(ready.status).toBe("ready");
+    expect(ready.content_outline).toContain("목표: 복잡한 운영 현황을 한눈에 이해시키기");
+    expect(ready.content_outline).toContain("대상: 처음 서비스를 검토하는 운영 책임자");
+    expect((await request(`/api/projects/${projectId}/design-directions`)).status).toBe(200);
+    expect((await projectRoutes.request(`http://local/api/projects/${projectId}/design-directions`)).status).toBe(200);
+
+    const selectedResponse = await request(`/api/projects/${projectId}/design-directions/select`, "POST", { generation_id: ready.generation_id, expected_selection_revision: 0, direction_id: "editorial" });
+    expect(selectedResponse.status).toBe(200);
+    const promptContext = await buildSessionContext(sessionId);
+    if (promptContext === null) throw new TypeError("session context missing");
+    const prompt = await buildPrompt(promptContext, { type: "user.message", text: "계속" });
+    expect(prompt).toContain("복잡한 운영 현황을 한눈에 이해시키기");
+    expect(prompt).toContain("처음 서비스를 검토하는 운영 책임자");
+    expect(prompt).not.toContain("모듈 시스템");
+    expect(prompt).not.toContain("흐름 서사");
+    expect((await request(`/api/projects/${projectId}/design-directions/select`, "POST", { generation_id: ready.generation_id, expected_selection_revision: 0, direction_id: "modular" })).status).toBe(409);
+    expect((await request(`/api/projects/${projectId}/design-directions/undo-selection`, "POST", { generation_id: ready.generation_id, expected_selection_revision: 1 })).status).toBe(200);
+
+    const previewPath = `/api/projects/${projectId}/design-directions/${ready.generation_id}/editorial/preview`;
+    const preview = await request(previewPath);
+    expect(preview.status).toBe(200);
+    expect(preview.headers.get("content-type")).toBe("image/svg+xml");
+    expect(preview.headers.get("cache-control")).toBe("private, no-cache");
+    const etag = preview.headers.get("etag");
+    expect(etag).not.toBeNull();
+    expect((await request(previewPath, "GET", undefined, { "if-none-match": etag ?? "" })).status).toBe(304);
+    expect((await request(`/api/projects/${projectId}/design-directions/${ready.generation_id}/unknown/preview`)).status).toBe(404);
+    expect((await request(`/api/projects/${projectId}/design-directions/${ready.generation_id}/%5Cescape/preview`)).status).toBe(400);
+  });
+
+  test("rejects unmanaged and symlink-escaped project directories without writing outside", async () => {
+    for (const id of [outsideProjectId, symlinkProjectId]) {
+      const response = await request(`/api/projects/${id}/design-directions/generate`, "POST");
+      expect(response.status).toBe(503);
+      expect(await response.json()).toEqual({ error: { code: "project_path_unavailable", message: "Project directory is outside managed storage" } });
+      expect(await Bun.file(path.join(outsideRoot, ".meta", "directions")).exists()).toBeFalse();
+      expect((await request(`/api/projects/${id}/design-directions/generation/editorial/preview`)).status).toBe(503);
+    }
+  });
+
+  test("returns typed busy, cancellation, and retry outcomes", async () => {
+    getSqlite().prepare("UPDATE sessions SET status='running' WHERE id=?").run(sessionId);
+    expect((await request(`/api/projects/${projectId}/design-directions/generate`, "POST")).status).toBe(409);
+    getSqlite().prepare("UPDATE sessions SET status='idle' WHERE id=?").run(sessionId);
+    expect((await request(`/api/projects/${projectId}/design-directions/cancel`, "POST")).status).toBe(409);
+    const retry = await request(`/api/projects/${projectId}/design-directions/retry`, "POST");
+    expect(retry.status).toBe(422);
+    expect(await retry.json()).toEqual({ error: { code: "nothing_to_retry", message: "nothing_to_retry" } });
+  });
+
+  test("returns the exact terminal cancellation state before immediate GET", async () => {
+    const renderer = new RouteProgressGateRenderer();
+    const replacement = new DesignDirectionWorkflow(renderer, () => 90, () => "route-cancel-terminal");
+    const restore = replaceDesignDirectionWorkflowForTest(replacement);
+    try {
+      const blocked = renderer.nextBlockedCall();
+      expect((await request(`/api/projects/${projectId}/design-directions/generate`, "POST")).status).toBe(202);
+      await blocked;
+
+      const response = await request(`/api/projects/${projectId}/design-directions/cancel`, "POST");
+      const body: unknown = await response.json();
+      const terminal = parseDesignDirectionState(isRecord(body) ? body["data"] : null);
+      const immediateBody: unknown = await (await request(`/api/projects/${projectId}/design-directions`)).json();
+
+      expect(response.status).toBe(202);
+      expect(body).toEqual({ data: terminal });
+      expect(terminal.status).toBe("cancelled");
+      expect(terminal.directions.map((slot) => slot.status)).toEqual(["ready", "cancelled", "cancelled"]);
+      expect(immediateBody).toEqual({ data: terminal });
+      expect((await request(`/api/projects/${projectId}/design-directions/cancel`, "POST")).status).toBe(409);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/packages/backend/tests/design-direction-workflow.test.ts
+++ b/packages/backend/tests/design-direction-workflow.test.ts
@@ -1,0 +1,201 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { parseDesignDirectionState, type DesignDirectionState } from "@bg/shared";
+import { runMigrations } from "../src/db/migrate-local";
+import { getSqlite } from "../src/db/sqlite-client";
+import { listSessionEvents } from "../src/db/events";
+import type { DesignDirectionRenderer, DirectionRenderInput } from "../src/services/design-direction-renderer";
+import { DIRECTION_INTERRUPTION_ERROR, DesignDirectionWorkflow, DesignDirectionWorkflowError } from "../src/services/design-direction-workflow";
+import { getLatestDirectionState, publishDirectionState } from "../src/services/design-direction-state";
+import { startUserTurn } from "../src/services/turns";
+import { buildSessionContext } from "../src/services/context";
+
+const projectId = `direction-workflow-${process.pid}`;
+const root = await mkdtemp(path.join(tmpdir(), "burnguard-directions-"));
+const sessionIds: string[] = [];
+
+beforeAll(async () => {
+  await runMigrations();
+  getSqlite().prepare("INSERT INTO projects(id,name,type,dir_path,entrypoint,backend_id,created_at,updated_at) VALUES (?,?,'prototype',?,'index.html','codex',1,1)").run(projectId, "방향 테스트", root);
+});
+afterAll(async () => { getSqlite().prepare("DELETE FROM projects WHERE id=?").run(projectId); await rm(root, { recursive: true, force: true }); });
+
+function session(label: string): { readonly projectId: string; readonly sessionId: string; readonly projectDir: string; readonly projectName: string; readonly projectType: "prototype"; readonly designBrief: null } {
+  const sessionId = `${projectId}-${label}`;
+  sessionIds.push(sessionId);
+  getSqlite().prepare("INSERT INTO sessions(id,project_id,backend_id,status,created_at,updated_at,last_active_at) VALUES (?,?,'codex','idle',1,1,1)").run(sessionId, projectId);
+  return { projectId, sessionId, projectDir: root, projectName: "방향 테스트", projectType: "prototype", designBrief: null };
+}
+
+class FailOnceRenderer implements DesignDirectionRenderer {
+  readonly calls: string[] = [];
+  private failed = false;
+  async render(input: DirectionRenderInput): Promise<void> {
+    this.calls.push(input.layout);
+    if (input.layout === "modular" && !this.failed) { this.failed = true; throw new TypeError("modular render failed"); }
+    await mkdir(path.dirname(input.outputPath), { recursive: true });
+    await writeFile(input.outputPath, `<svg data-layout="${input.layout}"/>`, { signal: input.signal });
+  }
+}
+
+class ProgressGateRenderer implements DesignDirectionRenderer {
+  private renderCount = 0;
+  private blockedWaiter: (() => void) | null = null;
+  nextBlockedCall(): Promise<void> { return new Promise((resolve) => { this.blockedWaiter = resolve; }); }
+  async render(input: DirectionRenderInput): Promise<void> {
+    this.renderCount += 1;
+    if (this.renderCount === 1) {
+      await mkdir(path.dirname(input.outputPath), { recursive: true });
+      await writeFile(input.outputPath, "<svg/>", { signal: input.signal });
+      return;
+    }
+    const waiter = this.blockedWaiter;
+    if (waiter === null) throw new TypeError("blocked renderer subscriber missing");
+    this.blockedWaiter = null;
+    waiter();
+    await new Promise<void>((resolve, reject) => input.signal.addEventListener("abort", () => reject(input.signal.reason), { once: true }));
+  }
+}
+
+class GateRenderer implements DesignDirectionRenderer {
+  private waiter: ((input: DirectionRenderInput) => void) | null = null;
+  private queued: DirectionRenderInput | null = null;
+  nextCall(): Promise<DirectionRenderInput> {
+    if (this.queued !== null) { const value = this.queued; this.queued = null; return Promise.resolve(value); }
+    return new Promise((resolve) => { this.waiter = resolve; });
+  }
+  async render(input: DirectionRenderInput): Promise<void> {
+    const waiter = this.waiter;
+    if (waiter === null) this.queued = input; else { this.waiter = null; waiter(input); }
+    await new Promise<void>((resolve, reject) => {
+      input.signal.addEventListener("abort", () => reject(input.signal.reason), { once: true });
+    });
+  }
+}
+
+describe("design direction workflow", () => {
+  test("persists exactly three structurally distinct production SVG previews", async () => {
+    const input = session("svg");
+    const completed = await (await new DesignDirectionWorkflow(undefined, () => 10, () => "generation-svg").generate(input)).completion;
+    expect(completed.status).toBe("ready");
+    expect(completed.directions).toHaveLength(3);
+    expect(completed.content_outline[0]).toContain("방향 테스트");
+    const svgs = await Promise.all(completed.directions.map((slot) => readFile(path.join(root, ".meta", "directions", completed.generation_id, `${slot.id}.svg`), "utf8")));
+    expect(new Set(svgs).size).toBe(3);
+    expect(svgs.every((svg) => svg.includes('width="640"') && svg.includes('height="360"'))).toBeTrue();
+    expect((await getLatestDirectionState(input.sessionId))?.status).toBe("ready");
+  });
+
+  test("retries only failed slots after a partial result", async () => {
+    const input = session("retry");
+    const renderer = new FailOnceRenderer();
+    const workflow = new DesignDirectionWorkflow(renderer, () => 20, () => "generation-retry");
+    const partial = await (await workflow.generate(input)).completion;
+    expect(partial.status).toBe("partial");
+    expect(renderer.calls).toEqual(["editorial", "modular", "narrative"]);
+    const retried = await (await workflow.retry(input)).completion;
+    expect(retried.status).toBe("ready");
+    expect(renderer.calls).toEqual(["editorial", "modular", "narrative", "modular"]);
+  });
+
+  test("advances every progress and selection timestamp with a constant clock", async () => {
+    const input = session("timestamps");
+    const workflow = new DesignDirectionWorkflow(undefined, () => 70, () => "generation-timestamps");
+    const started = await workflow.generate(input);
+    const ready = await started.completion;
+    const selected = await workflow.select(input.sessionId, ready.generation_id, 0, "editorial");
+    await workflow.undo(input.sessionId, ready.generation_id, selected.selection_revision);
+    const states = (await listSessionEvents(input.sessionId)).flatMap((item) =>
+      item.event.type === "design.direction_state" ? [parseDesignDirectionState(item.event.state)] : [],
+    );
+
+    expect(states.map((state) => state.updated_at)).toEqual([70, 71, 72, 73, 74, 75]);
+    expect(states.at(-1)?.selection_revision).toBe(2);
+  });
+
+  test("acknowledges cancellation only after the parsed terminal snapshot is published", async () => {
+    const input = session("cancel-terminal-ack");
+    const renderer = new ProgressGateRenderer();
+    const workflow = new DesignDirectionWorkflow(renderer, () => 79, () => "generation-cancel-terminal-ack");
+    const blocked = renderer.nextBlockedCall();
+    const started = await workflow.generate(input);
+    await blocked;
+
+    const cancelled = await workflow.cancel(input.sessionId);
+    const persisted = await getLatestDirectionState(input.sessionId);
+    const completed = await started.completion;
+
+    expect(cancelled).toEqual(completed);
+    expect(persisted).toEqual(completed);
+    expect(completed.status).toBe("cancelled");
+    expect(completed.directions.map((slot) => slot.status)).toEqual(["ready", "cancelled", "cancelled"]);
+  });
+
+  test("cancels when abort is requested immediately before renderer resolution", async () => {
+    const input = session("cancel-before-resolve");
+    let cancelOperation: (() => void) | null = null;
+    const renderer: DesignDirectionRenderer = {
+      async render(): Promise<void> {
+        const cancel = cancelOperation;
+        if (cancel === null) throw new TypeError("cancel callback missing");
+        cancel();
+      },
+    };
+    const workflow = new DesignDirectionWorkflow(renderer, () => 80, () => "generation-cancel-before-resolve");
+    cancelOperation = () => { void workflow.cancel(input.sessionId); };
+
+    const completed = await (await workflow.generate(input)).completion;
+
+    expect(completed.status).toBe("cancelled");
+    expect(completed.directions.every((slot) => slot.status === "cancelled")).toBeTrue();
+    expect(await workflow.cancel(input.sessionId)).toBeNull();
+  });
+
+  test("cancels through a renderer gate subscribed before generation", async () => {
+    const input = session("cancel");
+    const renderer = new GateRenderer();
+    const workflow = new DesignDirectionWorkflow(renderer, () => 30, () => "generation-cancel");
+    const entered = renderer.nextCall();
+    const started = await workflow.generate(input);
+    await entered;
+    expect(startUserTurn(input.sessionId, { type: "user.message", text: "blocked" })).toBeNull();
+    const acknowledged = await workflow.cancel(input.sessionId);
+    const cancelled = await started.completion;
+    expect(acknowledged).toEqual(cancelled);
+    expect(cancelled.status).toBe("cancelled");
+    expect(cancelled.directions.every((slot) => slot.status === "cancelled")).toBeTrue();
+  });
+
+  test("persists selection, detects conflicts, and undoes one revision", async () => {
+    const input = session("selection");
+    const workflow = new DesignDirectionWorkflow(undefined, () => 40, () => "generation-selection");
+    const ready = await (await workflow.generate(input)).completion;
+    const first = await workflow.select(input.sessionId, ready.generation_id, 0, "editorial");
+    const second = await workflow.select(input.sessionId, ready.generation_id, 1, "narrative");
+    expect((await getLatestDirectionState(input.sessionId))?.selected_id).toBe("narrative");
+    expect((await buildSessionContext(input.sessionId))?.designDirectionState?.selected_id).toBe("narrative");
+    await expect(workflow.select(input.sessionId, ready.generation_id, 1, "modular")).rejects.toBeInstanceOf(DesignDirectionWorkflowError);
+    const undone = await workflow.undo(input.sessionId, ready.generation_id, second.selection_revision);
+    expect(undone.selected_id).toBe(first.selected_id);
+    expect(undone.selection_revision).toBe(3);
+  });
+
+  test("recovers orphaned loading state as retryable failure", async () => {
+    const input = session("recovery");
+    const state: DesignDirectionState = {
+      schema_version: 1, project_id: projectId, session_id: input.sessionId, generation_id: "orphan", status: "loading",
+      content_outline: ["문제"], selected_id: null, selection_revision: 0, selection_history: [], error: null, updated_at: 50,
+      directions: [
+        { id: "editorial", order: 0, layout_key: "editorial", title: "편집", summary: "요약", style_facts: ["사실"], status: "pending", preview_url: null, error: null },
+        { id: "modular", order: 1, layout_key: "modular", title: "모듈", summary: "요약", style_facts: ["사실"], status: "pending", preview_url: null, error: null },
+        { id: "narrative", order: 2, layout_key: "narrative", title: "서사", summary: "요약", style_facts: ["사실"], status: "pending", preview_url: null, error: null },
+      ],
+    };
+    await publishDirectionState(input.sessionId, state);
+    const recovered = await new DesignDirectionWorkflow(undefined, () => 51).recover(input.sessionId);
+    expect(recovered?.status).toBe("failed");
+    expect(recovered?.directions.every((slot) => slot.error === DIRECTION_INTERRUPTION_ERROR)).toBeTrue();
+  });
+});

--- a/packages/backend/tests/export-handoff.test.ts
+++ b/packages/backend/tests/export-handoff.test.ts
@@ -100,7 +100,7 @@ describe("buildHandoffSpec", () => {
 });
 
 describe("copyProjectIntoBundle", () => {
-  test("mirrors the entire project tree into source/, minus .meta and .attachments", async () => {
+  test("mirrors managed project files without control or stage-input directories", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "bg-handoff-copy-"));
     const staged = path.join(root, "staged");
     const bundleSource = path.join(root, "bundle", "source");
@@ -123,18 +123,16 @@ describe("copyProjectIntoBundle", () => {
         "utf8",
       );
       mkdirSync(path.join(staged, ".attachments"), { recursive: true });
-      writeFileSync(
-        path.join(staged, ".attachments", "upload.bin"),
-        "SECRET",
-        "utf8",
-      );
+      writeFileSync(path.join(staged, ".attachments", "upload.bin"), "SECRET", "utf8");
+      mkdirSync(path.join(staged, ".burnguard-inputs"), { recursive: true });
+      writeFileSync(path.join(staged, ".burnguard-inputs", "source.pdf"), "INPUT", "utf8");
 
       const result = await copyProjectIntoBundle(staged, bundleSource);
 
       expect(result.copied.sort()).toEqual(
         ["assets", "deck.html", "fonts", "style.css"].sort(),
       );
-      expect(result.skipped.sort()).toEqual([".attachments", ".meta"].sort());
+      expect(result.skipped.sort()).toEqual([".attachments", ".burnguard-inputs", ".meta"].sort());
 
       expect(readFileSync(path.join(bundleSource, "deck.html"), "utf8")).toBe("<h1/>");
       expect(
@@ -148,6 +146,7 @@ describe("copyProjectIntoBundle", () => {
       const present = readdirSync(bundleSource);
       expect(present).not.toContain(".meta");
       expect(present).not.toContain(".attachments");
+      expect(present).not.toContain(".burnguard-inputs");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/backend/tests/export-render-lifecycle.test.ts
+++ b/packages/backend/tests/export-render-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { closeActiveExportBrowsers, registerExportBrowser } from "../src/services/export-browser-registry";
+import { activeExportBrowserCount, closeActiveExportBrowsers, registerExportBrowser } from "../src/services/export-browser-registry";
 import { armExportQaBarrier, exportQaHooks, releaseExportQaBarrier, waitForExportQaBarrier } from "../src/services/export-qa-barrier";
 
 describe("export browser lifecycle", () => {
@@ -11,6 +11,16 @@ describe("export browser lifecycle", () => {
 
   test("Given a normally closed renderer When shutdown begins Then it is not closed again", async () => {
     let closes = 0; const owner = registerExportBrowser(async () => { closes += 1; }); owner.release(); await closeActiveExportBrowsers(); expect(closes).toBe(0);
+  });
+
+  test("Given Chromium graceful close stalls When its deadline expires Then forced close empties ownership", async () => {
+    let closes = 0; const owner = registerExportBrowser(async () => { closes += 1; if (closes === 1) await new Promise<void>(() => undefined); }, { gracefulDeadlineMs: 0 });
+    await owner.close(); expect(closes).toBe(2); expect(activeExportBrowserCount()).toBe(0);
+  });
+
+  test("Given Chromium graceful close fails When forced close succeeds Then cleanup completes and the failure remains loud", async () => {
+    const failure = new TypeError("graceful close failed"); let closes = 0; const owner = registerExportBrowser(async () => { closes += 1; if (closes === 1) throw failure; });
+    await expect(owner.close()).rejects.toBe(failure); expect(closes).toBe(2); expect(activeExportBrowserCount()).toBe(0);
   });
 
   test("Given an armed attempt barrier When its exact phase is reached Then observation precedes release", async () => {

--- a/packages/backend/tests/graphic-canvas-contract.test.ts
+++ b/packages/backend/tests/graphic-canvas-contract.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import * as shared from "@bg/shared";
+
+function graphicCanvasParser(): (input: unknown) => unknown {
+  const parser = Reflect.get(shared, "parseGraphicCanvasV1");
+  expect(typeof parser).toBe("function");
+  if (typeof parser !== "function") {
+    return () => undefined;
+  }
+  return parser;
+}
+
+describe("GraphicCanvasV1", () => {
+  test.each([
+    { schema_version: 1, width: 1080, height: 1080 },
+    { schema_version: 1, width: 1200, height: 628 },
+    { schema_version: 1, width: 1080, height: 1920 },
+  ])("Given a bounded canvas When parsed Then exact dimensions are preserved", (canvas) => {
+    expect(graphicCanvasParser()(canvas)).toEqual(canvas);
+  });
+
+  test.each([
+    [{ schema_version: 1, width: 1080.5, height: 1080 }, "width"],
+    [{ schema_version: 1, width: 319, height: 1080 }, "width"],
+    [{ schema_version: 1, width: 4097, height: 1080 }, "width"],
+    [{ schema_version: 1, width: 1080, height: 239 }, "height"],
+    [{ schema_version: 1, width: 1080, height: 4097 }, "height"],
+    [{ schema_version: 1, width: 4000, height: 4001 }, "width"],
+    [{ schema_version: 1, width: 1080, height: 1080, extra: true }, "extra"],
+  ] satisfies readonly (readonly [Readonly<Record<string, unknown>>, string])[]) (
+    "Given an invalid canvas When parsed Then the typed path is %s",
+    (canvas, path) => {
+      try {
+        graphicCanvasParser()(canvas);
+        throw new TypeError("expected GraphicCanvasV1 rejection");
+      } catch (error) {
+        expect(error).toBeInstanceOf(shared.UpgradeContractError);
+        if (!(error instanceof shared.UpgradeContractError)) throw error;
+        expect(error.path).toBe(path);
+      }
+    },
+  );
+});

--- a/packages/backend/tests/graphic-export.test.ts
+++ b/packages/backend/tests/graphic-export.test.ts
@@ -1,0 +1,164 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { GraphicCanvasV1, SequencedEventEnvelope } from "@bg/shared";
+import { getExportAttemptDetail, getExportJob } from "../src/db/exports";
+import { runMigrations } from "../src/db/migrate-local";
+import { getSqlite } from "../src/db/sqlite-client";
+import { renderInitialArtifact } from "../src/db/templates";
+import { artifactRoutes } from "../src/routes/artifacts";
+import { projectsDir } from "../src/lib/paths";
+import { ArtifactCoordinator } from "../src/services/artifact-coordinator";
+import { inspectCanonicalTree } from "../src/services/canonical-tree-manifest";
+import { auditRenderedTree } from "../src/services/design-audit";
+import { sequencedBroker } from "../src/services/broker";
+import { activeExportBrowserCount } from "../src/services/export-browser-registry";
+import { enqueueProjectExport, ExportServiceError } from "../src/services/exports";
+import { parsePng } from "../src/services/export-png-validation";
+import { parseExportReceipt } from "../src/services/export-receipt";
+
+const projectId = `graphic-export-${process.pid}`;
+const sessionId = `${projectId}-session`;
+const projectDir = path.join(projectsDir, projectId);
+const canvas = { schema_version: 1, width: 1200, height: 628 } as const;
+const projectName = "Functional Graphic 1200x628";
+
+beforeAll(async () => {
+  await runMigrations();
+  await mkdir(projectDir, { recursive: true });
+  await writeFile(path.join(projectDir, "index.html"), renderInitialArtifact({ name: projectName, type: "graphic", options: { graphic_canvas: canvas } }));
+  getSqlite().prepare("INSERT INTO projects(id,name,type,dir_path,entrypoint,backend_id,options_json,created_at,updated_at) VALUES (?,?, 'graphic',?,'index.html','codex',?,1,1)").run(projectId, projectName, projectDir, JSON.stringify({ use_speaker_notes: false, copy_as_is: false, design_brief: { schema_version: 1, output_type: "graphic", audience: "Campaign visitors", objective: "Announce the autumn launch", content_source: "none", locale: "en-US", brand_mode: "none", visual_mood: "premium", density: "balanced", output_size: "custom" }, graphic_canvas: canvas }));
+  getSqlite().prepare("INSERT INTO sessions(id,project_id,backend_id,status,created_at,updated_at,last_active_at) VALUES (?,?,'codex','idle',1,1,1)").run(sessionId, projectId);
+  await new ArtifactCoordinator(getSqlite()).initialize(projectId, projectDir);
+});
+
+afterAll(async () => {
+  getSqlite().prepare("DELETE FROM projects WHERE id=?").run(projectId);
+  await rm(projectDir, { recursive: true, force: true });
+});
+
+describe("graphic PNG export invariant", () => {
+  test.each([
+    { png_width: 1201, png_height: 628, png_dpr: 1 as const },
+    { png_width: 1200, png_height: 629, png_dpr: 1 as const },
+    { png_width: 1200, png_height: 628, png_dpr: 2 as const },
+  ])("Given mismatched graphic PNG options When enqueued Then rejection precedes export authority", async (options) => {
+    const before = exportCount();
+    try {
+      await enqueueProjectExport(projectId, "png", options);
+      throw new TypeError("expected graphic export rejection");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ExportServiceError);
+      if (!(error instanceof ExportServiceError)) throw error;
+      expect(error.code).toBe("invalid_graphic_export_options");
+    }
+    expect(exportCount()).toBe(before);
+    expect(activeExportBrowserCount()).toBe(0);
+  });
+
+  test("Given a mismatched API request When posted Then a typed client-facing error is returned", async () => {
+    const response = await artifactRoutes.request(`http://local/api/projects/${projectId}/exports`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        format: "png",
+        options: { png_width: 1201, png_height: 628, png_dpr: 1 },
+      }),
+    });
+    const body: unknown = await response.json();
+    expect(response.status).toBe(400);
+    expect(body).toMatchObject({
+      error: { code: "invalid_graphic_export_options" },
+    });
+  });
+
+  test.each([
+    [projectName, canvas],
+    ["가".repeat(200), canvas],
+    ["Minimum canvas", { schema_version: 1, width: 320, height: 240 } as const],
+    ["Portrait canvas", { schema_version: 1, width: 1080, height: 1920 } as const],
+  ] as const)("Given a server initial graphic When audited at its persisted canvas Then authored text is audit-clean", async (name, dimensions) => {
+    const report = await auditInitialGraphic(name, dimensions);
+    const mustFix = report.checks.flatMap((check) => check.findings).filter((finding) => finding.severity === "must_fix");
+    const undersized = report.checks.find((check) => check.code === "minimum_text_size")?.findings ?? [];
+    expect(mustFix).toEqual([]);
+    expect(undersized).toEqual([]);
+  }, 70_000);
+
+  test("Given exact persisted dimensions When exported Then PNG IHDR statistics and receipt are exact", async () => {
+    const terminal = nextTerminalExport();
+    const started = await enqueueProjectExport(projectId, "png", {
+      png_width: canvas.width,
+      png_height: canvas.height,
+      png_dpr: 1,
+    });
+    if (started === null || started.latest_attempt === null) {
+      throw new TypeError("graphic export did not start");
+    }
+    await terminal;
+    const job = await getExportJob(started.id);
+    if (job?.status !== "succeeded") {
+      const attempt = await getExportAttemptDetail(started.latest_attempt.id);
+      throw new TypeError(`${job?.error_message ?? `unexpected graphic export status: ${job?.status ?? "missing"}`} ${JSON.stringify(attempt?.findings ?? [])}`);
+    }
+    if (job.output_path === null) {
+      throw new TypeError("graphic output unavailable");
+    }
+    const output = new Uint8Array(await readFile(job.output_path));
+    expect(parsePng(output)).toEqual({ width: 1200, height: 628 });
+    const receipt = parseExportReceipt(JSON.parse(await readFile(path.join(path.dirname(job.output_path), "receipt.json"), "utf8")));
+    expect(receipt.validation).toMatchObject({ width: 1200, height: 628 });
+    if (!("statistics" in receipt.validation)) throw new TypeError("PNG statistics missing");
+    expect(receipt.validation.statistics.pixels).toBe(753_600);
+    expect(receipt.validation.statistics.visible_pixels).toBe(753_600);
+    expect(receipt.validation.statistics.differing_pixels).toBeGreaterThan(0);
+    expect(activeExportBrowserCount()).toBe(0);
+  }, 70_000);
+});
+
+async function auditInitialGraphic(name: string, dimensions: GraphicCanvasV1) {
+  const root = await mkdtemp(path.join(tmpdir(), "bg-graphic-template-audit-"));
+  try {
+    await writeFile(path.join(root, "index.html"), renderInitialArtifact({
+      name,
+      type: "graphic",
+      options: { graphic_canvas: dimensions },
+    }));
+    const manifest = await inspectCanonicalTree(root);
+    const report = await auditRenderedTree({
+      projectId: "graphic-template-audit",
+      projectDir: root,
+      entrypoint: "index.html",
+      revision: 0,
+      digest: manifest.tree_digest,
+      canvas: dimensions,
+      safeFix: false,
+      signal: new AbortController().signal,
+    });
+    expect(activeExportBrowserCount()).toBe(0);
+    return report;
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function exportCount(): number {
+  const row = getSqlite().query<{ readonly count: number }, [string]>("SELECT COUNT(*) count FROM exports WHERE project_id=?").get(projectId);
+  return row?.count ?? 0;
+}
+
+function nextTerminalExport(): Promise<SequencedEventEnvelope> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      unsubscribe();
+      reject(new TypeError("graphic export terminal event timed out"));
+    }, 60_000);
+    const unsubscribe = sequencedBroker.subscribe(sessionId, (item) => {
+      if (item.event.type !== "export.attempt" || (item.event.status !== "failed" && item.event.status !== "validated")) return;
+      clearTimeout(timeout);
+      unsubscribe();
+      resolve(item);
+    });
+  });
+}

--- a/packages/backend/tests/graphic-migration.test.ts
+++ b/packages/backend/tests/graphic-migration.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { cp, mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { runMigrationsFrom } from "../src/db/migrate";
+
+const sourceDir = path.join(import.meta.dir, "../src/db/migrations");
+
+describe("0011 graphic project migration", () => {
+  test("Given persisted 0010 project state and a child row When 0011 applies Then data FKs indexes and type checks survive", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "burnguard-graphic-migration-"));
+    const db = new Database(":memory:");
+    db.exec("PRAGMA foreign_keys = ON");
+    try {
+      for (const file of (await readdir(sourceDir)).filter((name) => name <= "0010_research.sql")) {
+        await cp(path.join(sourceDir, file), path.join(directory, file));
+      }
+      await runMigrationsFrom(db, directory);
+      const options = JSON.stringify({
+        use_speaker_notes: false,
+        copy_as_is: false,
+        design_brief: null,
+      });
+      db.prepare(`INSERT INTO projects(
+        id,name,type,design_system_id,dir_path,entrypoint,thumbnail_path,
+        backend_id,options_json,archived_at,created_at,updated_at,current_revision,current_digest
+      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)`).run(
+        "existing-project",
+        "Existing",
+        "prototype",
+        null,
+        "/tmp/existing-project",
+        "index.html",
+        "/tmp/existing-thumbnail.png",
+        "codex",
+        options,
+        null,
+        10,
+        20,
+        7,
+        "existing-digest",
+      );
+      db.prepare("INSERT INTO sessions(id,project_id,backend_id,status,created_at,updated_at,last_active_at) VALUES (?,?,?,?,?,?,?)").run(
+        "existing-session",
+        "existing-project",
+        "codex",
+        "idle",
+        10,
+        20,
+        20,
+      );
+      await cp(
+        path.join(sourceDir, "0011_graphic_project_type.sql"),
+        path.join(directory, "0011_graphic_project_type.sql"),
+      );
+
+      await runMigrationsFrom(db, directory);
+
+      expect(db.query("SELECT id,name,type,design_system_id,dir_path,entrypoint,thumbnail_path,backend_id,options_json,archived_at,created_at,updated_at,current_revision,current_digest FROM projects WHERE id='existing-project'").get()).toEqual({
+        id: "existing-project",
+        name: "Existing",
+        type: "prototype",
+        design_system_id: null,
+        dir_path: "/tmp/existing-project",
+        entrypoint: "index.html",
+        thumbnail_path: "/tmp/existing-thumbnail.png",
+        backend_id: "codex",
+        options_json: options,
+        archived_at: null,
+        created_at: 10,
+        updated_at: 20,
+        current_revision: 7,
+        current_digest: "existing-digest",
+      });
+      expect(db.query("SELECT id,project_id FROM sessions WHERE id='existing-session'").get()).toEqual({
+        id: "existing-session",
+        project_id: "existing-project",
+      });
+      expect(db.query("PRAGMA foreign_keys").get()).toEqual({ foreign_keys: 1 });
+      expect(db.query("PRAGMA foreign_key_check").all()).toEqual([]);
+      expect(db.query("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='projects' ORDER BY name").all()).toEqual([
+        { name: "idx_projects_ds" },
+        { name: "idx_projects_updated" },
+        { name: "sqlite_autoindex_projects_1" },
+      ]);
+      expect(() => db.exec("INSERT INTO projects(id,name,type,dir_path,backend_id,created_at,updated_at) VALUES ('graphic-project','Graphic','graphic','/tmp/graphic','codex',1,1)")).not.toThrow();
+      expect(() => db.exec("INSERT INTO projects(id,name,type,dir_path,backend_id,created_at,updated_at) VALUES ('invalid-project','Invalid','poster','/tmp/invalid','codex',1,1)")).toThrow();
+    } finally {
+      db.close();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/backend/tests/graphic-template.test.ts
+++ b/packages/backend/tests/graphic-template.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { parse } from "node-html-parser";
+import { renderInitialArtifact } from "../src/db/templates";
+
+describe("initial graphic template", () => {
+  test("Given a graphic canvas When rendered Then one exact server-owned artboard is emitted", () => {
+    const html = renderInitialArtifact({
+      name: "행사 포스터",
+      type: "graphic",
+      options: { graphic_canvas: { schema_version: 1, width: 1080, height: 1920 } },
+    });
+    const root = parse(html);
+
+    expect(root.querySelectorAll("[data-graphic-artboard]")).toHaveLength(1);
+    expect(html).toContain("width: 1080px");
+    expect(html).toContain("height: 1920px");
+    expect(root.querySelectorAll("[data-bg-node-id]").length).toBeGreaterThanOrEqual(3);
+    expect(root.textContent.trim().length).toBeGreaterThan(20);
+    expect(html).not.toContain("data-slide");
+    expect(html).not.toContain("deck-stage.js");
+  });
+});

--- a/packages/backend/tests/home-project-input.test.ts
+++ b/packages/backend/tests/home-project-input.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { homeRoutes } from "../src/routes/home";
+import { parseProjectInput, ProjectInputError } from "../src/routes/home-project-input";
 
 type ErrorEnvelope = {
   readonly error: {
@@ -32,17 +33,52 @@ async function createProject(body: unknown): Promise<Response> {
 }
 
 describe("home project input boundary", () => {
+  test("Given a graphic canvas When parsed Then graphic creation uses index.html", () => {
+    expect(parseProjectInput({
+      name: "SNS 카드",
+      type: "graphic",
+      design_system_id: null,
+      backend_id: "claude-code",
+      options: { graphic_canvas: { schema_version: 1, width: 1200, height: 628 } },
+    })).toMatchObject({
+      type: "graphic",
+      entrypoint: "index.html",
+      optionsJson: JSON.stringify({
+        use_speaker_notes: false,
+        copy_as_is: false,
+        design_brief: null,
+        graphic_canvas: { schema_version: 1, width: 1200, height: 628 },
+      }),
+    });
+  });
+
+  test.each([
+    {
+      name: "Graphic without canvas",
+      type: "graphic",
+      design_system_id: null,
+      backend_id: "claude-code",
+    },
+    {
+      name: "Prototype with stale canvas",
+      type: "prototype",
+      design_system_id: null,
+      backend_id: "claude-code",
+      options: { graphic_canvas: { schema_version: 1, width: 1080, height: 1080 } },
+    },
+  ])("Given canvas/type mismatch When parsed Then project options reject it", (input) => {
+    try {
+      parseProjectInput(input);
+      throw new TypeError("expected project options rejection");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProjectInputError);
+      if (!(error instanceof ProjectInputError)) throw error;
+      expect(error.code).toBe("invalid_project_options");
+    }
+  });
+
   test.each([
     [{}, "invalid_name"],
-    [
-      {
-        name: "Project",
-        type: "graphic",
-        design_system_id: null,
-        backend_id: "claude-code",
-      },
-      "invalid_type",
-    ],
     [
       {
         name: "Project",

--- a/packages/backend/tests/owned-process-tree.test.ts
+++ b/packages/backend/tests/owned-process-tree.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { runClaudeCode } from "../src/adapters/claude-code/runner";
+
+test("Given an adapter exits with a surviving child When its result resolves Then the owned process tree is absent before publication", async () => {
+  if (process.platform === "win32") return;
+  const root = await mkdtemp(path.join(tmpdir(), "burnguard-adapter-tree-"));
+  const binary = path.join(root, "adapter-fixture");
+  const childScript = "await new Promise(() => {})";
+  await writeFile(binary, `#!/usr/bin/env bun\nconst child=Bun.spawn([process.execPath,"-e",${JSON.stringify(childScript)}],{stdin:"ignore",stdout:"ignore",stderr:"ignore"});child.unref();console.log(child.pid);\n`);
+  await chmod(binary, 0o700);
+  let childPid = 0;
+  try {
+    const result = await runClaudeCode({ binaryPath: binary, projectDir: root, prompt: "test", onStdoutLine: (line) => { childPid = Number(line); } });
+    expect(result.exitCode).toBe(0);
+    expect(Number.isSafeInteger(childPid) && childPid > 0).toBe(true);
+    expect(() => process.kill(childPid, 0)).toThrow();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/backend/tests/project-options.test.ts
+++ b/packages/backend/tests/project-options.test.ts
@@ -30,6 +30,17 @@ describe("project options", () => {
       use_speaker_notes: true,
       copy_as_is: false,
       design_brief: validBrief,
+      graphic_canvas: null,
+    });
+  });
+
+  test("Given graphic dimensions When parsed Then the canonical canvas is preserved", () => {
+    expect(
+      parseProjectOptions({
+        graphic_canvas: { schema_version: 1, width: 1200, height: 628 },
+      }),
+    ).toMatchObject({
+      graphic_canvas: { schema_version: 1, width: 1200, height: 628 },
     });
   });
 
@@ -49,6 +60,7 @@ describe("project options", () => {
       use_speaker_notes: false,
       copy_as_is: false,
       design_brief: null,
+      graphic_canvas: null,
     });
   });
 });

--- a/packages/backend/tests/project-thumbnails.test.ts
+++ b/packages/backend/tests/project-thumbnails.test.ts
@@ -1,0 +1,381 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createCanvas } from "@napi-rs/canvas";
+import { runMigrations } from "../src/db/migrate-local";
+import { listHomeProjects } from "../src/db/seed";
+import { getSqlite } from "../src/db/sqlite-client";
+import { projectsDir } from "../src/lib/paths";
+import { homeRoutes } from "../src/routes/home";
+import { classifyApiRoute } from "../src/server";
+import { parsePng } from "../src/services/export-png-validation";
+import {
+  loadProjectThumbnail,
+  projectThumbnailIdentity,
+  projectThumbnailUrl,
+  THUMBNAIL_HEIGHT,
+  THUMBNAIL_WIDTH,
+  type ThumbnailRenderer,
+} from "../src/services/project-thumbnails";
+
+const digestA = "a".repeat(64);
+const digestB = "b".repeat(64);
+const projectIds: string[] = [];
+const tempDirs: string[] = [];
+let sequence = 0;
+
+function pngFixture(width: number, height: number): Uint8Array {
+  const canvas = createCanvas(width, height);
+  const context = canvas.getContext("2d");
+  context.fillStyle = "#123456";
+  context.fillRect(0, 0, width, height);
+  context.fillStyle = "#f0f0f0";
+  context.fillRect(8, 8, Math.max(1, width - 16), Math.max(1, height - 16));
+  return Uint8Array.from(canvas.toBuffer("image/png"));
+}
+
+function recordingRenderer(width = THUMBNAIL_WIDTH, height = THUMBNAIL_HEIGHT) {
+  const requests: Array<{ readonly stagedDir: string; readonly entrypoint: string; readonly deck: boolean }> = [];
+  const renderer: ThumbnailRenderer = async (request) => {
+    requests.push({ stagedDir: request.stagedDir, entrypoint: request.entrypoint, deck: request.deck });
+    await writeFile(request.outputPath, pngFixture(width, height));
+  };
+  return { renderer, requests };
+}
+
+const failingRenderer: ThumbnailRenderer = async () => {
+  throw new Error("chromium_not_installed");
+};
+
+async function createProject(options: {
+  readonly digest: string | null;
+  readonly revision?: number;
+  readonly type?: "prototype" | "slide_deck";
+  readonly dirPath?: string;
+}): Promise<{ readonly id: string; readonly dirPath: string }> {
+  sequence += 1;
+  const id = `bg-thumb-${process.pid}-${sequence}`;
+  const dirPath = options.dirPath ?? path.join(projectsDir, id);
+  await mkdir(path.join(dirPath, ".meta"), { recursive: true });
+  await writeFile(path.join(dirPath, "index.html"), "<!doctype html><title>t</title>", "utf8");
+  getSqlite()
+    .prepare(
+      `INSERT INTO projects(id,name,type,dir_path,entrypoint,backend_id,created_at,updated_at,current_revision,current_digest)
+       VALUES (?,?,?,?,'index.html','codex',1,1,?,?)`,
+    )
+    .run(id, id, options.type ?? "prototype", dirPath, options.revision ?? 3, options.digest);
+  projectIds.push(id);
+  if (options.dirPath === undefined) tempDirs.push(dirPath);
+  return { id, dirPath };
+}
+
+function cacheDir(dirPath: string): string {
+  return path.join(dirPath, ".meta", "thumbnails");
+}
+
+async function cachedFiles(dirPath: string): Promise<readonly string[]> {
+  return (await readdir(cacheDir(dirPath)).catch(() => [] as string[])).filter((name) => name.endsWith(".png")).sort();
+}
+
+function request(route: string, headers?: Record<string, string>): Promise<Response> {
+  return homeRoutes.request(`http://local${route}`, headers === undefined ? undefined : { headers });
+}
+
+beforeAll(async () => {
+  await runMigrations();
+  await mkdir(projectsDir, { recursive: true });
+});
+
+afterAll(async () => {
+  const db = getSqlite();
+  for (const id of projectIds.splice(0)) db.prepare("DELETE FROM projects WHERE id=?").run(id);
+  for (const dir of tempDirs.splice(0)) await rm(dir, { recursive: true, force: true });
+});
+
+describe("project thumbnail identity", () => {
+  test("Given the same project revision digest and renderer When identity is derived Then it is stable and filename safe", () => {
+    const project = { id: "p1", current_revision: 3, current_digest: digestA };
+
+    const identity = projectThumbnailIdentity(project);
+
+    expect(identity).toBe(projectThumbnailIdentity({ ...project }));
+    expect(identity).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("Given a changed project id revision or digest When identity is derived Then every variant differs", () => {
+    const base = { id: "p1", current_revision: 3, current_digest: digestA };
+
+    const identity = projectThumbnailIdentity(base);
+
+    expect(projectThumbnailIdentity({ ...base, id: "p2" })).not.toBe(identity);
+    expect(projectThumbnailIdentity({ ...base, current_revision: 4 })).not.toBe(identity);
+    expect(projectThumbnailIdentity({ ...base, current_digest: digestB })).not.toBe(identity);
+  });
+
+  test("Given a project without a current digest When identity is derived Then there is no identity", () => {
+    expect(projectThumbnailIdentity({ id: "p1", current_revision: 3, current_digest: null })).toBeNull();
+  });
+
+  test("Given a project with a digest When the thumbnail URL is built Then it carries the identity as the cache buster", () => {
+    const project = { id: "p 1/x", current_revision: 3, current_digest: digestA };
+
+    const url = projectThumbnailUrl(project);
+
+    expect(url).toBe(`/api/projects/${encodeURIComponent("p 1/x")}/thumbnail?v=${projectThumbnailIdentity(project) ?? ""}`);
+  });
+
+  test("Given a project without a digest When the thumbnail URL is built Then no URL is exposed", () => {
+    expect(projectThumbnailUrl({ id: "p1", current_revision: 0, current_digest: null })).toBeNull();
+  });
+});
+
+describe("project list thumbnail exposure", () => {
+  test("Given a project with a current digest When the home list is read Then thumbnail_path is the route URL and nothing is rendered", async () => {
+    const project = await createProject({ digest: digestA, revision: 5 });
+
+    const listed = (await listHomeProjects("recent", 500, 0)).items.find((item) => item.id === project.id);
+
+    expect(listed?.thumbnail_path).toBe(
+      `/api/projects/${project.id}/thumbnail?v=${projectThumbnailIdentity({ id: project.id, current_revision: 5, current_digest: digestA }) ?? ""}`,
+    );
+    expect(await cachedFiles(project.dirPath)).toEqual([]);
+  });
+
+  test("Given a project without a current digest When the home list is read Then thumbnail_path stays null", async () => {
+    const project = await createProject({ digest: null });
+
+    const listed = (await listHomeProjects("recent", 500, 0)).items.find((item) => item.id === project.id);
+
+    expect(listed?.thumbnail_path).toBeNull();
+  });
+});
+
+describe("project thumbnail generation and cache", () => {
+  test("Given a project with no cached thumbnail When loaded Then it renders once at exactly 640x360 and stores the PNG", async () => {
+    const project = await createProject({ digest: digestA });
+    const { renderer, requests } = recordingRenderer();
+
+    const outcome = await loadProjectThumbnail(project.id, renderer);
+
+    expect(outcome.kind).toBe("ready");
+    expect(requests.length).toBe(1);
+    expect([THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT]).toEqual([640, 360]);
+    if (outcome.kind !== "ready") throw new Error("expected a ready thumbnail");
+    expect(parsePng(outcome.bytes)).toEqual({ width: 640, height: 360 });
+    expect(await cachedFiles(project.dirPath)).toEqual([`${projectThumbnailIdentity({ id: project.id, current_revision: 3, current_digest: digestA }) ?? ""}.png`]);
+  });
+
+  test("Given concurrent cold-cache requests When both render Then their temporary files cannot collide", async () => {
+    const project = await createProject({ digest: digestA });
+    const outputPaths: string[] = [];
+    const temporaryIds = ["first", "second"];
+    let releaseRender: (() => void) | null = null;
+    const renderGate = new Promise<void>((resolve) => {
+      releaseRender = resolve;
+    });
+    const renderer: ThumbnailRenderer = async (request) => {
+      outputPaths.push(request.outputPath);
+      if (outputPaths.length === 2) {
+        releaseRender?.();
+      }
+      await renderGate;
+      await writeFile(
+        request.outputPath,
+        pngFixture(THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT),
+      );
+    };
+
+    const outcomes = await Promise.all([
+      loadProjectThumbnail(project.id, renderer, () => temporaryIds.shift() ?? "unexpected"),
+      loadProjectThumbnail(project.id, renderer, () => temporaryIds.shift() ?? "unexpected"),
+    ]);
+
+    expect(outcomes.map((outcome) => outcome.kind)).toEqual([
+      "ready",
+      "ready",
+    ]);
+    expect(new Set(outputPaths).size).toBe(2);
+    expect(
+      outputPaths
+        .map((outputPath) => path.basename(outputPath).split(".").at(-2))
+        .sort(),
+    ).toEqual(["first", "second"]);
+    expect((await cachedFiles(project.dirPath)).length).toBe(1);
+  });
+
+  test("Given a slide deck project When the thumbnail renders Then the deck flag and project entrypoint are used", async () => {
+    const project = await createProject({ digest: digestA, type: "slide_deck" });
+    const { renderer, requests } = recordingRenderer();
+
+    await loadProjectThumbnail(project.id, renderer);
+
+    expect(requests[0]).toEqual({ stagedDir: project.dirPath, entrypoint: "index.html", deck: true });
+  });
+
+  test("Given an already cached thumbnail When loaded again Then the cache is served without re-rendering", async () => {
+    const project = await createProject({ digest: digestA });
+    const { renderer, requests } = recordingRenderer();
+    const first = await loadProjectThumbnail(project.id, renderer);
+
+    const second = await loadProjectThumbnail(project.id, renderer);
+
+    expect(requests.length).toBe(1);
+    if (first.kind !== "ready" || second.kind !== "ready") throw new Error("expected ready thumbnails");
+    expect(Buffer.from(second.bytes).equals(Buffer.from(first.bytes))).toBe(true);
+    expect(second.etag).toBe(first.etag);
+  });
+
+  test("Given a new artifact digest When loaded Then the stale cache entry is not served and a fresh identity is rendered", async () => {
+    const project = await createProject({ digest: digestA });
+    const { renderer, requests } = recordingRenderer();
+    const stale = await loadProjectThumbnail(project.id, renderer);
+    getSqlite().prepare("UPDATE projects SET current_digest=?, current_revision=4 WHERE id=?").run(digestB, project.id);
+
+    const fresh = await loadProjectThumbnail(project.id, renderer);
+
+    expect(requests.length).toBe(2);
+    if (stale.kind !== "ready" || fresh.kind !== "ready") throw new Error("expected ready thumbnails");
+    expect(fresh.etag).not.toBe(stale.etag);
+    expect((await cachedFiles(project.dirPath)).length).toBe(2);
+  });
+
+  test("Given a corrupt cached PNG When loaded Then it regenerates exactly once and returns a valid PNG", async () => {
+    const project = await createProject({ digest: digestA });
+    const { renderer, requests } = recordingRenderer();
+    await loadProjectThumbnail(project.id, renderer);
+    const identity = projectThumbnailIdentity({ id: project.id, current_revision: 3, current_digest: digestA }) ?? "";
+    await writeFile(path.join(cacheDir(project.dirPath), `${identity}.png`), "not-a-png");
+
+    const repaired = await loadProjectThumbnail(project.id, renderer);
+
+    expect(requests.length).toBe(2);
+    if (repaired.kind !== "ready") throw new Error("expected a ready thumbnail");
+    expect(parsePng(repaired.bytes)).toEqual({ width: 640, height: 360 });
+    await loadProjectThumbnail(project.id, renderer);
+    expect(requests.length).toBe(2);
+  });
+
+  test("Given a cached PNG with the wrong dimensions When loaded Then it is rejected and regenerated", async () => {
+    const project = await createProject({ digest: digestA });
+    const identity = projectThumbnailIdentity({ id: project.id, current_revision: 3, current_digest: digestA }) ?? "";
+    await mkdir(cacheDir(project.dirPath), { recursive: true });
+    await writeFile(path.join(cacheDir(project.dirPath), `${identity}.png`), pngFixture(320, 180));
+    const correctSize = recordingRenderer();
+
+    const outcome = await loadProjectThumbnail(project.id, correctSize.renderer);
+
+    expect(correctSize.requests.length).toBe(1);
+    if (outcome.kind !== "ready") throw new Error("expected a ready thumbnail");
+    expect(parsePng(outcome.bytes)).toEqual({ width: 640, height: 360 });
+  });
+
+  test("Given a render failure When loaded Then a typed unavailable outcome is returned and the list route still answers", async () => {
+    const project = await createProject({ digest: digestA });
+
+    const outcome = await loadProjectThumbnail(project.id, failingRenderer);
+
+    expect(outcome).toEqual({ kind: "unavailable", code: "thumbnail_unavailable" });
+    expect(await cachedFiles(project.dirPath)).toEqual([]);
+    expect((await request("/api/projects")).status).toBe(200);
+  });
+
+  test("Given a missing project or a project without a digest When loaded Then typed not-found and unavailable outcomes are returned", async () => {
+    const project = await createProject({ digest: null });
+
+    expect(await loadProjectThumbnail(`${project.id}-missing`, failingRenderer)).toEqual({ kind: "not_found" });
+    expect(await loadProjectThumbnail(project.id, failingRenderer)).toEqual({ kind: "unavailable", code: "artifact_unavailable" });
+  });
+});
+
+describe("project thumbnail path boundary", () => {
+  test("Given a project directory outside the managed projects root When loaded Then nothing is rendered or written", async () => {
+    const outside = await mkdtemp(path.join(tmpdir(), "bg-thumb-outside-"));
+    tempDirs.push(outside);
+    const project = await createProject({ digest: digestA, dirPath: outside });
+    const { renderer, requests } = recordingRenderer();
+
+    const outcome = await loadProjectThumbnail(project.id, renderer);
+
+    expect(outcome).toEqual({ kind: "unavailable", code: "thumbnail_unavailable" });
+    expect(requests.length).toBe(0);
+    expect(await cachedFiles(outside)).toEqual([]);
+  });
+
+  test("Given a thumbnail cache directory symlinked outside the project When loaded Then the escape is refused", async () => {
+    const project = await createProject({ digest: digestA });
+    const escape = await mkdtemp(path.join(tmpdir(), "bg-thumb-escape-"));
+    tempDirs.push(escape);
+    await symlink(escape, cacheDir(project.dirPath), process.platform === "win32" ? "junction" : "dir");
+    const { renderer, requests } = recordingRenderer();
+
+    const outcome = await loadProjectThumbnail(project.id, renderer);
+
+    expect(outcome).toEqual({ kind: "unavailable", code: "thumbnail_unavailable" });
+    expect(requests.length).toBe(0);
+    expect(await readdir(escape)).toEqual([]);
+  });
+});
+
+describe("project thumbnail route", () => {
+  test("Given a thumbnail request When the server classifies it Then the home route owns it", () => {
+    expect(
+      classifyApiRoute("/api/projects/project-1/thumbnail", "GET"),
+    ).toBe("home");
+  });
+
+  test("Given a cached thumbnail When requested Then PNG bytes ship with a quoted ETag and private no-cache", async () => {
+    const project = await createProject({ digest: digestA });
+    const { renderer } = recordingRenderer();
+    const cached = await loadProjectThumbnail(project.id, renderer);
+
+    const response = await request(`/api/projects/${project.id}/thumbnail`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect(response.headers.get("cache-control")).toBe("private, no-cache");
+    if (cached.kind !== "ready") throw new Error("expected a ready thumbnail");
+    expect(response.headers.get("etag")).toBe(cached.etag);
+    expect(response.headers.get("etag")).toMatch(/^"[0-9a-f]{64}"$/);
+    expect(parsePng(new Uint8Array(await response.arrayBuffer()))).toEqual({ width: 640, height: 360 });
+  });
+
+  test("Given a matching If-None-Match When requested Then the route answers 304 with no body", async () => {
+    const project = await createProject({ digest: digestA });
+    const { renderer } = recordingRenderer();
+    const cached = await loadProjectThumbnail(project.id, renderer);
+    if (cached.kind !== "ready") throw new Error("expected a ready thumbnail");
+
+    const response = await request(`/api/projects/${project.id}/thumbnail`, { "if-none-match": cached.etag });
+
+    expect(response.status).toBe(304);
+    expect(response.headers.get("etag")).toBe(cached.etag);
+    expect((await response.arrayBuffer()).byteLength).toBe(0);
+  });
+
+  test("Given a stale If-None-Match When requested Then the current PNG is returned", async () => {
+    const project = await createProject({ digest: digestA });
+    const { renderer } = recordingRenderer();
+    await loadProjectThumbnail(project.id, renderer);
+
+    const response = await request(`/api/projects/${project.id}/thumbnail`, { "if-none-match": `"${"c".repeat(64)}"` });
+
+    expect(response.status).toBe(200);
+  });
+
+  test("Given an unknown project a digest-less project or a boundary escape When requested Then typed errors are returned", async () => {
+    const withoutDigest = await createProject({ digest: null });
+    const outside = await mkdtemp(path.join(tmpdir(), "bg-thumb-route-outside-"));
+    tempDirs.push(outside);
+    const escaped = await createProject({ digest: digestA, dirPath: outside });
+
+    const missing = await request("/api/projects/does-not-exist/thumbnail");
+    const noDigest = await request(`/api/projects/${withoutDigest.id}/thumbnail`);
+    const unavailable = await request(`/api/projects/${escaped.id}/thumbnail`);
+
+    expect([missing.status, noDigest.status, unavailable.status]).toEqual([404, 409, 503]);
+    expect(await missing.json()).toEqual({ error: { code: "project_not_found", message: expect.any(String), details: { id: "does-not-exist" } } });
+    expect((await noDigest.json()).error.code).toBe("artifact_unavailable");
+    expect((await unavailable.json()).error.code).toBe("thumbnail_unavailable");
+  });
+});

--- a/packages/backend/tests/project-thumbnails.test.ts
+++ b/packages/backend/tests/project-thumbnails.test.ts
@@ -21,6 +21,7 @@ import {
 
 const digestA = "a".repeat(64);
 const digestB = "b".repeat(64);
+const PROJECT_TIMESTAMP = Number.MAX_SAFE_INTEGER;
 const projectIds: string[] = [];
 const tempDirs: string[] = [];
 let sequence = 0;
@@ -62,9 +63,18 @@ async function createProject(options: {
   getSqlite()
     .prepare(
       `INSERT INTO projects(id,name,type,dir_path,entrypoint,backend_id,created_at,updated_at,current_revision,current_digest)
-       VALUES (?,?,?,?,'index.html','codex',1,1,?,?)`,
+       VALUES (?,?,?,?,'index.html','codex',?,?,?,?)`,
     )
-    .run(id, id, options.type ?? "prototype", dirPath, options.revision ?? 3, options.digest);
+    .run(
+      id,
+      id,
+      options.type ?? "prototype",
+      dirPath,
+      PROJECT_TIMESTAMP,
+      PROJECT_TIMESTAMP,
+      options.revision ?? 3,
+      options.digest,
+    );
   projectIds.push(id);
   if (options.dirPath === undefined) tempDirs.push(dirPath);
   return { id, dirPath };

--- a/packages/backend/tests/prompt-builder.test.ts
+++ b/packages/backend/tests/prompt-builder.test.ts
@@ -37,6 +37,30 @@ function makeContext(
 }
 
 describe("buildPrompt", () => {
+  test("includes only the selected ready design direction", async () => {
+    const base = {
+      schema_version: 1, project_id: "p1", session_id: "s1", generation_id: "g1", status: "ready",
+      content_outline: ["outline-input-a", "outline-input-b"], selection_revision: 1, selection_history: [null], error: null, updated_at: 1,
+      directions: [
+        { id: "editorial", order: 0, layout_key: "editorial", title: "selected-input-title", summary: "selected-summary", style_facts: ["selected-input-fact"], status: "ready", preview_url: "/a", error: null },
+        { id: "modular", order: 1, layout_key: "modular", title: "unselected-input-title-b", summary: "other", style_facts: ["unselected-input-fact-b"], status: "ready", preview_url: "/b", error: null },
+        { id: "narrative", order: 2, layout_key: "narrative", title: "unselected-input-title-c", summary: "other", style_facts: ["unselected-input-fact-c"], status: "ready", preview_url: "/c", error: null },
+      ],
+      selected_id: "editorial",
+    } as const;
+    const selected = await buildPrompt(makeContext({}, { designDirectionState: base }), { type: "user.message", text: "continue" });
+    const beforeSelection = await buildPrompt(makeContext({}, { designDirectionState: { ...base, selected_id: null, selection_revision: 0, selection_history: [] } }), { type: "user.message", text: "continue" });
+
+    expect(selected).toContain("## Selected design direction");
+    expect(selected).toContain("outline-input-a");
+    expect(selected).toContain("selected-input-title");
+    expect(selected).toContain("editorial");
+    expect(selected).toContain("selected-input-fact");
+    expect(selected).not.toContain("unselected-input-title-b");
+    expect(selected).not.toContain("unselected-input-fact-c");
+    expect(beforeSelection).not.toContain("## Selected design direction");
+  });
+
   test("emits project + delivery + request sections for prototype", async () => {
     const prompt = await buildPrompt(makeContext(), {
       type: "user.message",

--- a/packages/backend/tests/prompt-builder.test.ts
+++ b/packages/backend/tests/prompt-builder.test.ts
@@ -370,15 +370,15 @@ header { padding: var(--space-md); }
     expect(prompt).not.toContain("## Attachments");
   });
 
-  test("lists attachments verbatim", async () => {
+  test("does not echo unmatched raw attachment paths", async () => {
     const prompt = await buildPrompt(makeContext(), {
       type: "user.message",
       text: "see files",
       attachments: ["/tmp/a.png", "/tmp/b.png"],
     });
     expect(prompt).toContain("## Attachments");
-    expect(prompt).toContain("- /tmp/a.png");
-    expect(prompt).toContain("- /tmp/b.png");
+    expect(prompt).not.toContain("/tmp/a.png");
+    expect(prompt).not.toContain("/tmp/b.png");
   });
 
   test("inlines compact summaries for pptx/pdf attachments and points Read to extracted text", async () => {
@@ -422,7 +422,7 @@ header { padding: var(--space-md); }
       );
 
       const prompt = await buildPrompt(
-        makeContext({}, {
+        makeContext({ project_dir: tempDir }, {
           attachments: [
             {
               id: "a1",
@@ -434,6 +434,8 @@ header { padding: var(--space-md); }
               original_name: "deck.pptx",
               size_bytes: 1024,
               sha256: null,
+              source_role: "ordinary_content",
+              source_role_explicit: false,
               created_at: Date.now(),
             },
           ],
@@ -446,10 +448,10 @@ header { padding: var(--space-md); }
       );
 
       expect(prompt).toContain(
-        `source_path: ${filePath} (binary attachment; do not Read/Glob/Bash this file directly)`,
+        "source_path: deck.pptx (binary attachment; do not Read/Glob/Bash this file directly)",
       );
       expect(prompt).toContain(
-        `extracted_text_path: ${attachmentExtractedTextPath(filePath)} (safe text version for Read)`,
+        "extracted_text_path: deck.pptx.extracted.md (safe text version for Read)",
       );
       expect(prompt).toContain(
         "summary: PPTX | 3 page(s) | brand=Quarterly Review",

--- a/packages/backend/tests/reference-layout-prompt.test.ts
+++ b/packages/backend/tests/reference-layout-prompt.test.ts
@@ -27,6 +27,8 @@ function attachment(
     original_name: originalName,
     size_bytes: 1024,
     sha256: "a".repeat(64),
+    source_role: "ordinary_content",
+    source_role_explicit: false,
     created_at: 1,
   };
 }
@@ -251,7 +253,21 @@ describe("reference layout prompt context", () => {
     ).toBe(false);
   });
 
-  test("Given a selected drawing filename When request text is generic Then the layout contract still activates", async () => {
+  test("Given an explicitly ordinary floor-plan attachment When request is generic Then filename heuristic is suppressed", async () => {
+    const filePath = "/tmp/floor-plan.pdf";
+    const ordinary = { ...attachment(filePath, "application/pdf", "floor-plan.pdf"), source_role_explicit: true };
+    const prompt = await buildPrompt(context([ordinary]), { type: "user.message", text: "Use the attached file", attachments: [filePath] });
+    expect(prompt).not.toContain("<burnguard-reference-layout-v1>");
+  });
+
+  test("Given a persisted immutable deck When request is generic Then reference layout activates without filename inference", async () => {
+    const filePath = "/tmp/deck.pptx";
+    const immutable = { ...attachment(filePath, "application/vnd.openxmlformats-officedocument.presentationml.presentation", "deck.pptx"), source_role: "immutable_reference" as const, source_role_explicit: true };
+    const prompt = await buildPrompt(context([immutable]), { type: "user.message", text: "Use the attached file", attachments: [filePath] });
+    expect(nested(taggedJson(prompt), "reference")["role"]).toBe("immutable_underlay");
+  });
+
+  test("Given a selected legacy drawing filename When request text is generic Then the layout contract still activates", async () => {
     const filePath = "/tmp/floor-plan.svg";
     const prompt = await buildPrompt(
       context([attachment(filePath, "image/svg+xml", "floor-plan.svg")]),

--- a/packages/backend/tests/serve-path-boundary.test.ts
+++ b/packages/backend/tests/serve-path-boundary.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
+import { PDFDocument } from "pdf-lib";
 import { watch } from "node:fs";
 import {
   mkdir,
@@ -123,6 +124,12 @@ function insertExport(projectId: string, outputPath: string): string {
 
 async function makeDirLink(target: string, link: string): Promise<void> {
   await symlink(target, link, process.platform === "win32" ? "junction" : "dir");
+}
+
+async function pdfFixture(name: string): Promise<File> {
+  const document = await PDFDocument.create();
+  document.addPage([200, 100]);
+  return new File([await document.save()], name, { type: "application/pdf" });
 }
 
 beforeAll(async () => {
@@ -460,11 +467,12 @@ describe("attachments service", () => {
     const projectId = insertProject(root);
     const sessionId = insertSession(projectId);
 
-    const records = await saveSessionAttachments(sessionId, [new File(["content"], "note.txt", { type: "text/plain" })]);
+    const fixture = await pdfFixture("note.pdf");
+    const records = await saveSessionAttachments(sessionId, [fixture]);
 
     expect(records).toHaveLength(1);
-    expect(await readFile(records[0] ?? "", "utf8")).toBe("content");
-    expect(getSqlite().query("SELECT original_name,size_bytes FROM attachments WHERE session_id=?").get(sessionId)).toEqual({ original_name: "note.txt", size_bytes: 7 });
+    expect((await readFile(records[0] ?? "")).byteLength).toBe(fixture.size);
+    expect(getSqlite().query("SELECT original_name,size_bytes FROM attachments WHERE session_id=?").get(sessionId)).toEqual({ original_name: "note.pdf", size_bytes: fixture.size });
   });
 
   test("rejects a symlinked .attachments directory before writing any upload", async () => {
@@ -475,7 +483,7 @@ describe("attachments service", () => {
     const sessionId = insertSession(projectId);
 
     await expect(
-      saveSessionAttachments(sessionId, [new File(["secret"], "../../secret.txt", { type: "text/plain" })]),
+      saveSessionAttachments(sessionId, [await pdfFixture("../../secret.pdf")]),
     ).rejects.toBeInstanceOf(PathBoundaryError);
     expect(await readdir(outside)).toEqual([]);
   });

--- a/packages/backend/tests/session-recovery.test.ts
+++ b/packages/backend/tests/session-recovery.test.ts
@@ -119,6 +119,11 @@ describe("sequence replay", () => {
       { id: "tf", ts: 1, type: "tool.finished", turnId: "t", toolCallId: "c", tool: "Bash", ok: true, output: {} },
       { id: "tp", ts: 1, type: "tool.permission_required", turnId: "t", toolCallId: "c", tool: "Bash", input: {} },
       { id: "a", ts: 1, type: "artifact.operation", operationId: "o", revision: 1, digest: "d", changedPaths: ["index.html"], outcome: "committed" },
+      { id: "dd", ts: 1, type: "design.direction_state", state: { schema_version: 1, project_id: "p", session_id: "s", generation_id: "g", status: "loading", content_outline: ["outline"], directions: [
+        { id: "editorial", order: 0, layout_key: "editorial", title: "a", summary: "a", style_facts: ["a"], status: "pending", preview_url: null, error: null },
+        { id: "modular", order: 1, layout_key: "modular", title: "b", summary: "b", style_facts: ["b"], status: "pending", preview_url: null, error: null },
+        { id: "narrative", order: 2, layout_key: "narrative", title: "c", summary: "c", style_facts: ["c"], status: "pending", preview_url: null, error: null },
+      ], selected_id: null, selection_revision: 0, selection_history: [], error: null, updated_at: 1 } },
       { id: "f", ts: 1, type: "file.changed", turnId: "t", action: "edited", path: "index.html" },
       { id: "r", ts: 1, type: "status.running" },
       { id: "i", ts: 1, type: "status.idle", stopReason: "end_turn" },

--- a/packages/backend/tests/stage-attachment-inputs.test.ts
+++ b/packages/backend/tests/stage-attachment-inputs.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rename, rm, symlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { inspectCanonicalTree } from "../src/services/canonical-tree-manifest";
+import { materializeManagedTree } from "../src/services/artifact-tree-storage";
+import { redactPrivateAttachmentPaths, withPrivateAttachmentInputs, type StageAttachment } from "../src/services/stage-attachment-inputs";
+
+const roots: string[] = [];
+afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true }))));
+
+async function fixture(): Promise<{ readonly project: string; readonly operation: string; readonly stage: string; readonly attachments: readonly StageAttachment[] }> {
+  const project = await mkdtemp(path.join(tmpdir(), "burnguard-input-project-"));
+  const operation = await mkdtemp(path.join(tmpdir(), "burnguard-operation-"));
+  const stage = path.join(operation, "stage");
+  roots.push(project, operation);
+  await mkdir(path.join(project, ".attachments"));
+  await writeFile(path.join(project, "index.html"), "base");
+  const attachments: StageAttachment[] = [];
+  for (const [id, content] of [["attachment-a", "first"], ["attachment-b", "second"]] as const) {
+    const filePath = path.join(project, ".attachments", `${id}.pdf`);
+    await writeFile(filePath, content);
+    await writeFile(`${filePath}.extracted.md`, `text:${content}`);
+    attachments.push({ id, file_path: filePath, original_name: "duplicate.pdf", size_bytes: content.length, sha256: createHash("sha256").update(content).digest("hex"), source_role: "ordinary_content" });
+  }
+  await materializeManagedTree(project, stage);
+  return { project, operation, stage, attachments };
+}
+
+describe("private attachment inputs", () => {
+  test("Given duplicate attachments When materialized Then absolute private paths are stable only for the callback and never enter authored stage", async () => {
+    const input = await fixture();
+    const captured: string[] = [];
+    await withPrivateAttachmentInputs({ operationDir: input.operation, projectDir: input.project, attachments: input.attachments, requestedPaths: input.attachments.map((item) => item.file_path), immutableSnapshots: [] }, async (sources) => {
+      expect(sources).toHaveLength(2);
+      expect(new Set(sources.map((source) => source.sourcePath)).size).toBe(2);
+      for (const source of sources) {
+        expect(path.isAbsolute(source.sourcePath)).toBe(true);
+        expect(path.relative(input.operation, source.sourcePath).startsWith("inputs-")).toBe(true);
+        expect(await readFile(source.sourcePath, "utf8")).toMatch(/first|second/u);
+        expect(await readFile(source.extractedTextPath ?? "missing", "utf8")).toMatch(/^text:/u);
+        const event = redactPrivateAttachmentPaths({ type: "tool.started", input: { file_path: source.sourcePath, command: `Read ${source.extractedTextPath}` } }, sources);
+        expect(JSON.stringify(event)).not.toContain(input.operation);
+        expect(JSON.stringify(event)).toContain(`.attachments/${path.basename(source.attachmentPath)}`);
+        captured.push(source.sourcePath);
+      }
+      expect((await inspectCanonicalTree(input.stage)).files.map((file) => file.path)).toEqual(["index.html"]);
+    });
+    for (const source of captured) await expect(readFile(source)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("Given private paths in nested tool-event keys and values When redacted Then shape survives with deterministic collision-free bounded keys", async () => {
+    const input = await fixture();
+    await withPrivateAttachmentInputs({ operationDir: input.operation, projectDir: input.project, attachments: input.attachments, requestedPaths: input.attachments.map((item) => item.file_path), immutableSnapshots: [] }, async (sources) => {
+      const first = sources[0];
+      const second = sources[1];
+      if (first === undefined || second === undefined) throw new Error("fixture_source_missing");
+      const privateRoot = path.dirname(first.sourcePath);
+      const event = {
+        type: "tool.started",
+        input: [{
+          "[private-input-path]": "existing",
+          [first.sourcePath]: { [`prefix:${privateRoot}:suffix`]: [first.sourcePath, { [second.sourcePath]: second.extractedTextPath }] },
+          [second.sourcePath]: privateRoot,
+        }],
+      };
+
+      const redacted = redactPrivateAttachmentPaths(event, sources);
+      const serialized = JSON.stringify(redacted);
+      const redactedInput = redacted.input[0];
+      if (redactedInput === undefined) throw new Error("redacted_input_missing");
+      expect(serialized).not.toContain(input.operation);
+      expect(serialized).not.toContain(privateRoot);
+      expect(Object.keys(redactedInput)).toHaveLength(3);
+      expect(Object.keys(redactedInput)).toEqual(["[private-input-path]", "[private-input-path:2]", "[private-input-path:3]"]);
+      const nested = redactedInput["[private-input-path:2]"];
+      expect(nested).toBeObject();
+      expect(Object.keys(nested as object)).toEqual(["[private-input-path]"]);
+      expect(serialized).toContain(`.attachments/${path.basename(first.attachmentPath)}`);
+    });
+  });
+
+  test("Given source or extracted sidecar path swap after open When materialized Then the already-open descriptor supplies the snapshot without touching outside", async () => {
+    for (const kind of ["source", "extracted"] as const) {
+      const input = await fixture();
+      const original = kind === "source" ? input.attachments[0]?.file_path ?? "missing" : `${input.attachments[0]?.file_path}.extracted.md`;
+      const displaced = `${original}.captured`;
+      const outside = path.join(input.project, `${kind}-outside`);
+      await writeFile(outside, kind === "source" ? "first" : new Uint8Array(5 * 1024 * 1024 + 1));
+      try {
+        await expect(withPrivateAttachmentInputs({ operationDir: input.operation, projectDir: input.project, attachments: input.attachments, requestedPaths: [input.attachments[0]?.file_path ?? "missing"], immutableSnapshots: [], hooks: { afterOpen: async (openedKind) => {
+          if (openedKind !== kind) return;
+          await rename(original, displaced);
+          await symlink(outside, original);
+        } } }, async (sources) => {
+          expect(await readFile(sources[0]?.sourcePath ?? "missing", "utf8")).toBe("first");
+          expect(await readFile(sources[0]?.extractedTextPath ?? "missing", "utf8")).toBe("text:first");
+        })).resolves.toBeUndefined();
+        expect((await readFile(outside)).byteLength).toBe(kind === "source" ? 5 : 5 * 1024 * 1024 + 1);
+      } finally {
+        await rm(original, { force: true });
+        await rename(displaced, original).catch(() => undefined);
+      }
+    }
+  });
+
+  test("Given adapter failure When inputs unwind Then the entire private directory is removed", async () => {
+    const input = await fixture();
+    let source = "";
+    await expect(withPrivateAttachmentInputs({ operationDir: input.operation, projectDir: input.project, attachments: input.attachments, requestedPaths: [input.attachments[0]?.file_path ?? "missing"], immutableSnapshots: [] }, async (sources) => { source = sources[0]?.sourcePath ?? ""; throw new Error("adapter_failed"); })).rejects.toThrow("adapter_failed");
+    await expect(readFile(source)).rejects.toMatchObject({ code: "ENOENT" });
+    expect((await inspectCanonicalTree(input.stage)).files.map((file) => file.path)).toEqual(["index.html"]);
+  });
+});

--- a/packages/backend/tests/turn-error-sanitizer.test.ts
+++ b/packages/backend/tests/turn-error-sanitizer.test.ts
@@ -1,0 +1,66 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { getSqlite } from "../src/db/sqlite-client";
+import { runMigrations } from "../src/db/migrate-local";
+import { broker, sequencedBroker } from "../src/services/broker";
+import { persistAndPublish } from "../src/services/turns";
+import { PathBoundaryError } from "../src/security/path-boundary";
+
+beforeAll(async () => {
+  await runMigrations();
+  const db = getSqlite();
+  db.prepare("INSERT OR IGNORE INTO projects(id,name,type,dir_path,entrypoint,backend_id,created_at,updated_at) VALUES ('turn-error-project','P','prototype','/tmp/project','index.html','codex',1,1)").run();
+  db.prepare("INSERT OR IGNORE INTO sessions(id,project_id,backend_id,status,created_at,updated_at,last_active_at) VALUES ('turn-error-session','turn-error-project','codex','idle',1,1,1)").run();
+});
+
+beforeEach(() => {
+  getSqlite().prepare("DELETE FROM events WHERE session_id='turn-error-session'").run();
+});
+
+describe("turn error event boundary", () => {
+  test("Given parent symlink PathBoundaryError When persisted and published Then DB SSE and replay contain only typed bounded Korean copy", async () => {
+    const raw = "/private/Users/alice/project/.attachments/source.pdf escaped root";
+    const observed: unknown[] = [];
+    const sequenced: unknown[] = [];
+    const unsubscribe = broker.subscribe("turn-error-session", (event) => { observed.push(event); });
+    const unsubscribeSequenced = sequencedBroker.subscribe("turn-error-session", (event) => { sequenced.push(event); });
+    try {
+      await persistAndPublish("turn-error-session", { id: "path-error", ts: 2, type: "status.error", message: raw, recoverable: true }, new PathBoundaryError("outside_root", raw));
+    } finally {
+      unsubscribe();
+      unsubscribeSequenced();
+    }
+    const row = getSqlite().query<{ readonly payload_json: string }, []>("SELECT payload_json FROM events WHERE id='path-error'").get();
+    const combined = JSON.stringify({ row, observed, sequenced });
+    expect(combined).not.toContain("/private/");
+    expect(combined).not.toContain("source.pdf");
+    expect(combined).toContain("path_unavailable");
+    expect(combined).toContain("프로젝트 파일에 안전하게 접근할 수 없어요");
+  });
+
+  test("Given arbitrary POSIX Windows multiline and stack error When crossing boundary Then generic bounded copy replaces all diagnostics", async () => {
+    const raw = "failed /private/a C:\\Users\\alice\\secret\nError: boom\n at internal (/srv/app.ts:4)";
+    await persistAndPublish("turn-error-session", { id: "unknown-error", ts: 3, type: "status.error", message: raw, recoverable: true }, new Error(raw));
+    const payload = getSqlite().query<{ readonly payload_json: string }, []>("SELECT payload_json FROM events WHERE id='unknown-error'").get()?.payload_json ?? "";
+    expect(payload).not.toContain("/private/");
+    expect(payload).not.toContain("C:\\\\Users");
+    expect(payload).not.toContain("internal");
+    expect(payload).toContain("turn_failed");
+    expect(payload).toContain("요청을 처리하지 못했어요");
+    expect(payload.length).toBeLessThan(300);
+  });
+
+  test("Given ordinary user cancellation When crossing boundary Then interrupted idle semantics remain unchanged", async () => {
+    await persistAndPublish("turn-error-session", { id: "cancelled", ts: 4, type: "status.idle", stopReason: "interrupted" });
+    expect(getSqlite().query<{ readonly payload_json: string }, []>("SELECT payload_json FROM events WHERE id='cancelled'").get()?.payload_json).toContain('"stopReason":"interrupted"');
+    expect(getSqlite().query<{ readonly count: number }, []>("SELECT COUNT(*) count FROM events WHERE session_id='turn-error-session' AND type='status.error'").get()?.count).toBe(0);
+  });
+
+  test("Given an allowlisted immutable failure When crossing boundary Then its stable code and Korean copy survive", async () => {
+    const error = Object.assign(new Error("raw /private/source.pdf"), { code: "immutable_reference_escaped" });
+    await persistAndPublish("turn-error-session", { id: "known-error", ts: 4, type: "status.error", message: error.message, recoverable: true }, error);
+    const payload = getSqlite().query<{ readonly payload_json: string }, []>("SELECT payload_json FROM events WHERE id='known-error'").get()?.payload_json ?? "";
+    expect(payload).toContain("immutable_reference_escaped");
+    expect(payload).toContain("읽기 전용 참조 파일은 결과물에 복사할 수 없어요");
+    expect(payload).not.toContain("/private/");
+  });
+});

--- a/packages/backend/tests/visual-source-migration.test.ts
+++ b/packages/backend/tests/visual-source-migration.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { cp, mkdtemp, readdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { runMigrationsFrom } from "../src/db/migrate";
+
+const roots: string[] = [];
+const databases: Database[] = [];
+
+async function migrationsThrough(last: string): Promise<string> {
+  const target = await mkdtemp(path.join(tmpdir(), "burnguard-visual-source-migration-"));
+  roots.push(target);
+  const source = path.join(import.meta.dir, "../src/db/migrations");
+  for (const name of (await readdir(source)).filter((entry) => entry <= last)) {
+    await cp(path.join(source, name), path.join(target, name));
+  }
+  return target;
+}
+
+afterEach(async () => {
+  for (const db of databases.splice(0)) db.close();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("visual source role migration", () => {
+  test("Given a legacy attachment When visual-source migrations run Then ordinary inferred role is durably backfilled and constrained", async () => {
+    const db = new Database(":memory:");
+    databases.push(db);
+    const before = await migrationsThrough("0011_graphic_project_type.sql");
+    await runMigrationsFrom(db, before);
+    db.exec("INSERT INTO projects(id,name,type,dir_path,backend_id,created_at,updated_at) VALUES ('p','P','prototype','/tmp/p','codex',1,1); INSERT INTO sessions(id,project_id,backend_id,status,created_at,updated_at,last_active_at) VALUES ('s','p','codex','idle',1,1,1); INSERT INTO attachments(id,session_id,file_path,mime_type,original_name,size_bytes,sha256,created_at) VALUES ('a','s','/tmp/p/.attachments/a.pdf','application/pdf','a.pdf',1,NULL,1)");
+    const after = await migrationsThrough("0013_visual_source_role_origin.sql");
+
+    await runMigrationsFrom(db, after);
+
+    expect(db.query("SELECT source_role,source_role_explicit FROM attachments WHERE id='a'").get()).toEqual({ source_role: "ordinary_content", source_role_explicit: 0 });
+    expect(() => db.exec("UPDATE attachments SET source_role='url' WHERE id='a'")).toThrow();
+    expect(db.query("SELECT name,\"notnull\" required,dflt_value defaultValue FROM pragma_table_info('attachments') WHERE name='source_role'").get()).toEqual({ name: "source_role", required: 1, defaultValue: "'ordinary_content'" });
+  });
+});

--- a/packages/backend/tests/visual-source-policy.test.ts
+++ b/packages/backend/tests/visual-source-policy.test.ts
@@ -1,0 +1,236 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { getSqlite } from "../src/db/sqlite-client";
+import { buildPrompt } from "../src/harness/prompt-builder";
+import { parsePersistedNormalizedEvent, parsePersistedUserEvent } from "../src/db/event-sequence-repository";
+import { parseVisualSourceUploadRequest } from "@bg/shared";
+import { ensureLearningSchema } from "./learning-fixture";
+import { buildVisualSourceManifest } from "../src/services/visual-source-manifest";
+
+type BuildContext = Parameters<typeof buildPrompt>[0];
+type Attachment = BuildContext["attachments"][number];
+
+let root = "";
+let filePath = "";
+let digest = "";
+
+beforeAll(async () => {
+  ensureLearningSchema(getSqlite());
+  root = await mkdtemp(path.join(tmpdir(), "burnguard-visual-source-policy-"));
+  await mkdir(path.join(root, ".attachments"));
+  filePath = path.join(root, ".attachments", "deck.pdf");
+  const bytes = new TextEncoder().encode("visual-source");
+  digest = createHash("sha256").update(bytes).digest("hex");
+  await writeFile(filePath, bytes);
+});
+
+afterAll(async () => rm(root, { recursive: true, force: true }));
+
+function context(attachment: Attachment): BuildContext {
+  return {
+    project: {
+      project_id: "visual-project",
+      project_name: "Visual sources",
+      project_type: "other",
+      project_dir: root,
+      entrypoint: "index.html",
+      options_json: null,
+      current_revision: 0,
+      current_digest: null,
+    },
+    designSystem: null,
+    files: [],
+    attachments: [attachment],
+    openComments: [],
+  };
+}
+
+function source(role: "ordinary_content" | "immutable_reference"): Attachment {
+  return {
+    id: "attachment-1",
+    session_id: "session-1",
+    turn_id: "turn-1",
+    file_path: filePath,
+    mime_type: "application/pdf",
+    original_name: "deck.pdf",
+    size_bytes: 13,
+    sha256: digest,
+    source_role: role,
+    source_role_explicit: true,
+    created_at: 1,
+  };
+}
+
+function manifest(prompt: string): Readonly<Record<string, unknown>> {
+  const match = prompt.match(/<burnguard-visual-sources-v1>\n([^\n]+)\n<\/burnguard-visual-sources-v1>/u);
+  expect(match).not.toBeNull();
+  return JSON.parse(match?.[1] ?? "{}") as Readonly<Record<string, unknown>>;
+}
+
+describe("visual source upload boundary", () => {
+  test("Given omitted metadata When parsed Then every upload defaults to ordinary content", () => {
+    expect(parseVisualSourceUploadRequest(undefined, 2)).toEqual({
+      schema_version: 1,
+      explicit: false,
+      sources: [
+        { source_type: "upload", upload_id: "upload-0", file_index: 0, role: "ordinary_content" },
+        { source_type: "upload", upload_id: "upload-1", file_index: 1, role: "ordinary_content" },
+      ],
+    });
+  });
+
+  test("Given an explicit immutable role When parsed Then its file index remains typed", () => {
+    expect(parseVisualSourceUploadRequest(JSON.stringify({
+      schema_version: 1,
+      sources: [{ source_type: "upload", upload_id: "deck", file_index: 0, role: "immutable_reference" }],
+    }), 1)).toEqual({
+      schema_version: 1,
+      explicit: true,
+      sources: [{ source_type: "upload", upload_id: "deck", file_index: 0, role: "immutable_reference" }],
+    });
+  });
+
+  test("Given URL web or stock metadata When parsed Then the unsupported source is rejected", () => {
+    for (const sourceType of ["url", "web", "stock"]) {
+      expect(() => parseVisualSourceUploadRequest(JSON.stringify({
+        schema_version: 1,
+        sources: [{ source_type: sourceType, url: "https://example.test/image" }],
+      }), 1)).toThrow("unsupported_visual_source");
+    }
+  });
+
+  test("Given duplicate missing or path-shaped upload metadata When parsed Then it fails closed", () => {
+    const invalid = [
+      { schema_version: 1, sources: [] },
+      { schema_version: 1, sources: [{ source_type: "upload", upload_id: "same", file_index: 0, role: "ordinary_content" }, { source_type: "upload", upload_id: "same", file_index: 0, role: "immutable_reference" }] },
+      { schema_version: 1, sources: [{ source_type: "upload", upload_id: "deck", file_index: 0, role: "ordinary_content", path: "../../escape.pdf" }] },
+    ];
+    for (const value of invalid) {
+      expect(() => parseVisualSourceUploadRequest(JSON.stringify(value), 1)).toThrow("invalid_visual_sources");
+    }
+  });
+});
+
+describe("visual source persistence and prompt", () => {
+  test("Given persisted source selection When replayed Then role and attachment provenance survive", () => {
+    const event = parsePersistedUserEvent(JSON.stringify({
+      type: "user.message",
+      text: "use it",
+      attachments: [filePath],
+      visualSources: [{ source_type: "uploaded_attachment", attachment_path: filePath, role: "immutable_reference" }],
+    }), "event-1");
+
+    expect(event).toMatchObject({
+      visualSources: [{ source_type: "uploaded_attachment", role: "immutable_reference" }],
+    });
+  });
+
+  test("Given a normalized user message manifest When replayed Then immutable provenance remains machine-readable", () => {
+    const visualSources = {
+      schema_version: 1,
+      network_sources: "unsupported",
+      sources: [{
+        source_type: "uploaded_attachment",
+        role: "immutable_reference",
+        attachment_id: "attachment-1",
+        original_name: "deck.pdf",
+        mime_type: "application/pdf",
+        size_bytes: 13,
+        preflight_verified_sha256: digest,
+        managed_path: ".attachments/deck.pdf",
+        role_origin: "explicit",
+        provenance: { session_id: "session-1", turn_id: "turn-1", storage: "managed_attachment" },
+        policy: { original_file: "preserve", original_hash: "preserve", never_overwrite: true, never_copy_into_authored_output: true, derived_artifact: "separate" },
+      }],
+    };
+
+    const event = parsePersistedNormalizedEvent(JSON.stringify({ id: "down-1", ts: 1, type: "chat.user_message", turnId: "turn-1", text: "use it", attachmentCount: 1, visualSources }), "down-1");
+
+    expect(event).toMatchObject({ type: "chat.user_message", visualSources });
+    expect(JSON.stringify(event)).not.toContain(root);
+    expect(JSON.stringify(event)).not.toContain(".burnguard-inputs");
+  });
+
+  test("Given a prebuilt turn manifest and private input When prompting Then agent-only absolute snapshot path is used without a second source read", async () => {
+    const attachment = source("immutable_reference");
+    const selection = [{ source_type: "uploaded_attachment" as const, attachment_path: filePath, role: "immutable_reference" as const }];
+    const built = await buildVisualSourceManifest({ projectDir: root, attachments: [attachment], requestedPaths: [filePath], selections: selection });
+    const moved = `${filePath}.moved`;
+    await rename(filePath, moved);
+    try {
+      const stagePath = path.join(root, ".meta", "artifact-operations", "operation-1", "inputs-private", "attachment-1-deck.pdf");
+      const prompt = await buildPrompt(context(attachment), { type: "user.message", text: "use", attachments: [filePath], visualSources: selection }, { visualSourceManifest: built, stageAttachmentInputs: [{ attachmentId: attachment.id, attachmentPath: filePath, sourcePath: stagePath, extractedTextPath: null, immutable: true, sourceSha256: digest, sourceSize: 13 }] });
+      expect(manifest(prompt)["sources"]).toEqual([expect.objectContaining({ managed_path: stagePath })]);
+      expect(prompt).toContain(stagePath);
+      expect(prompt).not.toContain(filePath);
+      expect(prompt).not.toContain(`${root}/.attachments`);
+      expect(JSON.stringify(built)).not.toContain(stagePath);
+    } finally {
+      await rename(moved, filePath);
+    }
+  });
+
+  test("Given ordinary content When prompting Then existing attachment behavior remains and no immutable policy is asserted", async () => {
+    const prompt = await buildPrompt(context(source("ordinary_content")), {
+      type: "user.message",
+      text: "summarize",
+      attachments: [filePath],
+      visualSources: [{ source_type: "uploaded_attachment", attachment_path: filePath, role: "ordinary_content" }],
+    });
+
+    const block = manifest(prompt);
+    expect(block["sources"]).toEqual([expect.objectContaining({ role: "ordinary_content", preflight_verified_sha256: digest })]);
+    expect(JSON.stringify(block)).not.toContain("never_overwrite");
+    expect(prompt).not.toContain("<burnguard-reference-layout-v1>");
+  });
+
+  test("Given an immutable uploaded reference When prompting Then original identity provenance and separation policy are closed", async () => {
+    const prompt = await buildPrompt(context(source("immutable_reference")), {
+      type: "user.message",
+      text: "use this reference",
+      attachments: [filePath],
+      visualSources: [{ source_type: "uploaded_attachment", attachment_path: filePath, role: "immutable_reference" }],
+    });
+
+    expect(prompt).toContain("<burnguard-reference-layout-v1>");
+    expect(manifest(prompt)).toEqual({
+      schema_version: 1,
+      network_sources: "unsupported",
+      sources: [{
+        source_type: "uploaded_attachment",
+        role: "immutable_reference",
+        attachment_id: "attachment-1",
+        original_name: "deck.pdf",
+        mime_type: "application/pdf",
+        size_bytes: 13,
+        preflight_verified_sha256: digest,
+        managed_path: ".attachments/deck.pdf",
+        role_origin: "explicit",
+        provenance: { session_id: "session-1", turn_id: "turn-1", storage: "managed_attachment" },
+        policy: {
+          original_file: "preserve",
+          original_hash: "preserve",
+          never_overwrite: true,
+          never_copy_into_authored_output: true,
+          derived_artifact: "separate",
+        },
+      }],
+    });
+  });
+
+  test("Given a selected attachment outside managed storage or with invalid hash provenance When prompting Then it is rejected", async () => {
+    const escaped = { ...source("immutable_reference"), file_path: "/tmp/escape.pdf" };
+    const badHash = { ...source("immutable_reference"), sha256: "not-a-sha" };
+    for (const attachment of [escaped, badHash]) {
+      await expect(buildPrompt(context(attachment), {
+        type: "user.message",
+        text: "use it",
+        attachments: [attachment.file_path],
+        visualSources: [{ source_type: "uploaded_attachment", attachment_path: attachment.file_path, role: "immutable_reference" }],
+      })).rejects.toThrow("invalid_visual_source_provenance");
+    }
+  });
+});

--- a/packages/backend/tests/visual-source-security.test.ts
+++ b/packages/backend/tests/visual-source-security.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { copyFile, mkdir, mkdtemp, readFile, rename, rm, symlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { getSqlite } from "../src/db/sqlite-client";
+import { runMigrations } from "../src/db/migrate-local";
+import { insertAttachmentRecord } from "../src/db/attachment-context";
+import { canonicalizeAttachmentRequest } from "../src/services/attachment-request";
+import { captureImmutableAttachments, verifyImmutableAttachments } from "../src/services/immutable-attachment-guard";
+import { ArtifactCoordinator } from "../src/services/artifact-coordinator";
+import { listSequencedSessionEvents, parsePersistedNormalizedEvent } from "../src/db/event-sequence-repository";
+import { sessionRoutes } from "../src/routes/session";
+import { releaseUserTurnReservation, reserveUserTurn } from "../src/services/turns";
+import { withPrivateAttachmentInputs } from "../src/services/stage-attachment-inputs";
+
+let root = "";
+let projectId = "";
+let sessionId = "";
+
+beforeEach(async () => {
+  await runMigrations();
+  root = await mkdtemp(path.join(tmpdir(), "burnguard-visual-security-"));
+  await mkdir(path.join(root, ".attachments"));
+  projectId = `visual-security-${crypto.randomUUID()}`;
+  sessionId = `${projectId}-session`;
+  getSqlite().prepare("INSERT INTO projects(id,name,type,dir_path,entrypoint,backend_id,created_at,updated_at) VALUES (?,?,'prototype',?,'index.html','codex',1,1)").run(projectId, projectId, root);
+  getSqlite().prepare("INSERT INTO sessions(id,project_id,backend_id,status,created_at,updated_at,last_active_at) VALUES (?,?,'codex','idle',1,1,1)").run(sessionId, projectId);
+});
+
+afterEach(async () => {
+  getSqlite().prepare("DELETE FROM projects WHERE id=?").run(projectId);
+  await rm(root, { recursive: true, force: true });
+});
+
+async function stored(role: "ordinary_content" | "immutable_reference", name = "source.pdf"): Promise<string> {
+  const filePath = path.join(root, ".attachments", name);
+  const bytes = new TextEncoder().encode("original");
+  await writeFile(filePath, bytes);
+  insertAttachmentRecord({ sessionId, filePath, mimeType: "application/pdf", originalName: name, sizeBytes: bytes.byteLength, sha256: createHash("sha256").update(bytes).digest("hex"), sourceRole: role });
+  return filePath;
+}
+
+describe("canonical attachment request", () => {
+  test("Given unmatched duplicate unsafe cross-session and newline paths When canonicalized Then each fails before use", async () => {
+    const valid = await stored("ordinary_content");
+    const foreignRoot = await mkdtemp(path.join(tmpdir(), "burnguard-foreign-"));
+    const foreignProject = `foreign-${crypto.randomUUID()}`;
+    const foreignSession = `${foreignProject}-session`;
+    getSqlite().prepare("INSERT INTO projects(id,name,type,dir_path,entrypoint,backend_id,created_at,updated_at) VALUES (?,?,'prototype',?,'index.html','codex',1,1)").run(foreignProject, foreignProject, foreignRoot);
+    getSqlite().prepare("INSERT INTO sessions(id,project_id,backend_id,status,created_at,updated_at,last_active_at) VALUES (?,?,'codex','idle',1,1,1)").run(foreignSession, foreignProject);
+    const foreign = path.join(foreignRoot, ".attachments", "foreign.pdf");
+    await mkdir(path.dirname(foreign)); await writeFile(foreign, "x");
+    insertAttachmentRecord({ sessionId: foreignSession, filePath: foreign, mimeType: "application/pdf", originalName: "foreign.pdf", sizeBytes: 1, sha256: "a".repeat(64) });
+    for (const paths of [[valid, valid], ["https://example.test/a.pdf"], ["../../escape.pdf"], [foreign], [`${valid}\nforged`], [path.join(root, ".attachments", "missing.pdf")]]) {
+      await expect(canonicalizeAttachmentRequest({ sessionId, requestedPaths: paths })).rejects.toThrow("invalid_attachments");
+    }
+    getSqlite().prepare("DELETE FROM projects WHERE id=?").run(foreignProject); await rm(foreignRoot, { recursive: true, force: true });
+  });
+
+  test("Given unsafe JSON attachment strings When routed Then bounded 4xx occurs before any event or status write", async () => {
+    const valid = await stored("ordinary_content");
+    for (const attachment of ["https://example.test/a.pdf", "/tmp/unmatched.pdf", "../../escape.pdf", `${valid}\nforged`]) {
+      const response = await sessionRoutes.request(`http://local/api/sessions/${sessionId}/events`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ type: "user.message", text: "x", attachments: [attachment] }) });
+      expect(response.status).toBe(400);
+    }
+    expect(getSqlite().query<{ readonly count: number }, []>("SELECT COUNT(*) count FROM events WHERE session_id=?").get(sessionId)?.count).toBe(0);
+  });
+
+  test("Given omitted or empty client roles When canonicalized Then persisted role remains authoritative", async () => {
+    const immutable = await stored("immutable_reference", "deck.pptx");
+    for (const selections of [undefined, []]) {
+      const result = await canonicalizeAttachmentRequest({ sessionId, requestedPaths: [immutable], selections });
+      expect(result.selections).toEqual([{ source_type: "uploaded_attachment", attachment_path: immutable, role: "immutable_reference" }]);
+    }
+    const mismatch = [{ source_type: "uploaded_attachment" as const, attachment_path: immutable, role: "ordinary_content" as const }];
+    await expect(canonicalizeAttachmentRequest({ sessionId, requestedPaths: [immutable], selections: mismatch })).rejects.toThrow("invalid_attachments");
+    const response = await sessionRoutes.request(`http://local/api/sessions/${sessionId}/events`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ type: "user.message", text: "x", attachments: [immutable], visualSources: mismatch }) });
+    expect(response.status).toBe(400);
+    expect(getSqlite().query<{ readonly count: number }, []>("SELECT COUNT(*) count FROM events WHERE session_id=?").get(sessionId)?.count).toBe(0);
+  });
+});
+
+describe("busy intake reservation", () => {
+  test("Given a concurrent reserved turn When multipart arrives Then it is rejected before attachment persistence", async () => {
+    const reservation = reserveUserTurn(sessionId);
+    expect(reservation).not.toBeNull();
+    const form = new FormData(); form.set("type", "user.message"); form.set("text", "busy"); form.append("files", new File(["pdf"], "busy.pdf", { type: "application/pdf" }));
+
+    const response = await sessionRoutes.request(`http://local/api/sessions/${sessionId}/events`, { method: "POST", body: form });
+
+    expect(response.status).toBe(409);
+    expect(getSqlite().query<{ readonly count: number }, []>("SELECT COUNT(*) count FROM attachments").get()?.count).toBe(0);
+    if (reservation !== null) releaseUserTurnReservation(reservation);
+  });
+});
+
+describe("immutable attachment guard", () => {
+  test("Given immutable private input bytes are copied to nested authored output When published Then typed rejection publishes zero result bytes", async () => {
+    await writeFile(path.join(root, "index.html"), "base");
+    const immutable = await stored("immutable_reference");
+    const immutableHash = createHash("sha256").update("original").digest("hex");
+    const coordinator = new ArtifactCoordinator(getSqlite());
+    const base = await coordinator.initialize(projectId, root);
+    const attachment = { id: "immutable-input", file_path: immutable, original_name: "source.pdf", size_bytes: 8, sha256: immutableHash, source_role: "immutable_reference" as const };
+
+    await expect(coordinator.run({ projectId, projectDir: root, kind: "turn", operationId: "private-copy", expectedRevision: 0, expectedArtifactDigest: base.tree_digest, publicationPolicy: { forbiddenSha256: new Set([immutableHash]) }, mutate: async (stage) => {
+      await writeFile(path.join(stage, "index.html"), "changed");
+      await mkdir(path.join(stage, "nested"));
+      await withPrivateAttachmentInputs({ operationDir: path.dirname(stage), projectDir: root, attachments: [attachment], requestedPaths: [immutable], immutableSnapshots: [] }, async (sources) => {
+        await copyFile(sources[0]?.sourcePath ?? "missing", path.join(stage, "nested", "authored-source.pdf"));
+      });
+    } })).rejects.toMatchObject({ code: "immutable_reference_escaped" });
+
+    expect(await readFile(path.join(root, "index.html"), "utf8")).toBe("base");
+    await expect(readFile(path.join(root, "nested", "authored-source.pdf"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(path.join(root, ".meta", "artifact-operations", "private-copy", "stage", "nested", "authored-source.pdf"))).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await readFile(immutable, "utf8")).toBe("original");
+  });
+
+  test("Given adapter mutation When postflight runs Then original bytes are restored and staged output is not committed", async () => {
+    await writeFile(path.join(root, "index.html"), "base");
+    const immutable = await stored("immutable_reference");
+    const snapshot = await captureImmutableAttachments([{ file_path: immutable, source_role: "immutable_reference", size_bytes: 8, sha256: createHash("sha256").update("original").digest("hex") }]);
+    const coordinator = new ArtifactCoordinator(getSqlite());
+    const base = await coordinator.initialize(projectId, root);
+
+    await expect(coordinator.run({ projectId, projectDir: root, kind: "turn", expectedRevision: 0, expectedArtifactDigest: base.tree_digest, mutate: async (stage) => {
+      await writeFile(path.join(stage, "index.html"), "changed");
+      await writeFile(immutable, "mutated");
+      await verifyImmutableAttachments(snapshot);
+    } })).rejects.toThrow("immutable_reference_mutated");
+
+    expect(await readFile(immutable, "utf8")).toBe("original");
+    expect(await readFile(path.join(root, "index.html"), "utf8")).toBe("base");
+  });
+
+  test("Given parent directory symlink swap When postflight runs Then outside bytes stay untouched and staged output is not published", async () => {
+    await writeFile(path.join(root, "index.html"), "base");
+    const immutable = await stored("immutable_reference");
+    const snapshots = await captureImmutableAttachments([{ file_path: immutable, source_role: "immutable_reference", size_bytes: 8, sha256: createHash("sha256").update("original").digest("hex") }]);
+    const outside = await mkdtemp(path.join(tmpdir(), "burnguard-immutable-outside-"));
+    const outsideSentinel = path.join(outside, path.basename(immutable));
+    await writeFile(outsideSentinel, "outside");
+    const displaced = `${path.dirname(immutable)}-captured`;
+    const coordinator = new ArtifactCoordinator(getSqlite());
+    const base = await coordinator.initialize(projectId, root);
+
+    try {
+      await expect(coordinator.run({ projectId, projectDir: root, kind: "turn", expectedRevision: 0, expectedArtifactDigest: base.tree_digest, mutate: async (stage) => {
+        await writeFile(path.join(stage, "index.html"), "changed");
+        await writeFile(immutable, "mutated");
+        await rename(path.dirname(immutable), displaced);
+        await symlink(outside, path.dirname(immutable), "dir");
+        try {
+          await verifyImmutableAttachments(snapshots);
+        } catch (error) {
+          await rm(path.dirname(immutable), { recursive: true, force: true });
+          await rename(displaced, path.dirname(immutable));
+          throw error;
+        }
+      } })).rejects.toThrow("immutable_reference_path_unavailable");
+      expect(await readFile(outsideSentinel, "utf8")).toBe("outside");
+      expect(await readFile(immutable, "utf8")).toBe("original");
+      expect(await readFile(path.join(root, "index.html"), "utf8")).toBe("base");
+      const handle = snapshots[0]?.handle;
+      expect(handle).toBeDefined();
+      await expect(handle?.stat()).rejects.toMatchObject({ code: "EBADF" });
+    } finally {
+      await rm(path.dirname(immutable), { recursive: true, force: true });
+      await rename(displaced, path.dirname(immutable)).catch(() => undefined);
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  test("Given file replacement symlink swap When postflight runs Then only captured inode is restored", async () => {
+    const immutable = await stored("immutable_reference");
+    const snapshots = await captureImmutableAttachments([{ file_path: immutable, source_role: "immutable_reference", size_bytes: 8, sha256: createHash("sha256").update("original").digest("hex") }]);
+    const outside = path.join(root, "outside-sentinel");
+    const displaced = `${immutable}.captured`;
+    await writeFile(outside, "outside");
+    await writeFile(immutable, "mutated");
+    await rename(immutable, displaced);
+    await symlink(outside, immutable);
+
+    try {
+      await expect(verifyImmutableAttachments(snapshots)).rejects.toThrow("immutable_reference_path_unavailable");
+      expect(await readFile(outside, "utf8")).toBe("outside");
+      expect(await readFile(displaced, "utf8")).toBe("original");
+      const handle = snapshots[0]?.handle;
+      await expect(handle?.stat()).rejects.toMatchObject({ code: "EBADF" });
+    } finally {
+      await rm(immutable, { force: true });
+      await rename(displaced, immutable).catch(() => undefined);
+    }
+  });
+
+  test("Given direct immutable mutation When postflight runs Then original bytes are atomically restored and the turn fails bounded", async () => {
+    const immutable = await stored("immutable_reference");
+    const snapshot = await captureImmutableAttachments([{ file_path: immutable, source_role: "immutable_reference", size_bytes: 8, sha256: createHash("sha256").update("original").digest("hex") }]);
+    await writeFile(immutable, "mutated");
+
+    await expect(verifyImmutableAttachments(snapshot)).rejects.toThrow("immutable_reference_mutated");
+    expect(await readFile(immutable, "utf8")).toBe("original");
+    await expect(snapshot[0]?.handle.stat()).rejects.toMatchObject({ code: "EBADF" });
+  });
+
+  test("Given unchanged immutable attachment When postflight succeeds Then its pre-opened handle is closed", async () => {
+    const immutable = await stored("immutable_reference");
+    const snapshots = await captureImmutableAttachments([{ file_path: immutable, source_role: "immutable_reference", size_bytes: 8, sha256: createHash("sha256").update("original").digest("hex") }]);
+    await expect(verifyImmutableAttachments(snapshots)).resolves.toBeUndefined();
+    await expect(snapshots[0]?.handle.stat()).rejects.toMatchObject({ code: "EBADF" });
+  });
+
+  test("Given ordinary attachment When guarded Then no handle or immutable failure is introduced", async () => {
+    const ordinary = await stored("ordinary_content");
+    const snapshots = await captureImmutableAttachments([{ file_path: ordinary, source_role: "ordinary_content", size_bytes: 8, sha256: createHash("sha256").update("original").digest("hex") }]);
+    expect(snapshots).toEqual([]);
+    await expect(verifyImmutableAttachments(snapshots)).resolves.toBeUndefined();
+  });
+});
+
+describe("authoritative replay provenance", () => {
+  test("Given duplicate manifest identity or mismatched turn When parsed Then replay fails closed", () => {
+    const source = { source_type: "uploaded_attachment", role: "ordinary_content", role_origin: "explicit", attachment_id: "a", original_name: "a.pdf", mime_type: "application/pdf", size_bytes: 1, preflight_verified_sha256: "a".repeat(64), managed_path: ".attachments/a.pdf", provenance: { session_id: sessionId, turn_id: "turn-1", storage: "managed_attachment" } };
+    const base = { id: "event", ts: 1, type: "chat.user_message", turnId: "turn-1", text: "x", attachmentCount: 1 };
+    expect(() => parsePersistedNormalizedEvent(JSON.stringify({ ...base, visualSources: { schema_version: 1, network_sources: "unsupported", sources: [source, source] } }), "event")).toThrow("corrupt_json");
+    expect(() => parsePersistedNormalizedEvent(JSON.stringify({ ...base, visualSources: { schema_version: 1, network_sources: "unsupported", sources: [{ ...source, provenance: { ...source.provenance, turn_id: "stale" } }] } }), "event")).toThrow("corrupt_json");
+    const wrongSession = { ...source, provenance: { ...source.provenance, session_id: "foreign-session" } };
+    getSqlite().prepare("INSERT INTO events(id,session_id,direction,type,payload_json,turn_id,processed_at,created_at,sequence) VALUES ('corrupt-replay',?,'down','chat.user_message',?,'turn-1',1,1,1)").run(sessionId, JSON.stringify({ ...base, id: "corrupt-replay", visualSources: { schema_version: 1, network_sources: "unsupported", sources: [wrongSession] } }));
+    expect(() => listSequencedSessionEvents(getSqlite(), sessionId, 0)).toThrow("corrupt_json");
+  });
+});

--- a/packages/frontend/src/api/design-audit.ts
+++ b/packages/frontend/src/api/design-audit.ts
@@ -1,0 +1,10 @@
+import { parseDesignAuditResult, type DesignAuditResult } from "@bg/shared";
+import { apiFetch } from "./client";
+
+export async function getProjectDesignAudit(projectId: string): Promise<DesignAuditResult> {
+  return parseDesignAuditResult(await apiFetch<unknown>(`/api/projects/${projectId}/design-audit`));
+}
+
+export async function retryProjectDesignAudit(projectId: string): Promise<DesignAuditResult> {
+  return parseDesignAuditResult(await apiFetch<unknown>(`/api/projects/${projectId}/design-audit/retry`, { method: "POST" }));
+}

--- a/packages/frontend/src/api/design-directions.ts
+++ b/packages/frontend/src/api/design-directions.ts
@@ -1,0 +1,80 @@
+import { parseDesignDirectionState, type DesignDirectionState } from "@bg/shared";
+import { apiFetch } from "./client";
+
+/**
+ * Design-direction workflow client. Every response body crosses the trust
+ * boundary through the shared contract parser exactly once, so the rest of
+ * the frontend only ever handles a typed `DesignDirectionState`.
+ */
+
+export type DirectionSelectionInput = {
+  readonly generation_id: string;
+  readonly expected_selection_revision: number;
+  readonly direction_id: string;
+};
+
+export type DirectionUndoInput = {
+  readonly generation_id: string;
+  readonly expected_selection_revision: number;
+};
+
+function base(projectId: string): string {
+  return `/api/projects/${encodeURIComponent(projectId)}/design-directions`;
+}
+
+function parseState(payload: unknown): DesignDirectionState {
+  return parseDesignDirectionState(payload);
+}
+
+/** Recovery-aware read. `null` means the session has never generated directions. */
+export async function getDesignDirectionState(
+  projectId: string,
+): Promise<DesignDirectionState | null> {
+  const payload = await apiFetch<unknown>(base(projectId));
+  return payload === null ? null : parseState(payload);
+}
+
+export async function generateDesignDirections(
+  projectId: string,
+): Promise<DesignDirectionState> {
+  return parseState(await apiFetch<unknown>(`${base(projectId)}/generate`, { method: "POST" }));
+}
+
+/** Retries every failed or cancelled slot of the current generation. */
+export async function retryDesignDirections(
+  projectId: string,
+): Promise<DesignDirectionState> {
+  return parseState(await apiFetch<unknown>(`${base(projectId)}/retry`, { method: "POST" }));
+}
+
+export async function cancelDesignDirections(
+  projectId: string,
+): Promise<DesignDirectionState> {
+  return parseState(
+    await apiFetch<unknown>(`${base(projectId)}/cancel`, { method: "POST" }),
+  );
+}
+
+export async function selectDesignDirection(
+  projectId: string,
+  input: DirectionSelectionInput,
+): Promise<DesignDirectionState> {
+  return parseState(
+    await apiFetch<unknown>(`${base(projectId)}/select`, {
+      method: "POST",
+      body: JSON.stringify(input),
+    }),
+  );
+}
+
+export async function undoDesignDirectionSelection(
+  projectId: string,
+  input: DirectionUndoInput,
+): Promise<DesignDirectionState> {
+  return parseState(
+    await apiFetch<unknown>(`${base(projectId)}/undo-selection`, {
+      method: "POST",
+      body: JSON.stringify(input),
+    }),
+  );
+}

--- a/packages/frontend/src/api/session.ts
+++ b/packages/frontend/src/api/session.ts
@@ -14,9 +14,14 @@ export async function listSessionEvents(
   return envelopes.map((item) => item.event);
 }
 
+/**
+ * `signal` cancels the HTTP request only. The backend keeps its own
+ * extraction lifecycle, and the client cannot observe extractor progress.
+ */
 export async function sendUserEvent(
   id: string,
   event: UserEvent & { files?: File[] },
+  options?: { readonly signal?: AbortSignal },
 ): Promise<void> {
   if (event.type === "user.message" && (event.files?.length ?? 0) > 0) {
     const form = new FormData();
@@ -26,16 +31,11 @@ export async function sendUserEvent(
       form.append("files", file);
     }
 
-    const res = await fetch(`/api/sessions/${id}/events`, {
+    await apiFetch<{ accepted: true }>(`/api/sessions/${id}/events`, {
       method: "POST",
-      credentials: "same-origin",
       body: form,
+      signal: options?.signal,
     });
-    if (!res.ok) {
-      throw new Error(
-        await res.text().catch(() => `Failed to send message to session ${id}`),
-      );
-    }
     return;
   }
 
@@ -47,6 +47,7 @@ export async function sendUserEvent(
         text: event.text,
         attachments: event.attachments,
       }),
+      signal: options?.signal,
     });
     return;
   }
@@ -54,6 +55,7 @@ export async function sendUserEvent(
   await apiFetch<{ accepted: true }>(`/api/sessions/${id}/events`, {
     method: "POST",
     body: JSON.stringify(event),
+    signal: options?.signal,
   });
 }
 

--- a/packages/frontend/src/api/session.ts
+++ b/packages/frontend/src/api/session.ts
@@ -1,4 +1,4 @@
-import type { BackendId, NormalizedEvent, SequencedEventEnvelope, SessionInfo, UserEvent } from "@bg/shared";
+import type { BackendId, NormalizedEvent, SequencedEventEnvelope, SessionInfo, UserEvent, VisualSourceRole } from "@bg/shared";
 import { apiFetch } from "./client";
 
 export async function getSession(id: string): Promise<SessionInfo> {
@@ -18,18 +18,34 @@ export async function listSessionEvents(
  * `signal` cancels the HTTP request only. The backend keeps its own
  * extraction lifecycle, and the client cannot observe extractor progress.
  */
+export type VisualSourceUploadFile = {
+  readonly id: string;
+  readonly file: File;
+  readonly role: VisualSourceRole;
+};
+
 export async function sendUserEvent(
   id: string,
-  event: UserEvent & { files?: File[] },
+  event: UserEvent & { files?: readonly (File | VisualSourceUploadFile)[] },
   options?: { readonly signal?: AbortSignal },
 ): Promise<void> {
   if (event.type === "user.message" && (event.files?.length ?? 0) > 0) {
     const form = new FormData();
     form.set("type", "user.message");
     form.set("text", event.text);
-    for (const file of event.files ?? []) {
-      form.append("files", file);
-    }
+    const uploads = (event.files ?? []).map((source, index) => source instanceof File
+      ? { id: `upload-${index}`, file: source, role: "ordinary_content" as const }
+      : source);
+    for (const upload of uploads) form.append("files", upload.file);
+    form.set("visual_sources", JSON.stringify({
+      schema_version: 1,
+      sources: uploads.map((upload, fileIndex) => ({
+        source_type: "upload",
+        upload_id: upload.id,
+        file_index: fileIndex,
+        role: upload.role,
+      })),
+    }));
 
     await apiFetch<{ accepted: true }>(`/api/sessions/${id}/events`, {
       method: "POST",
@@ -46,6 +62,7 @@ export async function sendUserEvent(
         type: "user.message",
         text: event.text,
         attachments: event.attachments,
+        visualSources: event.visualSources,
       }),
       signal: options?.signal,
     });

--- a/packages/frontend/src/components/canvas/Canvas.tsx
+++ b/packages/frontend/src/components/canvas/Canvas.tsx
@@ -11,6 +11,7 @@ import DrawLayer, {
 import EditLayer, { type EditTarget } from "./EditLayer";
 import SelectorOverlay from "./SelectorOverlay";
 import TweaksLayer, { type TweaksTarget } from "./TweaksLayer";
+import QualityLayer from "./QualityLayer";
 import {
   buildSandboxedArtifactSrcDoc,
   requestFrameSetActiveSlide,
@@ -96,6 +97,8 @@ export default function Canvas({
   canUndo,
   undoPending,
   onUndo,
+  qualityFocusedNodeId,
+  onQualityRevealResult,
 }: {
   mode: CanvasMode | null;
   src?: string | null;
@@ -130,6 +133,8 @@ export default function Canvas({
   canUndo?: boolean;
   undoPending?: boolean;
   onUndo?: () => void;
+  qualityFocusedNodeId: string | null;
+  onQualityRevealResult: (nodeBgId: string, found: boolean) => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -137,6 +142,7 @@ export default function Canvas({
   const restoreTargetSlideIdxRef = useRef<number | null>(null);
   const restoringSlideRef = useRef(false);
   const [frameSrcDoc, setFrameSrcDoc] = useState<string | null>(null);
+  const [loadedFrameKey, setLoadedFrameKey] = useState<string | null>(null);
   // Surfaces fetch failures inline instead of falling back to the
   // placeholder with no signal (audit fix #6). Cleared on every src
   // change so a successful Refresh recovers cleanly.
@@ -162,6 +168,7 @@ export default function Canvas({
   }, [frameKey, src]);
 
   useEffect(() => {
+    setLoadedFrameKey(null);
     if (!src) {
       setFrameSrcDoc(null);
       setLoadError(null);
@@ -267,7 +274,7 @@ export default function Canvas({
   }, [frameKey, frameSrcDoc, src]);
 
   return (
-    <div className="flex min-w-0 flex-1 flex-col bg-muted/40">
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-muted/40 max-[900px]:min-h-48">
       <CanvasTopBar
         mode={mode}
         onModeChange={onModeChange}
@@ -286,6 +293,7 @@ export default function Canvas({
             sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
             allow="fullscreen"
             className="absolute inset-0 h-full w-full border-0 bg-background"
+            onLoad={() => setLoadedFrameKey(frameKey ?? src)}
           />
         ) : (
           <iframe
@@ -325,6 +333,13 @@ export default function Canvas({
           selectedBgId={mode === "tweaks" ? tweaksSelectedBgId : null}
           onSelect={onSelectTweaksTarget}
         />
+        {mode === "quality" && <QualityLayer
+          active={loadedFrameKey === (frameKey ?? src ?? null)}
+          iframeRef={iframeRef}
+          nodeBgId={qualityFocusedNodeId}
+          requestKey={loadedFrameKey ?? "not-loaded"}
+          onRevealResult={onQualityRevealResult}
+        />}
         <DrawLayer
           ref={drawLayerRef}
           active={mode === "draw"}

--- a/packages/frontend/src/components/canvas/Canvas.tsx
+++ b/packages/frontend/src/components/canvas/Canvas.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import type { Comment } from "@bg/shared";
+import type { Comment, GraphicCanvasV1 } from "@bg/shared";
 import CanvasTopBar from "./CanvasTopBar";
 import CommentLayer from "./CommentLayer";
 import type { Ref } from "react";
@@ -99,6 +99,7 @@ export default function Canvas({
   onUndo,
   qualityFocusedNodeId,
   onQualityRevealResult,
+  graphicCanvas,
 }: {
   mode: CanvasMode | null;
   src?: string | null;
@@ -135,6 +136,7 @@ export default function Canvas({
   onUndo?: () => void;
   qualityFocusedNodeId: string | null;
   onQualityRevealResult: (nodeBgId: string, found: boolean) => void;
+  graphicCanvas?: GraphicCanvasV1 | null;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -200,6 +202,9 @@ export default function Canvas({
           buildSandboxedArtifactSrcDoc(
             html,
             new URL(src, window.location.href).toString(),
+            graphicCanvas === null || graphicCanvas === undefined
+              ? undefined
+              : { graphicCanvas },
           ),
         );
       })
@@ -215,7 +220,7 @@ export default function Canvas({
     return () => {
       cancelled = true;
     };
-  }, [frameKey, src]);
+  }, [frameKey, graphicCanvas, src]);
 
   useEffect(() => {
     // Push-based: deck-stage's BRIDGE_SCRIPT broadcasts active-slide-

--- a/packages/frontend/src/components/canvas/CanvasTopBar.tsx
+++ b/packages/frontend/src/components/canvas/CanvasTopBar.tsx
@@ -4,11 +4,12 @@ import type { CanvasMode } from "@/components/modes/types";
 import { Button } from "@/components/ui/button";
 
 const MODES: Array<{ id: CanvasMode; label: string; phase?: number }> = [
-  { id: "select", label: "Select" },
-  { id: "tweaks", label: "Tweaks" },
-  { id: "comment", label: "Comment" },
-  { id: "edit", label: "Edit" },
-  { id: "draw", label: "Draw" },
+  { id: "select", label: "선택" },
+  { id: "tweaks", label: "스타일" },
+  { id: "comment", label: "코멘트" },
+  { id: "edit", label: "편집" },
+  { id: "draw", label: "그리기" },
+  { id: "quality", label: "품질 점검" },
 ];
 
 export default function CanvasTopBar({
@@ -32,8 +33,8 @@ export default function CanvasTopBar({
   onUndo?: () => void;
 }) {
   return (
-    <div className="h-10 border-b border-border bg-background flex items-center justify-between px-3 shrink-0">
-      <div className="flex items-center gap-0.5">
+    <div className="h-10 border-b border-border bg-background flex items-center justify-between px-3 shrink-0 max-[900px]:h-auto max-[900px]:flex-col max-[900px]:items-stretch max-[900px]:px-2">
+      <div className="flex items-center gap-0.5 max-[900px]:grid max-[900px]:grid-cols-6">
         {MODES.map((m) => {
           const disabled = Boolean(m.phase);
           const active = m.id === mode;
@@ -46,13 +47,13 @@ export default function CanvasTopBar({
               disabled={disabled}
               title={
                 disabled
-                  ? `Phase ${m.phase}`
+                  ? `${m.phase}단계`
                   : active
-                    ? "Click again to deactivate"
+                    ? "다시 누르면 모드 끄기"
                     : undefined
               }
               className={cn(
-                "px-2.5 h-7 rounded text-xs transition-colors",
+                "px-2.5 h-7 rounded text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring max-[900px]:h-11 max-[900px]:min-w-0 max-[900px]:overflow-hidden max-[900px]:text-ellipsis max-[900px]:whitespace-nowrap max-[900px]:px-1 max-[900px]:text-[10px]",
                 active
                   ? "bg-muted text-foreground"
                   : "text-muted-foreground hover:text-foreground",
@@ -65,17 +66,17 @@ export default function CanvasTopBar({
         })}
       </div>
 
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-1 max-[900px]:self-end">
         <Button
           variant="ghost"
           size="icon"
-          className="h-7 w-7"
+          className="h-7 w-7 max-[900px]:h-11 max-[900px]:w-11"
           onClick={onUndo}
           disabled={!canUndo || undoPending || !onUndo}
           title={
             canUndo
-              ? "Undo last save (Edit / Tweaks)"
-              : "No GUI patch to undo on the active file"
+              ? "마지막 저장 실행 취소 (편집 / 스타일)"
+              : "현재 파일에서 실행 취소할 수정이 없어요"
           }
         >
           <Undo2 className="h-3.5 w-3.5" />
@@ -83,9 +84,9 @@ export default function CanvasTopBar({
         <Button
           variant="ghost"
           size="icon"
-          className="h-7 w-7"
+          className="h-7 w-7 max-[900px]:h-11 max-[900px]:w-11"
           onClick={onRefresh}
-          title="Refresh canvas"
+          title="캔버스 새로고침"
         >
           <RefreshCw className="h-3.5 w-3.5" />
         </Button>

--- a/packages/frontend/src/components/canvas/QualityLayer.tsx
+++ b/packages/frontend/src/components/canvas/QualityLayer.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState, type RefObject } from "react";
+import { requestFrameRectForBgId, type FrameRect } from "./frame-bridge";
+
+export default function QualityLayer({ active, iframeRef, nodeBgId, requestKey, onRevealResult }: {
+  readonly active: boolean;
+  readonly iframeRef: RefObject<HTMLIFrameElement | null>;
+  readonly nodeBgId: string | null;
+  readonly requestKey: string;
+  readonly onRevealResult: (nodeBgId: string, found: boolean) => void;
+}) {
+  const [rect, setRect] = useState<FrameRect | null>(null);
+  useEffect(() => {
+    if (!active || nodeBgId === null) { setRect(null); return; }
+    let mounted = true;
+    void requestFrameRectForBgId(iframeRef.current, nodeBgId).then((next) => {
+      if (!mounted) return;
+      setRect(next);
+      onRevealResult(nodeBgId, next !== null);
+    });
+    return () => { mounted = false; };
+  }, [active, iframeRef, nodeBgId, onRevealResult, requestKey]);
+  if (!active || rect === null) return null;
+  return <div aria-hidden="true" className="pointer-events-none absolute border-2 border-accent bg-accent/10" style={{ left: rect.left, top: rect.top, width: rect.width, height: rect.height }} />;
+}

--- a/packages/frontend/src/components/canvas/frame-bridge.ts
+++ b/packages/frontend/src/components/canvas/frame-bridge.ts
@@ -24,6 +24,9 @@
  *     ignored cheaply.
  */
 
+import type { GraphicCanvasV1 } from "@bg/shared";
+import { buildGraphicPreviewInjection } from "@/lib/graphic-preview";
+
 export interface FrameRect {
   left: number;
   top: number;
@@ -183,23 +186,32 @@ export function subscribeFrameEvent<E extends FrameEventName>(
   };
 }
 
+export type SandboxedArtifactOptions = {
+  readonly graphicCanvas?: GraphicCanvasV1;
+};
+
 export function buildSandboxedArtifactSrcDoc(
   html: string,
   baseHref: string,
+  options?: SandboxedArtifactOptions,
 ): string {
   const baseTag = `<base href="${escapeHtmlAttr(baseHref)}">`;
+  const graphicPreview = options?.graphicCanvas === undefined
+    ? ""
+    : buildGraphicPreviewInjection(options.graphicCanvas);
   const scriptTag = `<script>${BRIDGE_SCRIPT}<\/script>`;
   if (/<head[\s>]/i.test(html)) {
-    return html.replace(/<head([^>]*)>/i, `<head$1>${baseTag}${scriptTag}`);
+    return html.replace(/<head([^>]*)>/i, `<head$1>${baseTag}${graphicPreview}${scriptTag}`);
   }
   if (/<html[\s>]/i.test(html)) {
     return html.replace(
       /<html([^>]*)>/i,
-      `<html$1><head>${baseTag}${scriptTag}</head>`,
+      `<html$1><head>${baseTag}${graphicPreview}${scriptTag}</head>`,
     );
   }
-  return `<!doctype html><html><head>${baseTag}${scriptTag}</head><body>${html}</body></html>`;
+  return `<!doctype html><html><head>${baseTag}${graphicPreview}${scriptTag}</head><body>${html}</body></html>`;
 }
+
 
 export async function requestFrameSelectAtPoint(
   iframe: HTMLIFrameElement | null,

--- a/packages/frontend/src/components/chat/ChatPane.tsx
+++ b/packages/frontend/src/components/chat/ChatPane.tsx
@@ -1,9 +1,10 @@
 import { useState, type ReactNode } from "react";
 import { MessageSquare, MessageCircleMore } from "lucide-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import type { BackendId, NormalizedEvent, SessionInfo } from "@bg/shared";
+import type { BackendId, FileInfo, NormalizedEvent, SessionInfo } from "@bg/shared";
 import MessageStream from "./MessageStream";
 import Composer from "./Composer";
+import type { ReadyAttachmentSource } from "./attachment-intake";
 import { switchSessionBackend } from "@/api/session";
 import { useUIStore } from "@/state/uiStore";
 import { cn } from "@/lib/utils";
@@ -23,6 +24,7 @@ export default function ChatPane({
   revertingTurnId,
   composerInitialText,
   statusSlot,
+  projectFiles,
 }: {
   events: NormalizedEvent[];
   session: SessionInfo;
@@ -32,7 +34,7 @@ export default function ChatPane({
   onInterrupt?: () => void;
   onSend: (
     text: string,
-    files: File[],
+    files: readonly ReadyAttachmentSource[],
     signal: AbortSignal,
   ) => void | Promise<void>;
   onOpenFile?: (relPath: string) => void;
@@ -40,6 +42,7 @@ export default function ChatPane({
   revertingTurnId?: string | null;
   composerInitialText?: string;
   statusSlot?: ReactNode;
+  projectFiles: readonly FileInfo[];
 }) {
   const [tab, setTab] = useState<Tab>("chat");
   const queryClient = useQueryClient();
@@ -117,6 +120,7 @@ export default function ChatPane({
             interruptPending={interruptPending}
             onInterrupt={onInterrupt}
             initialText={composerInitialText}
+            projectFiles={projectFiles}
           />
         </>
       ) : (

--- a/packages/frontend/src/components/chat/ChatPane.tsx
+++ b/packages/frontend/src/components/chat/ChatPane.tsx
@@ -29,7 +29,11 @@ export default function ChatPane({
   canInterrupt?: boolean;
   interruptPending?: boolean;
   onInterrupt?: () => void;
-  onSend: (text: string, files: File[]) => void;
+  onSend: (
+    text: string,
+    files: File[],
+    signal: AbortSignal,
+  ) => void | Promise<void>;
   onOpenFile?: (relPath: string) => void;
   onRevertTurn?: (turnId: string) => void;
   revertingTurnId?: string | null;
@@ -65,7 +69,7 @@ export default function ChatPane({
   const sessionRunning = session.status === "running";
 
   return (
-    <aside className="w-[360px] shrink-0 border-r border-border bg-background flex flex-col min-h-0 overflow-hidden max-[900px]:w-full max-[900px]:h-[300px] max-[900px]:border-r-0 max-[900px]:border-b">
+    <aside className="w-[360px] shrink-0 border-r border-border bg-background flex flex-col min-h-0 overflow-hidden max-[900px]:h-[360px] max-[900px]:w-full max-[900px]:border-r-0 max-[900px]:border-b max-[480px]:h-[420px]">
       <div className="flex items-stretch gap-1 px-3 pt-2 border-b border-border">
         <ChatTab
           id="chat"

--- a/packages/frontend/src/components/chat/ChatPane.tsx
+++ b/packages/frontend/src/components/chat/ChatPane.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { MessageSquare, MessageCircleMore } from "lucide-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { BackendId, NormalizedEvent, SessionInfo } from "@bg/shared";
@@ -22,6 +22,7 @@ export default function ChatPane({
   onRevertTurn,
   revertingTurnId,
   composerInitialText,
+  statusSlot,
 }: {
   events: NormalizedEvent[];
   session: SessionInfo;
@@ -38,6 +39,7 @@ export default function ChatPane({
   onRevertTurn?: (turnId: string) => void;
   revertingTurnId?: string | null;
   composerInitialText?: string;
+  statusSlot?: ReactNode;
 }) {
   const [tab, setTab] = useState<Tab>("chat");
   const queryClient = useQueryClient();
@@ -105,6 +107,7 @@ export default function ChatPane({
             onRevertTurn={onRevertTurn}
             revertingTurnId={revertingTurnId}
           />
+          {statusSlot}
           <Composer
             onSend={onSend}
             disabled={composerDisabled}

--- a/packages/frontend/src/components/chat/ChatPane.tsx
+++ b/packages/frontend/src/components/chat/ChatPane.tsx
@@ -71,7 +71,7 @@ export default function ChatPane({
   const sessionRunning = session.status === "running";
 
   return (
-    <aside className="w-[360px] shrink-0 border-r border-border bg-background flex flex-col min-h-0 overflow-hidden max-[900px]:h-[360px] max-[900px]:w-full max-[900px]:border-r-0 max-[900px]:border-b max-[480px]:h-[420px]">
+    <aside className="w-[360px] shrink-0 border-r border-border bg-background flex flex-col min-h-0 overflow-hidden max-[900px]:h-[360px] max-[900px]:w-full max-[900px]:border-r-0 max-[900px]:border-b">
       <div className="flex items-stretch gap-1 px-3 pt-2 border-b border-border">
         <ChatTab
           id="chat"
@@ -107,7 +107,9 @@ export default function ChatPane({
             onRevertTurn={onRevertTurn}
             revertingTurnId={revertingTurnId}
           />
-          {statusSlot}
+          {statusSlot !== undefined && statusSlot !== null && (
+            <div className="shrink-0">{statusSlot}</div>
+          )}
           <Composer
             onSend={onSend}
             disabled={composerDisabled}
@@ -159,7 +161,7 @@ function BackendToggle({
                 : `Switch to ${opt} on next turn`
           }
           className={cn(
-            "px-1.5 py-0.5 font-mono uppercase transition-colors",
+            "max-[900px]:min-h-11 max-[900px]:min-w-11 px-1.5 py-0.5 font-mono uppercase transition-colors",
             opt === current
               ? "bg-foreground/90 text-background"
               : "bg-background text-muted-foreground hover:text-foreground",
@@ -194,7 +196,7 @@ function ChatTab({
     <button
       onClick={() => setActive(id)}
       className={cn(
-        "flex items-center gap-1.5 px-2.5 py-2 text-xs font-medium border-b-2 -mb-px transition-colors",
+        "flex max-[900px]:min-h-11 items-center gap-1.5 px-2.5 py-2 text-xs font-medium border-b-2 -mb-px transition-colors",
         active === id
           ? "border-foreground text-foreground"
           : "border-transparent text-muted-foreground hover:text-foreground",

--- a/packages/frontend/src/components/chat/Composer.tsx
+++ b/packages/frontend/src/components/chat/Composer.tsx
@@ -192,7 +192,7 @@ export default function Composer({
         <Button
           variant="ghost"
           size="icon"
-          className="h-7 w-7 text-muted-foreground"
+          className="h-7 w-7 text-muted-foreground max-[600px]:h-11 max-[600px]:w-11"
           title="설정 열기"
           onClick={() => setSettingsOpen(true)}
         >
@@ -201,7 +201,7 @@ export default function Composer({
         <Button
           variant="outline"
           size="sm"
-          className="h-7 gap-1 text-xs"
+          className="h-7 gap-1 text-xs max-[600px]:h-11"
           title="참고할 파일을 첨부합니다"
           disabled={disabled}
           onClick={() => fileInput.current?.click()}
@@ -213,7 +213,7 @@ export default function Composer({
           <Button
             variant="outline"
             size="sm"
-            className="h-7 gap-1 text-xs"
+            className="h-7 gap-1 text-xs max-[600px]:h-11"
             onClick={() => sendAbort.current?.abort()}
             aria-label="전송 취소"
             title="전송 요청을 취소합니다"
@@ -224,7 +224,7 @@ export default function Composer({
           <Button
             variant="destructive"
             size="sm"
-            className="h-7 gap-1 text-xs"
+            className="h-7 gap-1 text-xs max-[600px]:h-11"
             disabled={interruptPending || !onInterrupt}
             onClick={() => onInterrupt?.()}
             title="진행 중인 작업을 중단합니다"
@@ -236,7 +236,7 @@ export default function Composer({
           <Button
             variant="cta"
             size="sm"
-            className="h-7 gap-1 text-xs"
+            className="h-7 gap-1 text-xs max-[600px]:h-11"
             disabled={!canSend}
             onClick={() => void send()}
             aria-label={retrying ? "다시 보내기 (Cmd/Ctrl+Enter)" : "보내기 (Cmd/Ctrl+Enter)"}
@@ -248,8 +248,9 @@ export default function Composer({
         )}
       </div>
 
-      <p className="mt-1.5 text-center text-[10px] leading-relaxed text-foreground/80">
-        PDF와 PPTX를 여기로 끌어다 놓거나 자료 첨부로 올릴 수 있어요. 최대 8개, 파일당 10MB, 전체 25MB까지예요.
+      <p className="mt-1.5 break-words text-center text-[10px] leading-relaxed text-foreground/80 [word-break:keep-all]">
+        PDF와 PPTX를 여기로 끌어다 놓거나 자료 첨부로 올릴 수 있어요. 최대 8개,{" "}
+        <span className="whitespace-nowrap">파일당 10MB</span>, 전체 25MB까지예요.
       </p>
     </div>
   );

--- a/packages/frontend/src/components/chat/Composer.tsx
+++ b/packages/frontend/src/components/chat/Composer.tsx
@@ -1,18 +1,19 @@
 import { useRef, useState } from "react";
+import type { FileInfo } from "@bg/shared";
 import { Paperclip, Send, Settings2, StopCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useUIStore } from "@/state/uiStore";
 import { cn } from "@/lib/utils";
 import ComposerAttachments from "./ComposerAttachments";
+import { VisualSourceCandidates } from "./VisualSourceCandidates";
 import {
   COMPOSER_SUPPORTED_EXTENSIONS,
-  planAttachmentIntake,
-  readyAttachmentFiles,
   resolveSendOutcome,
-  type IntakeItem,
+  type ReadyAttachmentSource,
   type SendOutcome,
 } from "./attachment-intake";
 import { useComposerPlaceholder } from "./useComposerPlaceholder";
+import { useComposerVisualSources } from "./useComposerVisualSources";
 
 type ComposerSendState = { readonly kind: "idle" } | { readonly kind: "processing" } | SendOutcome;
 
@@ -25,9 +26,9 @@ function sendStateMessage(state: ComposerSendState): string | null {
     case "cancelled":
       return "전송 요청을 취소했어요. 다시 보낼 수 있어요.";
     case "failed":
-      return state.code === "unsupported_file_kind"
-        ? "지원하지 않는 형식이라 저장하지 않았어요. 해당 파일을 빼고 다시 보내 주세요."
-        : "전송에 실패했어요. 다시 보내기를 눌러 주세요.";
+      if (state.code === "unsupported_file_kind") return "지원하지 않는 형식이라 저장하지 않았어요. 해당 파일을 빼고 다시 보내 주세요.";
+      if (state.code === "unsupported_visual_source") return "URL·웹·스톡 소스는 지원하지 않아 저장하지 않았어요. 로컬 PDF 또는 PPTX를 업로드해 주세요.";
+      return "전송에 실패했어요. 다시 보내기를 눌러 주세요.";
     default: {
       const unreachable: never = state;
       return unreachable;
@@ -42,6 +43,7 @@ export default function Composer({
   interruptPending = false,
   onInterrupt,
   initialText = "",
+  projectFiles = [],
 }: {
   /**
    * `signal` aborts the in-flight send request when the caller forwards it to
@@ -49,7 +51,7 @@ export default function Composer({
    * reports "cancelled" if the returned promise actually rejects with
    * AbortError.
    */
-  onSend: (text: string, files: File[], signal: AbortSignal) => void | Promise<void>;
+  onSend: (text: string, files: readonly ReadyAttachmentSource[], signal: AbortSignal) => void | Promise<void>;
   disabled?: boolean;
   /**
    * True when the current turn has exceeded the user's configured
@@ -68,11 +70,15 @@ export default function Composer({
    * so a re-render can't clobber what the user has typed.
    */
   initialText?: string;
+  /** Indexed managed files are disclosed as editable-only source candidates. */
+  projectFiles?: readonly FileInfo[];
 }) {
   const setSettingsOpen = useUIStore((s) => s.setSettingsOpen);
   const [text, setText] = useState(initialText);
-  const [items, setItems] = useState<readonly IntakeItem[]>([]);
   const [sendState, setSendState] = useState<ComposerSendState>({ kind: "idle" });
+  const visualSources = useComposerVisualSources(() => {
+    if (sendState.kind !== "processing") setSendState({ kind: "idle" });
+  });
   const [dragOver, setDragOver] = useState(false);
   const fileInput = useRef<HTMLInputElement>(null);
   const sendAbort = useRef<AbortController | null>(null);
@@ -88,10 +94,7 @@ export default function Composer({
     setDragOver(false);
     const dropped = Array.from(e.dataTransfer.files);
     if (dropped.length > 0) {
-      setItems((prev) => planAttachmentIntake(prev, dropped));
-      if (sendState.kind !== "processing") {
-        setSendState({ kind: "idle" });
-      }
+      visualSources.add(dropped);
     }
   }
 
@@ -101,9 +104,9 @@ export default function Composer({
     sendAbort.current = controller;
     setSendState({ kind: "processing" });
     try {
-      await onSend(text, [...readyAttachmentFiles(items)], controller.signal);
+      await onSend(text, visualSources.ready(), controller.signal);
       setText("");
-      setItems([]);
+      visualSources.clear();
       setSendState({ kind: "idle" });
     } catch (error) {
       // Keep the text and the queue intact so retry costs one click.
@@ -128,17 +131,12 @@ export default function Composer({
       onDrop={handleDrop}
     >
       <ComposerAttachments
-        items={items}
+        items={visualSources.items}
         sending={sending}
-        onRemove={(index) => {
-          setItems((current) =>
-            current.filter((_, itemIndex) => itemIndex !== index),
-          );
-          if (sendState.kind !== "processing") {
-            setSendState({ kind: "idle" });
-          }
-        }}
+        onRoleChange={visualSources.setRole}
+        onRemove={visualSources.remove}
       />
+      <VisualSourceCandidates files={projectFiles} />
 
       {statusMessage !== null && (
         <p
@@ -181,10 +179,7 @@ export default function Composer({
           onChange={(e) => {
             const picked = Array.from(e.target.files ?? []);
             if (picked.length > 0) {
-              setItems((prev) => planAttachmentIntake(prev, picked));
-              if (sendState.kind !== "processing") {
-                setSendState({ kind: "idle" });
-              }
+              visualSources.add(picked);
             }
             e.target.value = "";
           }}
@@ -247,11 +242,6 @@ export default function Composer({
           </Button>
         )}
       </div>
-
-      <p className="mt-1.5 break-words text-center text-[10px] leading-relaxed text-foreground/80 [word-break:keep-all]">
-        PDF와 PPTX를 여기로 끌어다 놓거나 자료 첨부로 올릴 수 있어요. 최대 8개,{" "}
-        <span className="whitespace-nowrap">파일당 10MB</span>, 전체 25MB까지예요.
-      </p>
     </div>
   );
 }

--- a/packages/frontend/src/components/chat/Composer.tsx
+++ b/packages/frontend/src/components/chat/Composer.tsx
@@ -192,7 +192,7 @@ export default function Composer({
         <Button
           variant="ghost"
           size="icon"
-          className="h-7 w-7 text-muted-foreground max-[600px]:h-11 max-[600px]:w-11"
+          className="h-7 w-7 text-muted-foreground max-[900px]:h-11 max-[900px]:w-11"
           title="설정 열기"
           onClick={() => setSettingsOpen(true)}
         >
@@ -201,7 +201,7 @@ export default function Composer({
         <Button
           variant="outline"
           size="sm"
-          className="h-7 gap-1 text-xs max-[600px]:h-11"
+          className="h-7 gap-1 text-xs max-[900px]:h-11"
           title="참고할 파일을 첨부합니다"
           disabled={disabled}
           onClick={() => fileInput.current?.click()}
@@ -213,7 +213,7 @@ export default function Composer({
           <Button
             variant="outline"
             size="sm"
-            className="h-7 gap-1 text-xs max-[600px]:h-11"
+            className="h-7 gap-1 text-xs max-[900px]:h-11"
             onClick={() => sendAbort.current?.abort()}
             aria-label="전송 취소"
             title="전송 요청을 취소합니다"
@@ -224,7 +224,7 @@ export default function Composer({
           <Button
             variant="destructive"
             size="sm"
-            className="h-7 gap-1 text-xs max-[600px]:h-11"
+            className="h-7 gap-1 text-xs max-[900px]:h-11"
             disabled={interruptPending || !onInterrupt}
             onClick={() => onInterrupt?.()}
             title="진행 중인 작업을 중단합니다"
@@ -236,7 +236,7 @@ export default function Composer({
           <Button
             variant="cta"
             size="sm"
-            className="h-7 gap-1 text-xs max-[600px]:h-11"
+            className="h-7 gap-1 text-xs max-[900px]:h-11"
             disabled={!canSend}
             onClick={() => void send()}
             aria-label={retrying ? "다시 보내기 (Cmd/Ctrl+Enter)" : "보내기 (Cmd/Ctrl+Enter)"}

--- a/packages/frontend/src/components/chat/Composer.tsx
+++ b/packages/frontend/src/components/chat/Composer.tsx
@@ -1,28 +1,39 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Paperclip, Send, Settings2, StopCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useUIStore } from "@/state/uiStore";
 import { cn } from "@/lib/utils";
+import ComposerAttachments from "./ComposerAttachments";
+import {
+  COMPOSER_SUPPORTED_EXTENSIONS,
+  planAttachmentIntake,
+  readyAttachmentFiles,
+  resolveSendOutcome,
+  type IntakeItem,
+  type SendOutcome,
+} from "./attachment-intake";
+import { useComposerPlaceholder } from "./useComposerPlaceholder";
 
-const IDLE_PLACEHOLDER =
-  "뭘 만들고 싶나요? 로컬 CLI라 응답은 조금 느려요...";
+type ComposerSendState = { readonly kind: "idle" } | { readonly kind: "processing" } | SendOutcome;
 
-// Local CLIs take a few seconds to get going. Rotating the placeholder
-// while the turn is running turns the wait into a tiny loop of "the
-// app is alive" signals instead of a blank disabled textarea.
-const WAITING_PLACEHOLDERS = [
-  "로컬 CLI 워밍업 중...",
-  "Claude가 키보드를 두드리는 중...",
-  "토큰을 한 장 한 장 세는 중...",
-  "GPU가 기어를 올리는 소리가 들려요...",
-  "덱에 잉크를 바르는 중...",
-  "프롬프트를 천천히 음미하는 중...",
-  "로컬이라 좀 느립니다. 딴짓해도 돼요.",
-  "당신의 문장을 조립 중...",
-  "Claude가 스크롤을 읽는 중...",
-  "그림의 남은 한 조각을 찾는 중...",
-];
-const WAITING_INTERVAL_MS = 2400;
+function sendStateMessage(state: ComposerSendState): string | null {
+  switch (state.kind) {
+    case "idle":
+      return null;
+    case "processing":
+      return "보내는 중이에요. 서버 처리 진행률은 알 수 없어요.";
+    case "cancelled":
+      return "전송 요청을 취소했어요. 다시 보낼 수 있어요.";
+    case "failed":
+      return state.code === "unsupported_file_kind"
+        ? "지원하지 않는 형식이라 저장하지 않았어요. 해당 파일을 빼고 다시 보내 주세요."
+        : "전송에 실패했어요. 다시 보내기를 눌러 주세요.";
+    default: {
+      const unreachable: never = state;
+      return unreachable;
+    }
+  }
+}
 
 export default function Composer({
   onSend,
@@ -32,7 +43,13 @@ export default function Composer({
   onInterrupt,
   initialText = "",
 }: {
-  onSend: (text: string, files: File[]) => void;
+  /**
+   * `signal` aborts the in-flight send request when the caller forwards it to
+   * `sendUserEvent`. The composer never assumes it was honoured: it only
+   * reports "cancelled" if the returned promise actually rejects with
+   * AbortError.
+   */
+  onSend: (text: string, files: File[], signal: AbortSignal) => void | Promise<void>;
   disabled?: boolean;
   /**
    * True when the current turn has exceeded the user's configured
@@ -54,46 +71,53 @@ export default function Composer({
 }) {
   const setSettingsOpen = useUIStore((s) => s.setSettingsOpen);
   const [text, setText] = useState(initialText);
-  const [files, setFiles] = useState<File[]>([]);
+  const [items, setItems] = useState<readonly IntakeItem[]>([]);
+  const [sendState, setSendState] = useState<ComposerSendState>({ kind: "idle" });
   const [dragOver, setDragOver] = useState(false);
-  const [waitingIndex, setWaitingIndex] = useState(0);
   const fileInput = useRef<HTMLInputElement>(null);
+  const sendAbort = useRef<AbortController | null>(null);
+  const placeholder = useComposerPlaceholder(disabled);
 
-  // Rotate the placeholder every few seconds while the CLI is busy.
-  // Random start so the same message doesn't greet every turn.
-  useEffect(() => {
-    if (!disabled) return;
-    setWaitingIndex(Math.floor(Math.random() * WAITING_PLACEHOLDERS.length));
-    const id = window.setInterval(() => {
-      setWaitingIndex((prev) => (prev + 1) % WAITING_PLACEHOLDERS.length);
-    }, WAITING_INTERVAL_MS);
-    return () => window.clearInterval(id);
-  }, [disabled]);
-
-  const placeholder = disabled
-    ? (WAITING_PLACEHOLDERS[waitingIndex] ?? IDLE_PLACEHOLDER)
-    : IDLE_PLACEHOLDER;
-
-  const canSend = text.trim().length > 0 && !disabled;
+  const sending = sendState.kind === "processing";
+  const canSend = text.trim().length > 0 && !disabled && !sending;
+  const statusMessage = sendStateMessage(sendState);
+  const retrying = sendState.kind === "failed" || sendState.kind === "cancelled";
 
   function handleDrop(e: React.DragEvent) {
     e.preventDefault();
     setDragOver(false);
     const dropped = Array.from(e.dataTransfer.files);
-    if (dropped.length > 0) setFiles((prev) => [...prev, ...dropped]);
+    if (dropped.length > 0) {
+      setItems((prev) => planAttachmentIntake(prev, dropped));
+      if (sendState.kind !== "processing") {
+        setSendState({ kind: "idle" });
+      }
+    }
   }
 
-  function send() {
+  async function send() {
     if (!canSend) return;
-    onSend(text, files);
-    setText("");
-    setFiles([]);
+    const controller = new AbortController();
+    sendAbort.current = controller;
+    setSendState({ kind: "processing" });
+    try {
+      await onSend(text, [...readyAttachmentFiles(items)], controller.signal);
+      setText("");
+      setItems([]);
+      setSendState({ kind: "idle" });
+    } catch (error) {
+      // Keep the text and the queue intact so retry costs one click.
+      setSendState(resolveSendOutcome(error));
+    } finally {
+      sendAbort.current = null;
+    }
   }
 
   return (
     <div
+      data-qa="composer"
       className={cn(
-        "border-t border-border p-3 bg-background",
+        "shrink-0 border-t border-border p-3 bg-background",
         dragOver && "ring-2 ring-accent ring-inset",
       )}
       onDragOver={(e) => {
@@ -103,39 +127,44 @@ export default function Composer({
       onDragLeave={() => setDragOver(false)}
       onDrop={handleDrop}
     >
-      {files.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 mb-2">
-          {files.map((f, i) => (
-            <span
-              key={i}
-              className="inline-flex items-center gap-1 rounded bg-muted text-muted-foreground text-[11px] px-2 py-1"
-            >
-              <Paperclip className="h-3 w-3" />
-              <span className="max-w-[120px] truncate">{f.name}</span>
-              <button
-                className="ml-0.5 text-muted-foreground hover:text-foreground"
-                title={`${f.name} 첨부 취소`}
-                onClick={() =>
-                  setFiles((prev) => prev.filter((_, j) => j !== i))
-                }
-              >
-                ×
-              </button>
-            </span>
-          ))}
-        </div>
+      <ComposerAttachments
+        items={items}
+        sending={sending}
+        onRemove={(index) => {
+          setItems((current) =>
+            current.filter((_, itemIndex) => itemIndex !== index),
+          );
+          if (sendState.kind !== "processing") {
+            setSendState({ kind: "idle" });
+          }
+        }}
+      />
+
+      {statusMessage !== null && (
+        <p
+          role="status"
+          aria-live="polite"
+          className="mb-2 text-[11px] leading-relaxed text-muted-foreground"
+        >
+          {statusMessage}
+        </p>
       )}
 
       <textarea
         value={text}
-        onChange={(e) => setText(e.target.value)}
+        onChange={(e) => {
+          setText(e.target.value);
+          if (sendState.kind !== "processing") {
+            setSendState({ kind: "idle" });
+          }
+        }}
         placeholder={placeholder}
         rows={3}
         disabled={disabled}
         onKeyDown={(e) => {
           if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
             e.preventDefault();
-            send();
+            void send();
           }
         }}
         className="w-full resize-none bg-transparent text-sm placeholder:text-muted-foreground focus:outline-none"
@@ -146,11 +175,18 @@ export default function Composer({
           ref={fileInput}
           type="file"
           multiple
+          accept={COMPOSER_SUPPORTED_EXTENSIONS.join(",")}
+          aria-label="자료 파일 선택 (PDF, PPTX)"
           className="hidden"
           onChange={(e) => {
-            if (e.target.files) {
-              setFiles((prev) => [...prev, ...Array.from(e.target.files!)]);
+            const picked = Array.from(e.target.files ?? []);
+            if (picked.length > 0) {
+              setItems((prev) => planAttachmentIntake(prev, picked));
+              if (sendState.kind !== "processing") {
+                setSendState({ kind: "idle" });
+              }
             }
+            e.target.value = "";
           }}
         />
         <Button
@@ -173,7 +209,18 @@ export default function Composer({
           <Paperclip className="h-3.5 w-3.5" /> 자료 첨부
         </Button>
         <div className="flex-1" />
-        {disabled && canInterrupt ? (
+        {sending ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 gap-1 text-xs"
+            onClick={() => sendAbort.current?.abort()}
+            aria-label="전송 취소"
+            title="전송 요청을 취소합니다"
+          >
+            <StopCircle className="h-3.5 w-3.5" aria-hidden="true" /> 전송 취소
+          </Button>
+        ) : disabled && canInterrupt ? (
           <Button
             variant="destructive"
             size="sm"
@@ -191,16 +238,18 @@ export default function Composer({
             size="sm"
             className="h-7 gap-1 text-xs"
             disabled={!canSend}
-            onClick={send}
+            onClick={() => void send()}
+            aria-label={retrying ? "다시 보내기 (Cmd/Ctrl+Enter)" : "보내기 (Cmd/Ctrl+Enter)"}
             title="보내기 (Cmd/Ctrl+Enter)"
           >
-            <Send className="h-3.5 w-3.5" /> 보내기
+            <Send className="h-3.5 w-3.5" aria-hidden="true" />{" "}
+            {retrying ? "다시 보내기" : "보내기"}
           </Button>
         )}
       </div>
 
       <p className="mt-1.5 text-center text-[10px] leading-relaxed text-foreground/80">
-        파일을 여기로 끌어다 놓거나 자료 첨부로 올릴 수 있어요.
+        PDF와 PPTX를 여기로 끌어다 놓거나 자료 첨부로 올릴 수 있어요. 최대 8개, 파일당 10MB, 전체 25MB까지예요.
       </p>
     </div>
   );

--- a/packages/frontend/src/components/chat/ComposerAttachments.tsx
+++ b/packages/frontend/src/components/chat/ComposerAttachments.tsx
@@ -1,0 +1,79 @@
+import { Paperclip } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type {
+  IntakeItem,
+  IntakeRejection,
+} from "./attachment-intake";
+
+interface ComposerAttachmentsProps {
+  readonly items: readonly IntakeItem[];
+  readonly sending: boolean;
+  readonly onRemove: (index: number) => void;
+}
+
+export default function ComposerAttachments({
+  items,
+  sending,
+  onRemove,
+}: ComposerAttachmentsProps) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul
+      className="mb-2 flex flex-wrap gap-1.5"
+      aria-label="첨부 목록"
+      aria-busy={sending}
+      aria-live="polite"
+    >
+      {items.map((item, index) => (
+        <li
+          key={`${item.file.name}-${index}`}
+          className={cn(
+            "inline-flex items-center gap-1 rounded px-2 py-1 text-[11px]",
+            item.status === "ready"
+              ? "bg-muted text-muted-foreground"
+              : "bg-destructive/10 text-destructive",
+          )}
+        >
+          <Paperclip className="h-3 w-3" aria-hidden="true" />
+          <span className="max-w-[120px] truncate">{item.file.name}</span>
+          <span className="opacity-90">
+            {item.status === "ready"
+              ? sending
+                ? "보내는 중"
+                : "준비됨"
+              : rejectionLabel(item.reason)}
+          </span>
+          <button
+            type="button"
+            className="ml-0.5 text-muted-foreground hover:text-foreground disabled:opacity-40"
+            aria-label={`${item.file.name} 첨부 취소`}
+            disabled={sending}
+            onClick={() => onRemove(index)}
+          >
+            ×
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function rejectionLabel(reason: IntakeRejection): string {
+  switch (reason) {
+    case "unsupported_kind":
+      return "지원하지 않는 형식";
+    case "too_large":
+      return "파일당 10MB 초과";
+    case "count_exceeded":
+      return "최대 8개까지";
+    case "total_exceeded":
+      return "전체 25MB 초과";
+    default: {
+      const unreachable: never = reason;
+      return unreachable;
+    }
+  }
+}

--- a/packages/frontend/src/components/chat/ComposerAttachments.tsx
+++ b/packages/frontend/src/components/chat/ComposerAttachments.tsx
@@ -1,4 +1,5 @@
 import { Paperclip } from "lucide-react";
+import type { VisualSourceRole } from "@bg/shared";
 import { cn } from "@/lib/utils";
 import type {
   IntakeItem,
@@ -8,13 +9,15 @@ import type {
 interface ComposerAttachmentsProps {
   readonly items: readonly IntakeItem[];
   readonly sending: boolean;
-  readonly onRemove: (index: number) => void;
+  readonly onRemove: (id: string) => void;
+  readonly onRoleChange: (id: string, role: VisualSourceRole) => void;
 }
 
 export default function ComposerAttachments({
   items,
   sending,
   onRemove,
+  onRoleChange,
 }: ComposerAttachmentsProps) {
   if (items.length === 0) {
     return null;
@@ -27,11 +30,11 @@ export default function ComposerAttachments({
       aria-busy={sending}
       aria-live="polite"
     >
-      {items.map((item, index) => (
+      {items.map((item) => (
         <li
-          key={`${item.file.name}-${index}`}
+          key={item.id}
           className={cn(
-            "inline-flex items-center gap-1 rounded px-2 py-1 text-[11px]",
+            "inline-flex min-w-0 items-center gap-1 rounded px-2 py-1 text-xs max-[900px]:flex-wrap",
             item.status === "ready"
               ? "bg-muted text-muted-foreground"
               : "bg-destructive/10 text-destructive",
@@ -39,19 +42,26 @@ export default function ComposerAttachments({
         >
           <Paperclip className="h-3 w-3" aria-hidden="true" />
           <span className="max-w-[120px] truncate">{item.file.name}</span>
-          <span className="opacity-90">
-            {item.status === "ready"
-              ? sending
-                ? "보내는 중"
-                : "준비됨"
-              : rejectionLabel(item.reason)}
-          </span>
+          {item.status === "ready" ? (
+            <select
+              value={item.role}
+              disabled={sending}
+              onChange={(event) => onRoleChange(item.id, event.target.value === "immutable_reference" ? "immutable_reference" : "ordinary_content")}
+              aria-label={`${item.file.name} 역할`}
+              className="max-w-[152px] rounded border border-border bg-background px-1.5 py-1 text-xs text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent max-[900px]:min-h-11 max-[900px]:max-w-full max-[900px]:flex-1"
+            >
+              <option value="ordinary_content">일반 자료</option>
+              <option value="immutable_reference">수정하지 않는 시각 참조</option>
+            </select>
+          ) : (
+            <span className="opacity-90">{rejectionLabel(item.reason)}</span>
+          )}
           <button
             type="button"
-            className="ml-0.5 text-muted-foreground hover:text-foreground disabled:opacity-40"
+            className="ml-0.5 min-h-7 min-w-7 rounded text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-40 max-[900px]:min-h-11 max-[900px]:min-w-11"
             aria-label={`${item.file.name} 첨부 취소`}
             disabled={sending}
-            onClick={() => onRemove(index)}
+            onClick={() => onRemove(item.id)}
           >
             ×
           </button>

--- a/packages/frontend/src/components/chat/VisualSourceCandidates.tsx
+++ b/packages/frontend/src/components/chat/VisualSourceCandidates.tsx
@@ -1,0 +1,36 @@
+import { useMemo } from "react";
+import { FileImage, Globe2 } from "lucide-react";
+import type { FileInfo } from "@bg/shared";
+import { listExistingVisualSources } from "./visual-source-selection";
+
+export function VisualSourceCandidates({ files }: { readonly files: readonly FileInfo[] }) {
+  const sources = useMemo(() => listExistingVisualSources(files), [files]);
+  return (
+    <>
+    <div className="mb-2 rounded border border-border bg-muted/40 px-2.5 py-2 text-[11px] leading-relaxed">
+      {sources.length > 0 && (
+        <div>
+          <p className="mb-1 font-medium text-foreground">프로젝트 안의 시각 파일</p>
+          <ul className="max-h-28 space-y-1 overflow-y-auto overscroll-contain pr-1" aria-label="기존 프로젝트 시각 파일">
+            {sources.map((source) => (
+              <li key={source.rel_path} className="flex min-w-0 items-center gap-1.5 text-muted-foreground">
+                <FileImage className="h-3 w-3 shrink-0" aria-hidden="true" />
+                <span className="min-w-0 flex-1 truncate" title={source.rel_path}>{source.rel_path}</span>
+                <span className="shrink-0 rounded-full border border-border bg-background px-1.5">기존 파일 · 편집 가능</span>
+              </li>
+            ))}
+          </ul>
+          <p className="mt-1 text-foreground/80 [word-break:keep-all]">기존 파일은 이 화면에서 불변 참조로 바꾸지 않아요. 불변 원본이 필요하면 별도로 업로드하세요.</p>
+        </div>
+      )}
+      <p className="mt-1 flex items-start gap-1.5 text-foreground/80 [word-break:keep-all]">
+        <Globe2 className="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
+        URL·웹·스톡 이미지는 지원하지 않으며 네트워크에서 가져오거나 복사하지 않아요.
+      </p>
+    </div>
+    <p className="mt-1.5 break-words text-center text-[10px] leading-relaxed text-foreground/80 [word-break:keep-all]">
+      PDF와 PPTX를 올린 뒤 파일마다 일반 자료 또는 수정하지 않는 시각 참조를 선택하세요. 최대 8개, 파일당 10MB, 전체 25MB까지예요.
+    </p>
+    </>
+  );
+}

--- a/packages/frontend/src/components/chat/attachment-intake.ts
+++ b/packages/frontend/src/components/chat/attachment-intake.ts
@@ -1,3 +1,4 @@
+import type { VisualSourceRole } from "@bg/shared";
 import { ApiError } from "@/api/client";
 
 /**
@@ -20,12 +21,19 @@ export type IntakeRejection =
   | "total_exceeded";
 
 export type IntakeItem =
-  | { readonly status: "ready"; readonly file: File }
+  | { readonly id: string; readonly status: "ready"; readonly file: File; readonly role: VisualSourceRole }
   | {
+      readonly id: string;
       readonly status: "rejected";
       readonly file: File;
       readonly reason: IntakeRejection;
     };
+
+export type ReadyAttachmentSource = {
+  readonly id: string;
+  readonly file: File;
+  readonly role: VisualSourceRole;
+};
 
 export type SendOutcome =
   | { readonly kind: "cancelled" }
@@ -48,27 +56,43 @@ export function planAttachmentIntake(
       0,
     );
     const reason = rejectionFor(file, ready.length, readyBytes);
+    const id = crypto.randomUUID();
     items.push(
       reason === null
-        ? { status: "ready", file }
-        : { status: "rejected", file, reason },
+        ? { id, status: "ready", file, role: "ordinary_content" }
+        : { id, status: "rejected", file, reason },
     );
   }
   return items;
 }
 
-export function readyAttachmentFiles(
+export function readyAttachmentSources(items: readonly IntakeItem[]): readonly ReadyAttachmentSource[] {
+  return items.flatMap((item) => item.status === "ready" ? [{ id: item.id, file: item.file, role: item.role }] : []);
+}
+
+export function setAttachmentRole(
   items: readonly IntakeItem[],
-): readonly File[] {
-  return items.flatMap((item) =>
-    item.status === "ready" ? [item.file] : [],
-  );
+  id: string,
+  role: VisualSourceRole,
+): readonly IntakeItem[] {
+  return items.map((item) => item.id === id && item.status === "ready" ? { ...item, role } : item);
 }
 
 /**
  * An aborted request reports cancellation. Any other observed error stays
  * retryable without inferring server-side extraction progress.
  */
+export function visualSourceSendErrorCopy(error: unknown): string {
+  if (!(error instanceof ApiError)) return "요청을 보내지 못했어요. 잠시 후 다시 시도해 주세요.";
+  switch (error.code) {
+    case "invalid_attachments": return "첨부 자료를 확인할 수 없어요. 목록에서 제거한 뒤 다시 올려 주세요.";
+    case "invalid_visual_sources": return "시각 자료 역할 정보가 올바르지 않아요. 역할을 다시 선택해 주세요.";
+    case "unsupported_visual_source": return "URL·웹·스톡 자료는 지원하지 않아요. 로컬 PDF 또는 PPTX를 올려 주세요.";
+    case "session_busy": return "이미 작업이 진행 중이에요. 완료된 뒤 다시 보내 주세요.";
+    default: return "요청을 보내지 못했어요. 첨부 자료를 확인한 뒤 다시 시도해 주세요.";
+  }
+}
+
 export function resolveSendOutcome(error: unknown): SendOutcome {
   if (error instanceof DOMException && error.name === "AbortError") {
     return { kind: "cancelled" };

--- a/packages/frontend/src/components/chat/attachment-intake.ts
+++ b/packages/frontend/src/components/chat/attachment-intake.ts
@@ -1,0 +1,113 @@
+import { ApiError } from "@/api/client";
+
+/**
+ * Mirrors the backend intake contract for early feedback only. The backend
+ * remains authoritative, and composer-intake.test.ts pins supported kinds
+ * against the real extractor.
+ */
+export const COMPOSER_ATTACHMENT_LIMITS = {
+  maxCount: 8,
+  maxBytesPerFile: 10 * 1024 * 1024,
+  maxBytesTotal: 25 * 1024 * 1024,
+} as const;
+
+export const COMPOSER_SUPPORTED_EXTENSIONS = [".pdf", ".pptx"] as const;
+
+export type IntakeRejection =
+  | "unsupported_kind"
+  | "too_large"
+  | "count_exceeded"
+  | "total_exceeded";
+
+export type IntakeItem =
+  | { readonly status: "ready"; readonly file: File }
+  | {
+      readonly status: "rejected";
+      readonly file: File;
+      readonly reason: IntakeRejection;
+    };
+
+export type SendOutcome =
+  | { readonly kind: "cancelled" }
+  | {
+      readonly kind: "failed";
+      readonly code: string;
+      readonly message: string;
+    };
+
+/** Screens picked or dropped files into states the UI can truthfully show. */
+export function planAttachmentIntake(
+  current: readonly IntakeItem[],
+  incoming: readonly File[],
+): readonly IntakeItem[] {
+  const items = [...current];
+  for (const file of incoming) {
+    const ready = items.filter((item) => item.status === "ready");
+    const readyBytes = ready.reduce(
+      (total, item) => total + item.file.size,
+      0,
+    );
+    const reason = rejectionFor(file, ready.length, readyBytes);
+    items.push(
+      reason === null
+        ? { status: "ready", file }
+        : { status: "rejected", file, reason },
+    );
+  }
+  return items;
+}
+
+export function readyAttachmentFiles(
+  items: readonly IntakeItem[],
+): readonly File[] {
+  return items.flatMap((item) =>
+    item.status === "ready" ? [item.file] : [],
+  );
+}
+
+/**
+ * An aborted request reports cancellation. Any other observed error stays
+ * retryable without inferring server-side extraction progress.
+ */
+export function resolveSendOutcome(error: unknown): SendOutcome {
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return { kind: "cancelled" };
+  }
+  if (error instanceof ApiError) {
+    return {
+      kind: "failed",
+      code: error.code,
+      message: error.message,
+    };
+  }
+  return {
+    kind: "failed",
+    code: "unknown",
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+function rejectionFor(
+  file: File,
+  readyCount: number,
+  readyBytes: number,
+): IntakeRejection | null {
+  const name = file.name.toLowerCase();
+  if (
+    !COMPOSER_SUPPORTED_EXTENSIONS.some((extension) =>
+      name.endsWith(extension),
+    )
+  ) {
+    return "unsupported_kind";
+  }
+  if (file.size > COMPOSER_ATTACHMENT_LIMITS.maxBytesPerFile) {
+    return "too_large";
+  }
+  if (readyCount >= COMPOSER_ATTACHMENT_LIMITS.maxCount) {
+    return "count_exceeded";
+  }
+  if (readyBytes + file.size > COMPOSER_ATTACHMENT_LIMITS.maxBytesTotal) {
+    return "total_exceeded";
+  }
+  return null;
+}

--- a/packages/frontend/src/components/chat/blocks/UsageFooter.tsx
+++ b/packages/frontend/src/components/chat/blocks/UsageFooter.tsx
@@ -7,7 +7,10 @@ export default function UsageFooter({
 }) {
   const fmt = (n: number) => n.toLocaleString();
   return (
-    <div className="sticky bottom-0 -mx-3 -mb-4 border-t border-border bg-background/95 backdrop-blur px-3 py-1.5 flex items-center gap-3 text-[10px] text-muted-foreground font-mono">
+    <div
+      data-qa="usage-footer"
+      className="sticky bottom-0 -mx-3 -mb-4 border-t border-border bg-background/95 backdrop-blur px-3 py-1.5 flex items-center gap-3 text-[10px] text-muted-foreground font-mono"
+    >
       <span>in {fmt(usage.input)}</span>
       <span>out {fmt(usage.output)}</span>
       <span>cached {fmt(usage.cached)}</span>

--- a/packages/frontend/src/components/chat/useComposerPlaceholder.ts
+++ b/packages/frontend/src/components/chat/useComposerPlaceholder.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+
+const IDLE_PLACEHOLDER = "뭘 만들고 싶나요? 로컬 CLI라 응답은 조금 느려요...";
+const WAITING_PLACEHOLDERS = [
+  "로컬 CLI 워밍업 중...",
+  "Claude가 키보드를 두드리는 중...",
+  "토큰을 한 장 한 장 세는 중...",
+  "GPU가 기어를 올리는 소리가 들려요...",
+  "덱에 잉크를 바르는 중...",
+  "프롬프트를 천천히 음미하는 중...",
+  "로컬이라 좀 느립니다. 딴짓해도 돼요.",
+  "당신의 문장을 조립 중...",
+  "Claude가 스크롤을 읽는 중...",
+  "그림의 남은 한 조각을 찾는 중...",
+] as const;
+const WAITING_INTERVAL_MS = 2_400;
+
+export function useComposerPlaceholder(disabled: boolean): string {
+  const [waitingIndex, setWaitingIndex] = useState(0);
+
+  useEffect(() => {
+    if (!disabled) {
+      return;
+    }
+    setWaitingIndex(Math.floor(Math.random() * WAITING_PLACEHOLDERS.length));
+    const intervalId = window.setInterval(() => {
+      setWaitingIndex(
+        (current) => (current + 1) % WAITING_PLACEHOLDERS.length,
+      );
+    }, WAITING_INTERVAL_MS);
+    return () => window.clearInterval(intervalId);
+  }, [disabled]);
+
+  return disabled
+    ? (WAITING_PLACEHOLDERS[waitingIndex] ?? IDLE_PLACEHOLDER)
+    : IDLE_PLACEHOLDER;
+}

--- a/packages/frontend/src/components/chat/useComposerVisualSources.ts
+++ b/packages/frontend/src/components/chat/useComposerVisualSources.ts
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import type { VisualSourceRole } from "@bg/shared";
+import {
+  planAttachmentIntake,
+  readyAttachmentSources,
+  setAttachmentRole,
+  type IntakeItem,
+} from "./attachment-intake";
+
+export function useComposerVisualSources(onEdit: () => void) {
+  const [items, setItems] = useState<readonly IntakeItem[]>([]);
+  return {
+    items,
+    add(files: readonly File[]) {
+      setItems((current) => planAttachmentIntake(current, files));
+      onEdit();
+    },
+    remove(id: string) {
+      setItems((current) => current.filter((item) => item.id !== id));
+      onEdit();
+    },
+    setRole(id: string, role: VisualSourceRole) {
+      setItems((current) => setAttachmentRole(current, id, role));
+      onEdit();
+    },
+    clear() {
+      setItems([]);
+    },
+    ready() {
+      return readyAttachmentSources(items);
+    },
+  };
+}

--- a/packages/frontend/src/components/chat/visual-source-selection.ts
+++ b/packages/frontend/src/components/chat/visual-source-selection.ts
@@ -1,0 +1,20 @@
+import type { FileInfo } from "@bg/shared";
+
+export type ExistingVisualSource = {
+  readonly source_type: "existing_project_file";
+  readonly rel_path: string;
+  readonly status: "editable";
+  readonly sha256: string;
+};
+
+const VISUAL_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".pdf", ".pptx"] as const;
+
+export function listExistingVisualSources(files: readonly FileInfo[]): readonly ExistingVisualSource[] {
+  return files.flatMap((file) => {
+    const relative = file.rel_path.replaceAll("\\", "/");
+    const safe = relative.length > 0 && !relative.startsWith("/") && relative.split("/").every((part) => part.length > 0 && part !== "." && part !== "..");
+    const hash = file.hash;
+    if (!safe || typeof hash !== "string" || !/^[a-f0-9]{64}$/u.test(hash) || !VISUAL_EXTENSIONS.some((extension) => relative.toLowerCase().endsWith(extension))) return [];
+    return [{ source_type: "existing_project_file" as const, rel_path: relative, status: "editable" as const, sha256: hash }];
+  });
+}

--- a/packages/frontend/src/components/directions/DirectionCard.tsx
+++ b/packages/frontend/src/components/directions/DirectionCard.tsx
@@ -1,0 +1,128 @@
+import type { DesignDirectionSlot } from "@bg/shared";
+import { AlertCircle, LoaderCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type DirectionCardProps = {
+  readonly direction: DesignDirectionSlot;
+  readonly selected: boolean;
+  readonly selectable: boolean;
+  readonly onSelect: (directionId: string) => void;
+};
+
+export function DirectionCard({
+  direction,
+  selected,
+  selectable,
+  onSelect,
+}: DirectionCardProps) {
+  const pending = direction.status === "pending";
+  const styleFactsId = `direction-style-facts-${direction.order}`;
+  return (
+    <article
+      className={cn(
+        "min-w-0 overflow-hidden rounded-lg border bg-card",
+        selected ? "border-accent ring-2 ring-accent/20" : "border-border",
+      )}
+      aria-busy={pending}
+    >
+      <div className="aspect-video w-full bg-muted">
+        {direction.status === "ready" && direction.preview_url !== null ? (
+          <img
+            src={direction.preview_url}
+            alt={`${direction.title} 디자인 방향 미리보기`}
+            width={640}
+            height={360}
+            className="h-full w-full object-contain"
+          />
+        ) : (
+          <div className="grid h-full place-items-center px-5 text-center text-sm text-muted-foreground">
+            {pending ? (
+              <span className="inline-flex items-center gap-2">
+                <LoaderCircle className="h-4 w-4" aria-hidden="true" />
+                미리보기를 만들고 있어요
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-2">
+                <AlertCircle className="h-4 w-4" aria-hidden="true" />
+                {slotFailure(direction.status, direction.error)}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+      <div className="p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <h2 className="break-words text-sm font-semibold">{direction.title}</h2>
+            <p className="mt-1 break-words text-xs leading-relaxed text-muted-foreground [word-break:keep-all]">
+              {direction.summary}
+            </p>
+          </div>
+          <span className="shrink-0 rounded-full bg-muted px-2 py-1 font-mono text-[10px] text-muted-foreground">
+            {direction.order + 1}/3
+          </span>
+        </div>
+        <ul
+          id={styleFactsId}
+          className="mt-3 flex flex-wrap gap-1.5"
+          aria-label="스타일 특징"
+        >
+          {direction.style_facts.map((fact) => (
+            <li
+              key={fact}
+              className="max-w-full break-words rounded-full border border-border px-2 py-1 text-[11px]"
+            >
+              {fact}
+            </li>
+          ))}
+        </ul>
+        {direction.status === "ready" ? (
+          <Button
+            type="button"
+            variant={selected ? "secondary" : "outline"}
+            className={cn(
+              "mt-4 min-h-11 w-full",
+              selected && "disabled:opacity-100",
+            )}
+            aria-pressed={selected}
+            aria-describedby={styleFactsId}
+            disabled={!selectable || selected}
+            onClick={() => onSelect(direction.id)}
+          >
+            {selected ? "선택됨" : "이 방향 선택"}
+          </Button>
+        ) : direction.status === "failed" || direction.status === "cancelled" ? (
+          <p className="mt-4 flex min-h-11 items-center rounded-md border border-border bg-muted/50 px-3 text-xs leading-relaxed text-muted-foreground [word-break:keep-all]">
+            위의 다시 만들기에서 이 방향을 재시도할 수 있어요.
+          </p>
+        ) : null}
+      </div>
+    </article>
+  );
+}
+
+function slotFailure(
+  status: DesignDirectionSlot["status"],
+  error: string | null,
+): string {
+  if (error === "Direction generation was interrupted; retry unfinished directions.") {
+    return "앱이 다시 시작되어 생성을 마치지 못했어요.";
+  }
+  if (error === "Direction generation was cancelled; retry this direction.") {
+    return "요청에 따라 미리보기 생성을 취소했어요.";
+  }
+  switch (status) {
+    case "failed":
+    case "cancelled":
+      return "미리보기 생성 중 오류가 발생했어요.";
+    case "pending":
+      return "미리보기를 기다리고 있어요.";
+    case "ready":
+      return "미리보기가 준비됐어요.";
+    default: {
+      const unreachable: never = status;
+      return unreachable;
+    }
+  }
+}

--- a/packages/frontend/src/components/directions/DirectionStatusBar.tsx
+++ b/packages/frontend/src/components/directions/DirectionStatusBar.tsx
@@ -1,0 +1,85 @@
+import type { DesignDirectionState } from "@bg/shared";
+import { Compass, StopCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type DirectionStatusBarProps = {
+  readonly state: DesignDirectionState | null;
+  readonly cancelPending: boolean;
+  readonly onOpen: () => void;
+  readonly onCancel: () => void;
+};
+
+export function DirectionStatusBar({
+  state,
+  cancelPending,
+  onOpen,
+  onCancel,
+}: DirectionStatusBarProps) {
+  const selectedTitle =
+    state?.directions.find((direction) => direction.id === state.selected_id)?.title ?? null;
+  const loading = state?.status === "loading";
+  const currentStatus = statusLabel(state);
+  const fullStatus =
+    selectedTitle === null ? currentStatus : `${currentStatus} · 선택: ${selectedTitle}`;
+
+  return (
+    <div className="shrink-0 border-t border-border bg-muted/60 px-3 py-2">
+      <div className="flex min-w-0 items-center gap-2 max-[480px]:flex-wrap">
+        <Compass className="h-4 w-4 shrink-0 text-accent" aria-hidden="true" />
+        <p
+          className="min-w-0 flex-1 truncate text-xs text-foreground"
+          role="status"
+          aria-live="polite"
+          title={fullStatus}
+        >
+          <span className="font-medium">{currentStatus}</span>
+          {selectedTitle !== null ? (
+            <span className="text-muted-foreground"> · 선택: {selectedTitle}</span>
+          ) : null}
+        </p>
+        {loading ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="min-h-11 shrink-0"
+            disabled={cancelPending}
+            onClick={onCancel}
+          >
+            <StopCircle aria-hidden="true" />
+            {cancelPending ? "취소 요청 중" : "생성 취소"}
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="min-h-11 shrink-0 text-accent"
+          onClick={onOpen}
+        >
+          방향 보기
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function statusLabel(state: DesignDirectionState | null): string {
+  if (state === null) return "디자인 방향을 아직 만들지 않았어요";
+  switch (state.status) {
+    case "loading":
+      return "디자인 방향을 만들고 있어요";
+    case "ready":
+      return "디자인 방향 3개가 준비됐어요";
+    case "partial":
+      return "일부 디자인 방향이 준비됐어요";
+    case "failed":
+      return "디자인 방향 생성에 실패했어요";
+    case "cancelled":
+      return "디자인 방향 생성을 취소했어요";
+    default: {
+      const unreachable: never = state.status;
+      return unreachable;
+    }
+  }
+}

--- a/packages/frontend/src/components/directions/DirectionsView.tsx
+++ b/packages/frontend/src/components/directions/DirectionsView.tsx
@@ -1,0 +1,228 @@
+import type { DesignDirectionState } from "@bg/shared";
+import { Check, Compass, RotateCcw, StopCircle } from "lucide-react";
+import { ApiError } from "@/api/client";
+import { Button } from "@/components/ui/button";
+import { DirectionCard } from "./DirectionCard";
+import { directionActions, directionProgress } from "@/lib/design-direction-state";
+
+type DirectionsViewProps = {
+  readonly state: DesignDirectionState | null;
+  readonly recovering: boolean;
+  readonly actionPending: boolean;
+  readonly cancelPending: boolean;
+  readonly error: Error | null;
+  readonly onGenerate: () => void;
+  readonly onCancel: () => void;
+  readonly onRetry: () => void;
+  readonly onSelect: (directionId: string) => void;
+  readonly onUndo: () => void;
+};
+
+export function DirectionsView({
+  state,
+  recovering,
+  actionPending,
+  cancelPending,
+  error,
+  onGenerate,
+  onCancel,
+  onRetry,
+  onSelect,
+  onUndo,
+}: DirectionsViewProps) {
+  const actions = directionActions(state);
+  const selected =
+    state?.directions.find((direction) => direction.id === state.selected_id) ?? null;
+
+  if (recovering && state === null) {
+    return (
+      <DirectionShell busy>
+        <div className="grid min-h-full place-items-center px-4 text-sm text-muted-foreground">
+          저장된 디자인 방향을 불러오고 있어요.
+        </div>
+      </DirectionShell>
+    );
+  }
+
+  if (state === null) {
+    return (
+      <DirectionShell busy={actionPending}>
+        <div className="grid min-h-full place-items-center px-4 py-12 text-center">
+          <div className="max-w-md">
+            <Compass className="mx-auto mb-4 h-8 w-8 text-accent" aria-hidden="true" />
+            <h1 className="text-lg font-semibold">프로젝트의 디자인 방향을 정해요</h1>
+            <p className="mt-2 text-sm leading-relaxed text-muted-foreground [word-break:keep-all]">
+              현재 콘텐츠를 바탕으로 서로 다른 구성과 스타일의 미리보기 3개를 만들어요.
+            </p>
+            <Button
+              type="button"
+              variant="cta"
+              className="mt-6 min-h-11"
+              disabled={actionPending}
+              onClick={onGenerate}
+            >
+              방향 3개 생성
+            </Button>
+            <DirectionError error={error} />
+          </div>
+        </div>
+      </DirectionShell>
+    );
+  }
+
+  const progress = directionProgress(state);
+  const loading = state.status === "loading";
+
+  return (
+    <DirectionShell busy={loading || actionPending}>
+      <div className="mx-auto w-full max-w-[1440px] px-4 py-5 sm:px-6">
+        <header className="flex items-start justify-between gap-4 max-[600px]:flex-col">
+          <div className="min-w-0">
+            <h1 className="text-lg font-semibold">디자인 방향</h1>
+            <p className="mt-1 text-sm leading-relaxed text-muted-foreground [word-break:keep-all]">
+              {stateSummary(state, progress.resolved)}
+            </p>
+          </div>
+          {loading ? (
+            <Button
+              type="button"
+              variant="outline"
+              className="min-h-11 shrink-0"
+              disabled={cancelPending || !actions.canCancel}
+              onClick={onCancel}
+            >
+              <StopCircle aria-hidden="true" />
+              {cancelPending ? "취소 요청 중" : "생성 취소"}
+            </Button>
+          ) : actions.canRetry ? (
+            <Button
+              type="button"
+              variant="outline"
+              className="min-h-11 shrink-0"
+              disabled={actionPending}
+              onClick={onRetry}
+            >
+              <RotateCcw aria-hidden="true" />
+              실패한 방향 모두 다시 만들기
+            </Button>
+          ) : null}
+        </header>
+
+        {!loading ? <ContentOutline items={state.content_outline} /> : null}
+
+        <section
+          className="mt-5 grid min-w-0 grid-cols-3 gap-4 max-[900px]:grid-cols-2 max-[600px]:grid-cols-1"
+          aria-label="디자인 방향 후보"
+        >
+          {state.directions.map((direction) => (
+            <DirectionCard
+              key={direction.id}
+              direction={direction}
+              selected={state.selected_id === direction.id}
+              selectable={actions.canSelect && !actionPending}
+              onSelect={onSelect}
+            />
+          ))}
+        </section>
+
+        {!loading ? (
+          <div className="mt-5 flex min-h-14 items-center gap-3 rounded-lg border border-border bg-muted/50 px-4 py-2 max-[600px]:flex-wrap">
+            <Check className="h-4 w-4 shrink-0 text-accent" aria-hidden="true" />
+            <p className="min-w-0 flex-1 text-sm [word-break:keep-all]">
+              {selected === null
+                ? "선택한 방향이 없어요."
+                : `선택한 방향: ${selected.title} · 다음 생성에 이 방향을 적용해요.`}
+            </p>
+            {actions.canUndo ? (
+              <Button
+                type="button"
+                variant="ghost"
+                className="min-h-11 shrink-0"
+                disabled={actionPending}
+                onClick={onUndo}
+              >
+                선택 되돌리기
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+        <DirectionError error={error} />
+      </div>
+    </DirectionShell>
+  );
+}
+
+function DirectionShell({
+  busy,
+  children,
+}: {
+  readonly busy: boolean;
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <main
+      className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden bg-background max-[900px]:overflow-visible"
+      aria-busy={busy}
+    >
+      {children}
+    </main>
+  );
+}
+
+function ContentOutline({ items }: { readonly items: readonly string[] }) {
+  return (
+    <section className="mt-5 rounded-lg border border-border bg-muted/50 p-4">
+      <h2 className="text-xs font-medium text-muted-foreground">콘텐츠 구성</h2>
+      <ol className="mt-2 grid gap-1 text-sm min-[1000px]:grid-cols-2">
+        {items.map((item, index) => (
+          <li
+            key={`${index}-${item}`}
+            className="min-w-0 break-words [word-break:keep-all]"
+          >
+            <span className="mr-2 font-mono text-xs text-muted-foreground">{index + 1}</span>
+            {item}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function stateSummary(state: DesignDirectionState, resolved: number): string {
+  switch (state.status) {
+    case "loading":
+      return `3개 중 ${resolved}개 준비됨 · 완료된 방향부터 바로 확인할 수 있어요.`;
+    case "ready":
+      return "3개 방향이 모두 준비됐어요. 비교한 뒤 하나를 선택하세요.";
+    case "partial":
+      return "준비된 방향은 선택할 수 있어요. 실패한 방향은 한 번에 다시 만들 수 있어요.";
+    case "failed":
+      return "방향을 만들지 못했어요. 잠시 후 모두 다시 시도하세요.";
+    case "cancelled":
+      return "생성을 취소했어요. 이미 준비된 방향은 계속 선택할 수 있어요.";
+    default: {
+      const unreachable: never = state.status;
+      return unreachable;
+    }
+  }
+}
+
+function DirectionError({ error }: { readonly error: Error | null }) {
+  if (error === null) return null;
+  return (
+    <p role="alert" className="mt-4 text-sm text-destructive">
+      {boundedError(error)}
+    </p>
+  );
+}
+
+function boundedError(error: Error): string {
+  if (!(error instanceof ApiError)) return "요청을 처리하지 못했어요. 잠시 후 다시 시도하세요.";
+  if (error.code === "session_busy") return "채팅 작업이 끝난 뒤 다시 시도하세요.";
+  if (error.code === "operation_active" || error.code === "generation_conflict") {
+    return "이미 디자인 방향을 만들고 있어요.";
+  }
+  if (error.code === "revision_conflict") return "선택 상태가 바뀌었어요. 최신 상태에서 다시 시도하세요.";
+  if (error.code === "operation_not_active") return "이미 생성 작업이 끝났어요.";
+  return "디자인 방향 요청을 처리하지 못했어요. 잠시 후 다시 시도하세요.";
+}

--- a/packages/frontend/src/components/directions/DirectionsView.tsx
+++ b/packages/frontend/src/components/directions/DirectionsView.tsx
@@ -161,7 +161,7 @@ function DirectionShell({
 }) {
   return (
     <main
-      className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden bg-background max-[900px]:overflow-visible"
+      className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden bg-background"
       aria-busy={busy}
     >
       {children}

--- a/packages/frontend/src/components/export/ExportMenu.tsx
+++ b/packages/frontend/src/components/export/ExportMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Download,
@@ -46,7 +46,7 @@ const OPTIONS: Option[] = [
     key: "pdf-a4",
     format: "pdf",
     options: { pdf_paper: "a4" },
-    label: "PDF · A4 landscape (deck only)",
+    label: "PDF · A4 landscape",
     icon: FileType2,
     onlyForTypes: ["slide_deck"],
   },
@@ -54,7 +54,7 @@ const OPTIONS: Option[] = [
     key: "pdf-letter",
     format: "pdf",
     options: { pdf_paper: "letter" },
-    label: "PDF · Letter landscape (deck only)",
+    label: "PDF · Letter landscape",
     icon: FileType2,
     onlyForTypes: ["slide_deck"],
   },
@@ -62,7 +62,7 @@ const OPTIONS: Option[] = [
     key: "pdf-widescreen",
     format: "pdf",
     options: { pdf_paper: "widescreen-16x9" },
-    label: "PDF · 16:9 widescreen (deck only)",
+    label: "PDF · 16:9 widescreen",
     icon: FileType2,
     onlyForTypes: ["slide_deck"],
   },
@@ -70,7 +70,7 @@ const OPTIONS: Option[] = [
     key: "pptx-16x9",
     format: "pptx",
     options: { pptx_size: "16x9" },
-    label: "PowerPoint · 16:9 (deck only)",
+    label: "PowerPoint · 16:9",
     icon: Presentation,
     onlyForTypes: ["slide_deck"],
   },
@@ -78,22 +78,28 @@ const OPTIONS: Option[] = [
     key: "pptx-4x3",
     format: "pptx",
     options: { pptx_size: "4x3" },
-    label: "PowerPoint · 4:3 (deck only)",
+    label: "PowerPoint · 4:3",
     icon: Presentation,
     onlyForTypes: ["slide_deck"],
   },
   { key: "handoff", format: "handoff", label: "Developer handoff (.zip)", icon: PackagePlus },
 ];
 
-export default function ExportMenu({
-  projectId,
-  projectType,
-}: {
-  projectId: string;
-  projectType: ProjectType;
+export type ExportQualityGate = { readonly mustFixCount: number } | null;
+
+export default function ExportMenu({ projectId, projectType, qualityGate, onOpenQuality }: {
+  readonly projectId: string;
+  readonly projectType: ProjectType;
+  readonly qualityGate: ExportQualityGate;
+  readonly onOpenQuality: () => void;
 }) {
   const queryClient = useQueryClient();
   const pushToast = useUIStore((s) => s.pushToast);
+  const [open, setOpen] = useState(false);
+  const openQuality = () => {
+    setOpen(false);
+    onOpenQuality();
+  };
 
   // Poll while any job is still pending/running. Once everything settles to
   // succeeded/failed, polling stops and the list stays static until a new
@@ -150,14 +156,15 @@ export default function ExportMenu({
       const previous = lastStatusRef.current.get(job.id);
       lastStatusRef.current.set(job.id, job.status);
       if (job.status === "failed" && previous !== "failed") {
-        const looksLikeChromium = job.error_message
-          ?.toLowerCase()
-          .includes("chromium");
+        const looksLikeChromium = job.error_message?.toLowerCase().includes("chromium");
+        const auditFailed = isDesignAuditExportFailure(job);
         pushToast({
           title: `Export failed (${formatLabel(job.format)})`,
-          body: looksLikeChromium
-            ? 'Chromium is not installed. Open Settings → "Chromium for exports" → Install, then re-run the export.'
-            : (job.error_message ?? "Unknown error."),
+          body: auditFailed
+            ? "내보내기 전 품질 점검에서 고쳐야 할 문제가 발견됐어요."
+            : looksLikeChromium
+              ? 'Chromium is not installed. Open Settings → "Chromium for exports" → Install, then re-run the export.'
+              : (job.error_message ?? "Unknown error."),
           tone: "error",
         });
       }
@@ -165,20 +172,24 @@ export default function ExportMenu({
   }, [jobs, pushToast, jobsQuery.status]);
 
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
         <Button
           variant="outline"
           size="sm"
-          className="gap-1.5 max-[900px]:w-8 max-[900px]:justify-center max-[900px]:gap-0 max-[900px]:px-0 max-[900px]:text-[0px]"
+          className="gap-1.5 focus:ring-2 focus:ring-ring focus:ring-offset-1 max-[900px]:min-h-11 max-[900px]:min-w-11 max-[900px]:justify-center max-[900px]:gap-0 max-[900px]:px-0 max-[900px]:text-[0px]"
           aria-label="Export"
         >
           <Download className="h-3.5 w-3.5" /> Export
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-72">
+      <DropdownMenuContent data-export-menu-content align="end" className="z-[100] w-72">
         <DropdownMenuLabel>Export as</DropdownMenuLabel>
         <DropdownMenuSeparator />
+        {qualityGate !== null && <div className="mx-2 mb-2 rounded-md border border-destructive/30 bg-destructive/10 p-2">
+          <p className="text-pretty break-keep text-xs text-foreground">고쳐야 할 문제 {qualityGate.mustFixCount}개가 있어 내보내기를 {"시작할\u00A0수\u00A0없어요."}</p>
+          <Button type="button" variant="outline" size="sm" className="mt-2 h-8 w-full max-[900px]:min-h-11" onClick={openQuality}>품질 점검 열기</Button>
+        </div>}
         {OPTIONS.map((o) => {
           const wrongType =
             o.onlyForTypes && !o.onlyForTypes.includes(projectType);
@@ -190,6 +201,11 @@ export default function ExportMenu({
               disabled={disabled}
               onClick={(event) => {
                 if (disabled) return;
+                if (qualityGate !== null) {
+                  event.preventDefault();
+                  openQuality();
+                  return;
+                }
                 // Keep the dropdown open so the user can watch the status list.
                 event.preventDefault();
                 createMutation.mutate({ format: o.format, options: o.options });
@@ -209,6 +225,10 @@ export default function ExportMenu({
             </DropdownMenuItem>
           );
         })}
+        {jobs.some(isDesignAuditExportFailure) && <div className="mx-2 mt-2 rounded-md bg-warning/15 p-2">
+          <p className="break-keep text-xs">최근 내보내기가 품질 점검에서 중단됐어요.</p>
+          <Button type="button" variant="outline" size="sm" className="mt-2 h-8 w-full max-[900px]:min-h-11" onClick={openQuality}>품질 점검 열기</Button>
+        </div>}
         {jobs.length > 0 && (
           <>
             <DropdownMenuSeparator />
@@ -217,7 +237,10 @@ export default function ExportMenu({
               // Retry uses default options — see services/exports.ts
               // comment on enqueueProjectExport. The user can re-pick a
               // specific preset from the menu above if they need it.
-              onRetry={(format) => createMutation.mutate({ format })}
+              onRetry={(format) => {
+                if (qualityGate !== null) { openQuality(); return; }
+                createMutation.mutate({ format });
+              }}
               retryDisabled={createMutation.isPending}
             />
           </>
@@ -225,4 +248,8 @@ export default function ExportMenu({
       </DropdownMenuContent>
     </DropdownMenu>
   );
+}
+
+function isDesignAuditExportFailure(job: { readonly error_message: string | null; readonly latest_attempt: { readonly stop_reason: string | null } | null }): boolean {
+  return job.latest_attempt?.stop_reason === "validation_failed" && job.error_message?.startsWith("Design audit found ") === true;
 }

--- a/packages/frontend/src/components/export/ExportMenu.tsx
+++ b/packages/frontend/src/components/export/ExportMenu.tsx
@@ -27,69 +27,25 @@ import {
 } from "@/api/export";
 import { useUIStore } from "@/state/uiStore";
 import ExportStatusList from "./ExportStatusList";
+import {
+  buildExportMenuModel,
+  buildExportRetryRequest,
+} from "./export-options";
 
-interface Option {
-  /** Stable React key — also doubles as a click identifier. */
-  key: string;
-  format: ExportFormat;
-  options?: ExportOptions;
-  label: string;
-  icon: LucideIcon;
-  phase?: number;
-  /** Restrict the option to specific project types. Empty/undefined = all. */
-  onlyForTypes?: ProjectType[];
-}
-
-const OPTIONS: Option[] = [
-  { key: "html_zip", format: "html_zip", label: "HTML zip", icon: FileDown },
-  {
-    key: "pdf-a4",
-    format: "pdf",
-    options: { pdf_paper: "a4" },
-    label: "PDF · A4 landscape",
-    icon: FileType2,
-    onlyForTypes: ["slide_deck"],
-  },
-  {
-    key: "pdf-letter",
-    format: "pdf",
-    options: { pdf_paper: "letter" },
-    label: "PDF · Letter landscape",
-    icon: FileType2,
-    onlyForTypes: ["slide_deck"],
-  },
-  {
-    key: "pdf-widescreen",
-    format: "pdf",
-    options: { pdf_paper: "widescreen-16x9" },
-    label: "PDF · 16:9 widescreen",
-    icon: FileType2,
-    onlyForTypes: ["slide_deck"],
-  },
-  {
-    key: "pptx-16x9",
-    format: "pptx",
-    options: { pptx_size: "16x9" },
-    label: "PowerPoint · 16:9",
-    icon: Presentation,
-    onlyForTypes: ["slide_deck"],
-  },
-  {
-    key: "pptx-4x3",
-    format: "pptx",
-    options: { pptx_size: "4x3" },
-    label: "PowerPoint · 4:3",
-    icon: Presentation,
-    onlyForTypes: ["slide_deck"],
-  },
-  { key: "handoff", format: "handoff", label: "Developer handoff (.zip)", icon: PackagePlus },
-];
+const OPTION_ICON: Record<ExportFormat, LucideIcon> = {
+  html_zip: FileDown,
+  pdf: FileType2,
+  png: Download,
+  pptx: Presentation,
+  handoff: PackagePlus,
+};
 
 export type ExportQualityGate = { readonly mustFixCount: number } | null;
 
-export default function ExportMenu({ projectId, projectType, qualityGate, onOpenQuality }: {
+export default function ExportMenu({ projectId, projectType, projectOptionsJson, qualityGate, onOpenQuality }: {
   readonly projectId: string;
   readonly projectType: ProjectType;
+  readonly projectOptionsJson: string | null;
   readonly qualityGate: ExportQualityGate;
   readonly onOpenQuality: () => void;
 }) {
@@ -135,6 +91,7 @@ export default function ExportMenu({ projectId, projectType, qualityGate, onOpen
   });
 
   const jobs = jobsQuery.data ?? [];
+  const menuModel = buildExportMenuModel(projectType, projectOptionsJson);
 
   // Surface async failures via a toast — the createMutation onError only
   // catches synchronous create-call errors. Background pipeline failures
@@ -190,14 +147,18 @@ export default function ExportMenu({ projectId, projectType, qualityGate, onOpen
           <p className="text-pretty break-keep text-xs text-foreground">고쳐야 할 문제 {qualityGate.mustFixCount}개가 있어 내보내기를 {"시작할\u00A0수\u00A0없어요."}</p>
           <Button type="button" variant="outline" size="sm" className="mt-2 h-8 w-full max-[900px]:min-h-11" onClick={openQuality}>품질 점검 열기</Button>
         </div>}
-        {OPTIONS.map((o) => {
-          const wrongType =
-            o.onlyForTypes && !o.onlyForTypes.includes(projectType);
+        {!menuModel.ok && (
+          <p className="mx-2 rounded-md border border-warning/30 bg-warning/15 p-2 text-pretty break-keep text-xs">
+            {menuModel.message}
+          </p>
+        )}
+        {menuModel.options.map((option) => {
+          const Icon = OPTION_ICON[option.format];
           const disabled =
-            Boolean(o.phase) || wrongType || createMutation.isPending;
+            option.disabledReason !== undefined || createMutation.isPending;
           return (
             <DropdownMenuItem
-              key={o.key}
+              key={option.key}
               disabled={disabled}
               onClick={(event) => {
                 if (disabled) return;
@@ -208,20 +169,19 @@ export default function ExportMenu({ projectId, projectType, qualityGate, onOpen
                 }
                 // Keep the dropdown open so the user can watch the status list.
                 event.preventDefault();
-                createMutation.mutate({ format: o.format, options: o.options });
+                createMutation.mutate({
+                  format: option.format,
+                  options: option.options,
+                });
               }}
             >
-              <o.icon className="h-3.5 w-3.5" />
-              <span className="flex-1">{o.label}</span>
-              {o.phase ? (
-                <span className="text-[10px] text-muted-foreground">
-                  Phase {o.phase}
-                </span>
-              ) : wrongType ? (
+              <Icon className="h-3.5 w-3.5" />
+              <span className="flex-1">{option.label}</span>
+              {option.disabledReason === "deck_only" && (
                 <span className="text-[10px] text-muted-foreground">
                   deck only
                 </span>
-              ) : null}
+              )}
             </DropdownMenuItem>
           );
         })}
@@ -234,12 +194,16 @@ export default function ExportMenu({ projectId, projectType, qualityGate, onOpen
             <DropdownMenuSeparator />
             <ExportStatusList
               jobs={jobs}
-              // Retry uses default options — see services/exports.ts
-              // comment on enqueueProjectExport. The user can re-pick a
-              // specific preset from the menu above if they need it.
+              // Standard retries keep using default options — see
+              // services/exports.ts. Graphic PNG is the exact-size exception.
               onRetry={(format) => {
                 if (qualityGate !== null) { openQuality(); return; }
-                createMutation.mutate({ format });
+                const request = buildExportRetryRequest(
+                  projectType,
+                  format,
+                  menuModel,
+                );
+                if (request !== null) createMutation.mutate(request);
               }}
               retryDisabled={createMutation.isPending}
             />

--- a/packages/frontend/src/components/export/ExportStatusList.tsx
+++ b/packages/frontend/src/components/export/ExportStatusList.tsx
@@ -59,7 +59,7 @@ export default function ExportStatusList({
             <li
               key={j.id}
               className="flex items-center gap-2 px-1 text-xs"
-              title={j.error_message ?? undefined}
+              title={j.latest_attempt?.stop_reason === "validation_failed" && j.error_message?.startsWith("Design audit found ") ? "품질 점검에서 고쳐야 할 문제가 발견됐어요." : (j.error_message ?? undefined)}
             >
               <Icon className={iconClass} />
               <span className="flex-1 truncate">{formatLabel(j.format)}</span>

--- a/packages/frontend/src/components/export/export-options.ts
+++ b/packages/frontend/src/components/export/export-options.ts
@@ -1,0 +1,89 @@
+import {
+  type ExportFormat,
+  type ExportOptions,
+  type ProjectType,
+} from "@bg/shared";
+import { parseProjectGraphicCanvas } from "@/lib/graphic-project";
+
+export type ExportMenuOption = {
+  readonly key: string;
+  readonly format: ExportFormat;
+  readonly options?: ExportOptions;
+  readonly label: string;
+  readonly disabledReason?: "deck_only";
+};
+
+export type ExportMenuModel =
+  | { readonly ok: true; readonly options: readonly ExportMenuOption[] }
+  | {
+      readonly ok: false;
+      readonly options: readonly [];
+      readonly message: string;
+    };
+
+export type ExportRetryRequest = {
+  readonly format: ExportFormat;
+  readonly options?: ExportOptions;
+};
+
+export function buildExportRetryRequest(
+  projectType: ProjectType,
+  format: ExportFormat,
+  model: ExportMenuModel,
+): ExportRetryRequest | null {
+  if (projectType !== "graphic") return { format };
+  if (!model.ok) return null;
+  const matches = model.options.filter((option) => option.format === format);
+  const option = matches.length === 1 ? matches[0] : undefined;
+  if (option === undefined || option.options === undefined) return null;
+  return { format, options: option.options };
+}
+
+const STANDARD_OPTIONS = [
+  { key: "html_zip", format: "html_zip", label: "HTML zip" },
+  { key: "pdf-a4", format: "pdf", options: { pdf_paper: "a4" }, label: "PDF · A4 landscape" },
+  { key: "pdf-letter", format: "pdf", options: { pdf_paper: "letter" }, label: "PDF · Letter landscape" },
+  { key: "pdf-widescreen", format: "pdf", options: { pdf_paper: "widescreen-16x9" }, label: "PDF · 16:9 widescreen" },
+  { key: "pptx-16x9", format: "pptx", options: { pptx_size: "16x9" }, label: "PowerPoint · 16:9" },
+  { key: "pptx-4x3", format: "pptx", options: { pptx_size: "4x3" }, label: "PowerPoint · 4:3" },
+  { key: "handoff", format: "handoff", label: "Developer handoff (.zip)" },
+] as const satisfies readonly ExportMenuOption[];
+
+export function buildExportMenuModel(
+  projectType: ProjectType,
+  optionsJson: string | null,
+): ExportMenuModel {
+  if (projectType !== "graphic") {
+    return {
+      ok: true,
+      options: projectType === "slide_deck"
+        ? STANDARD_OPTIONS
+        : STANDARD_OPTIONS.map((option) =>
+            option.format === "pdf" || option.format === "pptx"
+              ? { ...option, disabledReason: "deck_only" as const }
+              : option,
+          ),
+    };
+  }
+  const canvas = parseProjectGraphicCanvas(projectType, optionsJson);
+  if (canvas === null) {
+    return {
+      ok: false,
+      options: [],
+      message: "저장된 그래픽 크기를 확인할 수 없어 PNG 내보내기를 시작할 수 없어요.",
+    };
+  }
+  return {
+    ok: true,
+    options: [{
+      key: "graphic-png",
+      format: "png",
+      options: {
+        png_width: canvas.width,
+        png_height: canvas.height,
+        png_dpr: 1,
+      },
+      label: `PNG · ${canvas.width}×${canvas.height}`,
+    }],
+  };
+}

--- a/packages/frontend/src/components/home/DeleteDesignSystemDialog.tsx
+++ b/packages/frontend/src/components/home/DeleteDesignSystemDialog.tsx
@@ -45,15 +45,17 @@ export default function DeleteDesignSystemDialog({
           <div className="h-10 w-10 rounded-md bg-destructive/10 text-destructive grid place-items-center mb-3">
             <AlertTriangle className="h-5 w-5" />
           </div>
-          <DialogTitle>
-            {hasBlocker ? "Can't delete yet" : `Delete "${systemName}"?`}
+          <DialogTitle className="break-keep leading-snug">
+            {hasBlocker
+              ? "아직 삭제할 수 없어요"
+              : `“${systemName}” 디자인 시스템을 삭제할까요?`}
           </DialogTitle>
-          <DialogDescription>
+          <DialogDescription className="break-keep">
             {hasBlocker
               ? blocker?.reason === "is_template"
-                ? "This is a seeded template design system and cannot be deleted."
-                : "Projects still use this design system. Reassign or archive them first."
-              : "This permanently removes the design system row, every preview card, and the canonical folder under ~/.burnguard/data/systems. This cannot be undone."}
+                ? "기본으로 제공되는 템플릿 디자인 시스템이라 삭제할 수 없어요."
+                : "이 디자인 시스템을 쓰는 프로젝트가 아직 있어요. 아래 프로젝트에서 다른 디자인 시스템을 고르거나 프로젝트를 보관 처리한 뒤 다시 시도해 주세요."
+              : "디자인 시스템 항목과 모든 미리보기 카드, ~/.burnguard/data/systems 아래 표준 폴더가 영구 삭제돼요. 되돌릴 수 없어요."}
           </DialogDescription>
         </DialogHeader>
 
@@ -74,7 +76,7 @@ export default function DeleteDesignSystemDialog({
             onClick={() => onOpenChange(false)}
             disabled={isPending}
           >
-            {hasBlocker ? "Close" : "Cancel"}
+            {hasBlocker ? "닫기" : "취소"}
           </Button>
           {!hasBlocker ? (
             <Button
@@ -82,7 +84,7 @@ export default function DeleteDesignSystemDialog({
               onClick={onConfirm}
               disabled={isPending}
             >
-              {isPending ? "Deleting…" : "Delete"}
+              {isPending ? "삭제하는 중..." : "삭제"}
             </Button>
           ) : null}
         </DialogFooter>

--- a/packages/frontend/src/components/home/DeleteProjectDialog.tsx
+++ b/packages/frontend/src/components/home/DeleteProjectDialog.tsx
@@ -29,9 +29,11 @@ export default function DeleteProjectDialog({
           <div className="h-10 w-10 rounded-md bg-destructive/10 text-destructive grid place-items-center mb-3">
             <AlertTriangle className="h-5 w-5" />
           </div>
-          <DialogTitle>Delete &ldquo;{projectName}&rdquo;?</DialogTitle>
-          <DialogDescription>
-            This permanently removes the project, its session history, attachments, and generated files. This cannot be undone.
+          <DialogTitle className="break-keep leading-snug">
+            &ldquo;{projectName}&rdquo; 프로젝트를 삭제할까요?
+          </DialogTitle>
+          <DialogDescription className="break-keep">
+            프로젝트와 대화 기록, 첨부 파일, 생성된 파일이 모두 영구 삭제돼요. 되돌릴 수 없어요.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="pt-2 border-t border-border">
@@ -40,14 +42,14 @@ export default function DeleteProjectDialog({
             onClick={() => onOpenChange(false)}
             disabled={isPending}
           >
-            Cancel
+            취소
           </Button>
           <Button
             variant="destructive"
             onClick={onConfirm}
             disabled={isPending}
           >
-            {isPending ? "Deleting…" : "Delete"}
+            {isPending ? "삭제하는 중..." : "삭제"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/packages/frontend/src/components/home/GraphicCanvasFields.tsx
+++ b/packages/frontend/src/components/home/GraphicCanvasFields.tsx
@@ -1,0 +1,78 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  GRAPHIC_PRESETS,
+  PROJECT_LABEL_CLASS,
+} from "@/lib/project-creation";
+
+export function GraphicCanvasFields({
+  width,
+  height,
+  disabled,
+  onChange,
+}: {
+  readonly width: number;
+  readonly height: number;
+  readonly disabled: boolean;
+  readonly onChange: (size: { readonly width: number; readonly height: number }) => void;
+}) {
+  return (
+    <fieldset className="space-y-3 border-t border-border pt-4">
+      <legend className="text-xs font-medium text-foreground/80">
+        그래픽 캔버스 · CSS px
+      </legend>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <label htmlFor="graphic-width" className={PROJECT_LABEL_CLASS}>
+            너비
+          </label>
+          <Input
+            id="graphic-width"
+            type="number"
+            inputMode="numeric"
+            min={320}
+            max={4096}
+            step={1}
+            value={width}
+            disabled={disabled}
+            onChange={(event) => onChange({ width: Number(event.target.value), height })}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <label htmlFor="graphic-height" className={PROJECT_LABEL_CLASS}>
+            높이
+          </label>
+          <Input
+            id="graphic-height"
+            type="number"
+            inputMode="numeric"
+            min={240}
+            max={4096}
+            step={1}
+            value={height}
+            disabled={disabled}
+            onChange={(event) => onChange({ width, height: Number(event.target.value) })}
+          />
+        </div>
+      </div>
+      <div className="grid grid-cols-3 gap-2">
+        {GRAPHIC_PRESETS.map((preset) => (
+          <Button
+            key={preset.label}
+            type="button"
+            variant="outline"
+            className="h-auto min-h-11 flex-col gap-0.5 px-2 text-xs"
+            disabled={disabled}
+            aria-label={`${preset.label} ${preset.width}×${preset.height}`}
+            onClick={() => onChange(preset)}
+          >
+            <span>{preset.label}</span>
+            <span className="font-mono text-[10px] text-foreground/70">
+              {preset.width}×{preset.height}
+            </span>
+          </Button>
+        ))}
+      </div>
+    </fieldset>
+  );
+}

--- a/packages/frontend/src/components/home/NewProjectPanel.tsx
+++ b/packages/frontend/src/components/home/NewProjectPanel.tsx
@@ -15,6 +15,7 @@ import { Input } from "@/components/ui/input";
 import ProjectBriefFields, {
   ToggleRow,
 } from "@/components/home/ProjectBriefFields";
+import { GraphicCanvasFields } from "@/components/home/GraphicCanvasFields";
 import {
   INITIAL_BRIEF_FORM,
   PROBLEM_MESSAGE,
@@ -32,6 +33,7 @@ export type { ProjectType };
 const TYPE_LABEL: Record<ProjectType, string> = {
   prototype: "새 프로토타입",
   slide_deck: "새 슬라이드 덱",
+  graphic: "새 그래픽",
   from_template: "템플릿으로 시작",
   other: "새 프로젝트",
 };
@@ -63,6 +65,7 @@ export default function NewProjectPanel({
     selectable,
   );
   const isTemplate = type === "from_template";
+  const isGraphic = type === "graphic";
 
   const createMutation = useMutation({
     mutationFn: (request: CreateProjectRequest) => createProject(request),
@@ -148,10 +151,24 @@ export default function NewProjectPanel({
             : "게시된 디자인 시스템만 목록에 나와요. 없이도 시작할 수 있어요."}
         </p>
 
+        {isGraphic && (
+          <GraphicCanvasFields
+            width={form.graphicWidth}
+            height={form.graphicHeight}
+            disabled={disabled}
+            onChange={(size) => setForm((current) => ({
+              ...current,
+              graphicWidth: size.width,
+              graphicHeight: size.height,
+            }))}
+          />
+        )}
+
         <ProjectBriefFields
           form={form}
           disabled={disabled}
           onChange={update}
+          showOutputSize={!isGraphic}
         />
 
         {type === "slide_deck" && (

--- a/packages/frontend/src/components/home/ProjectBriefFields.tsx
+++ b/packages/frontend/src/components/home/ProjectBriefFields.tsx
@@ -27,10 +27,12 @@ export default function ProjectBriefFields({
   form,
   disabled,
   onChange,
+  showOutputSize = true,
 }: {
   form: BriefForm;
   disabled: boolean;
   onChange: BriefFieldChange;
+  showOutputSize?: boolean;
 }) {
   return (
     <div className="space-y-3 border-t border-border pt-4">
@@ -96,14 +98,16 @@ export default function ProjectBriefFields({
         />
       </div>
 
-      <ChoiceField
-        id="brief-output-size"
-        label="출력 크기"
-        choices={OUTPUT_SIZE_CHOICES}
-        value={form.outputSize}
-        disabled={disabled}
-        onSelect={(v) => onChange("outputSize", v)}
-      />
+      {showOutputSize && (
+        <ChoiceField
+          id="brief-output-size"
+          label="출력 크기"
+          choices={OUTPUT_SIZE_CHOICES}
+          value={form.outputSize}
+          disabled={disabled}
+          onSelect={(v) => onChange("outputSize", v)}
+        />
+      )}
     </div>
   );
 }

--- a/packages/frontend/src/components/home/ProjectCard.tsx
+++ b/packages/frontend/src/components/home/ProjectCard.tsx
@@ -52,9 +52,9 @@ export default function ProjectCard(
         {props.isTemplate && (
           <Badge
             variant="outline"
-            className="absolute top-2 left-2 bg-background/95 text-[10px] uppercase tracking-wider"
+            className="absolute top-2 left-2 bg-background/95 text-[10px] tracking-wider"
           >
-            Template
+            템플릿
           </Badge>
         )}
         <div data-qa="project-card-details" className="p-3">
@@ -77,7 +77,7 @@ export default function ProjectCard(
                   e.stopPropagation();
                 }}
                 className="h-7 w-7 rounded-md bg-background/95 border border-border grid place-items-center text-muted-foreground hover:text-foreground shadow-app-1"
-                aria-label="Project actions"
+                aria-label={`${props.name} 옵션 메뉴`}
               >
                 <MoreHorizontal className="h-3.5 w-3.5" />
               </button>
@@ -91,7 +91,7 @@ export default function ProjectCard(
                 }}
               >
                 <Trash2 className="h-3.5 w-3.5" />
-                Delete
+                삭제
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/packages/frontend/src/components/home/ProjectCard.tsx
+++ b/packages/frontend/src/components/home/ProjectCard.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { MoreHorizontal, Trash2 } from "lucide-react";
+import { resolveThumbnailSource } from "./thumbnail-source";
 import { Badge } from "@/components/ui/badge";
 import {
   DropdownMenu,
@@ -13,6 +15,9 @@ import type { CardViewModel } from "./mappers";
 export default function ProjectCard(
   props: CardViewModel & { onDelete?: () => void },
 ) {
+  const [failedSource, setFailedSource] = useState<string | null>(null);
+  const thumbnailSource = resolveThumbnailSource(props.thumbnail, failedSource);
+
   return (
     <div className="group relative">
       <Link
@@ -20,15 +25,28 @@ export default function ProjectCard(
         className="block rounded-xl border border-border bg-card overflow-hidden hover:shadow-app-3 transition-shadow"
       >
         <div
+          data-qa="project-thumbnail"
+          data-state={thumbnailSource === null ? "fallback" : "image"}
           className={cn(
-            "h-[120px] grid place-items-center text-2xl",
+            "aspect-video grid place-items-center overflow-hidden text-2xl",
             props.tintClass,
           )}
         >
-          {props.emoji ? (
-            <span className="text-3xl">{props.emoji}</span>
+          {thumbnailSource === null ? (
+            props.emoji ? (
+              <span className="text-3xl">{props.emoji}</span>
+            ) : (
+              <div className="h-10 w-10 rounded bg-white/50 border border-border" />
+            )
           ) : (
-            <div className="h-10 w-10 rounded bg-white/50 border border-border" />
+            <img
+              src={thumbnailSource}
+              alt=""
+              loading="lazy"
+              decoding="async"
+              className="h-full w-full object-cover"
+              onError={() => setFailedSource(thumbnailSource)}
+            />
           )}
         </div>
         {props.isTemplate && (
@@ -39,7 +57,7 @@ export default function ProjectCard(
             Template
           </Badge>
         )}
-        <div className="p-3">
+        <div data-qa="project-card-details" className="p-3">
           <div className="text-sm font-medium text-foreground line-clamp-1">
             {props.name}
           </div>

--- a/packages/frontend/src/components/home/ProjectCardSection.tsx
+++ b/packages/frontend/src/components/home/ProjectCardSection.tsx
@@ -10,7 +10,10 @@ interface ProjectCardSectionProps {
   readonly isLoading: boolean;
   readonly error: Error | null;
   readonly emptyText: string;
+  readonly emptyHint: string;
   readonly onRetry: () => void;
+  readonly onClearQuery: () => void;
+  readonly onStartProject: () => void;
   readonly onDelete?: (card: CardViewModel) => void;
 }
 
@@ -21,16 +24,24 @@ export default function ProjectCardSection({
   isLoading,
   error,
   emptyText,
+  emptyHint,
   onRetry,
+  onClearQuery,
+  onStartProject,
   onDelete,
 }: ProjectCardSectionProps) {
   if (isLoading) {
     return (
       <div
         aria-live="polite"
-        className="rounded-xl border border-dashed border-border bg-card/50 p-16 text-center text-sm text-muted-foreground"
+        className="rounded-xl border border-dashed border-border bg-card/50 p-16 text-center"
       >
-        프로젝트를 불러오는 중입니다.
+        <p className="text-sm font-medium text-foreground">
+          프로젝트를 불러오는 중이에요.
+        </p>
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+          잠시만 기다려 주세요.
+        </p>
       </div>
     );
   }
@@ -41,8 +52,11 @@ export default function ProjectCardSection({
         role="alert"
         className="rounded-xl border border-destructive/30 bg-destructive/5 p-10 text-center"
       >
-        <p className="text-sm text-destructive">
-          프로젝트를 불러오지 못했습니다.
+        <p className="text-sm font-medium text-foreground">
+          프로젝트를 불러오지 못했어요.
+        </p>
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+          로컬 서버가 켜져 있는지 확인한 뒤 다시 시도해 주세요.
         </p>
         <Button className="mt-4" variant="outline" onClick={onRetry}>
           다시 시도
@@ -55,9 +69,15 @@ export default function ProjectCardSection({
     return (
       <div
         aria-live="polite"
-        className="rounded-xl border border-dashed border-border bg-card/50 p-16 text-center text-sm text-muted-foreground"
+        className="rounded-xl border border-dashed border-border bg-card/50 p-16 text-center"
       >
-        {emptyText}
+        <p className="text-sm font-medium text-foreground">{emptyText}</p>
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+          {emptyHint}
+        </p>
+        <Button className="mt-4" variant="cta" onClick={onStartProject}>
+          새 프로젝트 만들기
+        </Button>
       </div>
     );
   }
@@ -66,9 +86,17 @@ export default function ProjectCardSection({
     return (
       <div
         aria-live="polite"
-        className="rounded-xl border border-dashed border-border bg-card/50 p-16 text-center text-sm text-muted-foreground"
+        className="rounded-xl border border-dashed border-border bg-card/50 p-16 text-center"
       >
-        ‘{query.trim()}’와 일치하는 프로젝트가 없습니다.
+        <p className="text-sm font-medium text-foreground">
+          ‘{query.trim()}’에 대한 검색 결과가 없어요.
+        </p>
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+          검색어를 지우면 전체 목록으로 돌아가요.
+        </p>
+        <Button className="mt-4" variant="outline" onClick={onClearQuery}>
+          검색어 지우기
+        </Button>
       </div>
     );
   }

--- a/packages/frontend/src/components/home/ProjectCardSection.tsx
+++ b/packages/frontend/src/components/home/ProjectCardSection.tsx
@@ -1,0 +1,87 @@
+import { Button } from "@/components/ui/button";
+import CardGrid from "./CardGrid";
+import type { CardViewModel } from "./mappers";
+import ProjectCard from "./ProjectCard";
+
+interface ProjectCardSectionProps {
+  readonly cards: readonly CardViewModel[];
+  readonly sourceCount: number;
+  readonly query: string;
+  readonly isLoading: boolean;
+  readonly error: Error | null;
+  readonly emptyText: string;
+  readonly onRetry: () => void;
+  readonly onDelete?: (card: CardViewModel) => void;
+}
+
+export default function ProjectCardSection({
+  cards,
+  sourceCount,
+  query,
+  isLoading,
+  error,
+  emptyText,
+  onRetry,
+  onDelete,
+}: ProjectCardSectionProps) {
+  if (isLoading) {
+    return (
+      <div
+        aria-live="polite"
+        className="rounded-xl border border-dashed border-border bg-card/50 p-16 text-center text-sm text-muted-foreground"
+      >
+        프로젝트를 불러오는 중입니다.
+      </div>
+    );
+  }
+
+  if (error !== null) {
+    return (
+      <div
+        role="alert"
+        className="rounded-xl border border-destructive/30 bg-destructive/5 p-10 text-center"
+      >
+        <p className="text-sm text-destructive">
+          프로젝트를 불러오지 못했습니다.
+        </p>
+        <Button className="mt-4" variant="outline" onClick={onRetry}>
+          다시 시도
+        </Button>
+      </div>
+    );
+  }
+
+  if (sourceCount === 0) {
+    return (
+      <div
+        aria-live="polite"
+        className="rounded-xl border border-dashed border-border bg-card/50 p-16 text-center text-sm text-muted-foreground"
+      >
+        {emptyText}
+      </div>
+    );
+  }
+
+  if (cards.length === 0) {
+    return (
+      <div
+        aria-live="polite"
+        className="rounded-xl border border-dashed border-border bg-card/50 p-16 text-center text-sm text-muted-foreground"
+      >
+        ‘{query.trim()}’와 일치하는 프로젝트가 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <CardGrid>
+      {cards.map((card) => (
+        <ProjectCard
+          key={card.id}
+          {...card}
+          onDelete={onDelete ? () => onDelete(card) : undefined}
+        />
+      ))}
+    </CardGrid>
+  );
+}

--- a/packages/frontend/src/components/home/mappers.ts
+++ b/packages/frontend/src/components/home/mappers.ts
@@ -36,6 +36,7 @@ export function filterHomeCards(
 const PROJECT_TINTS: Record<string, string> = {
   prototype: "bg-rose-100",
   slide_deck: "bg-slate-100",
+  graphic: "bg-sky-100",
   from_template: "bg-blue-100",
   other: "bg-stone-100",
 };

--- a/packages/frontend/src/components/home/mappers.ts
+++ b/packages/frontend/src/components/home/mappers.ts
@@ -1,4 +1,8 @@
-import type { DesignSystemSummary, ProjectSummary } from "@bg/shared";
+import type {
+  DesignSystemStatus,
+  DesignSystemSummary,
+  ProjectSummary,
+} from "@bg/shared";
 import { formatRelativeDay, projectTypeLabel } from "@/lib/format";
 
 /**
@@ -38,6 +42,12 @@ const PROJECT_TINTS: Record<string, string> = {
 
 const SYSTEM_TINTS = ["bg-amber-100", "bg-sky-100", "bg-emerald-100", "bg-violet-100"];
 
+const SYSTEM_STATUS_SUFFIX: Record<DesignSystemStatus, string> = {
+  draft: "디자인 시스템 · 초안",
+  review: "디자인 시스템 · 검토 중",
+  published: "디자인 시스템",
+};
+
 export function projectToCard(p: ProjectSummary): CardViewModel {
   const name = stripInternalProjectTag(p.name);
   return {
@@ -52,8 +62,7 @@ export function projectToCard(p: ProjectSummary): CardViewModel {
 }
 
 export function systemToCard(s: DesignSystemSummary, index = 0): CardViewModel {
-  const statusSuffix =
-    s.status === "published" ? "Design system" : `Design system · ${capitalize(s.status)}`;
+  const statusSuffix = SYSTEM_STATUS_SUFFIX[s.status];
   return {
     id: s.id,
     name: s.name,
@@ -63,10 +72,6 @@ export function systemToCard(s: DesignSystemSummary, index = 0): CardViewModel {
     thumbnail: s.thumbnail_path,
     isTemplate: s.is_template,
   };
-}
-
-function capitalize(s: string): string {
-  return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
 function stripInternalProjectTag(name: string): string {

--- a/packages/frontend/src/components/home/mappers.ts
+++ b/packages/frontend/src/components/home/mappers.ts
@@ -16,6 +16,19 @@ export interface CardViewModel {
   isTemplate?: boolean;
 }
 
+export function filterHomeCards(
+  cards: readonly CardViewModel[],
+  query: string,
+): readonly CardViewModel[] {
+  const normalizedQuery = normalizeSearchText(query);
+  if (normalizedQuery.length === 0) {
+    return cards;
+  }
+  return cards.filter((card) =>
+    normalizeSearchText(card.name).includes(normalizedQuery),
+  );
+}
+
 const PROJECT_TINTS: Record<string, string> = {
   prototype: "bg-rose-100",
   slide_deck: "bg-slate-100",
@@ -58,4 +71,12 @@ function capitalize(s: string): string {
 
 function stripInternalProjectTag(name: string): string {
   return name.replace(/^\[burnguard:[^\]]+\]\s*/, "");
+}
+
+function normalizeSearchText(value: string): string {
+  return value
+    .normalize("NFC")
+    .toLocaleLowerCase("ko-KR")
+    .trim()
+    .replace(/\s+/gu, " ");
 }

--- a/packages/frontend/src/components/home/thumbnail-source.ts
+++ b/packages/frontend/src/components/home/thumbnail-source.ts
@@ -1,0 +1,12 @@
+/**
+ * Picks the image URL a card should render, or null when the deterministic
+ * tint/emoji placeholder must be used instead. A URL that differs from the one
+ * that previously failed is retried, so a regenerated thumbnail recovers.
+ */
+export function resolveThumbnailSource(
+  thumbnail: string | null | undefined,
+  failedSource: string | null,
+): string | null {
+  if (!thumbnail) return null;
+  return thumbnail === failedSource ? null : thumbnail;
+}

--- a/packages/frontend/src/components/layout/AppShell.tsx
+++ b/packages/frontend/src/components/layout/AppShell.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import { useLocation } from "react-router-dom";
+import { cn } from "@/lib/utils";
 import Sidebar from "./Sidebar";
 import TopBar from "./TopBar";
 
@@ -8,12 +9,31 @@ export default function AppShell({ children }: { children: ReactNode }) {
   const isHome = location.pathname === "/";
   const isProject = location.pathname.startsWith("/projects/");
 
+  // The project route is an app surface, not a document: it is capped to the
+  // viewport so the top bar and every panel header stay put and each pane owns
+  // its own scrollport. Document-shaped routes (home, settings, systems) keep
+  // page scrolling.
   return (
-    <div className="min-h-screen bg-background text-foreground flex flex-col">
+    <div
+      className={cn(
+        "bg-background text-foreground flex flex-col",
+        isProject ? "h-dvh overflow-hidden" : "min-h-screen",
+      )}
+    >
       {!isHome && !isProject && <TopBar />}
-      <div className="flex min-h-0 flex-1 max-[900px]:flex-col max-[900px]:overflow-y-auto">
+      <div
+        className={cn(
+          "flex min-h-0 flex-1 max-[900px]:flex-col",
+          isProject ? "overflow-hidden" : "max-[900px]:overflow-y-auto",
+        )}
+      >
         {isHome && <Sidebar />}
-        <main className="min-w-0 flex-1 max-[900px]:order-1 flex flex-col">
+        <main
+          className={cn(
+            "min-w-0 flex-1 max-[900px]:order-1 flex flex-col",
+            isProject && "min-h-0 overflow-hidden",
+          )}
+        >
           {children}
         </main>
       </div>

--- a/packages/frontend/src/components/layout/AppShell.tsx
+++ b/packages/frontend/src/components/layout/AppShell.tsx
@@ -11,9 +11,11 @@ export default function AppShell({ children }: { children: ReactNode }) {
   return (
     <div className="min-h-screen bg-background text-foreground flex flex-col">
       {!isHome && !isProject && <TopBar />}
-      <div className="flex-1 flex min-h-0">
+      <div className="flex min-h-0 flex-1 max-[900px]:flex-col max-[900px]:overflow-y-auto">
         {isHome && <Sidebar />}
-        <main className="flex-1 min-w-0 flex flex-col">{children}</main>
+        <main className="min-w-0 flex-1 max-[900px]:order-1 flex flex-col">
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/packages/frontend/src/components/layout/Sidebar.tsx
+++ b/packages/frontend/src/components/layout/Sidebar.tsx
@@ -56,7 +56,7 @@ export default function Sidebar() {
   const systems = systemsQuery.data ?? [];
 
   return (
-    <aside className="flex w-[360px] shrink-0 flex-col border-r border-border bg-background">
+    <aside className="flex w-[360px] shrink-0 flex-col border-r border-border bg-background max-[900px]:order-2 max-[900px]:w-full max-[900px]:border-b max-[900px]:border-r-0">
       <header className="p-6 pb-4">
         <div className="flex items-center gap-3">
           <div className="grid h-9 w-9 place-items-center rounded-md bg-accent/15 text-accent">

--- a/packages/frontend/src/components/layout/Sidebar.tsx
+++ b/packages/frontend/src/components/layout/Sidebar.tsx
@@ -15,6 +15,13 @@ const TYPES: Array<{ id: ProjectType; label: string }> = [
   { id: "other", label: "기타" },
 ];
 
+/**
+ * The seeded default display name is app chrome rather than user data,
+ * so it is shown in Korean. Any name the user actually set is rendered
+ * verbatim.
+ */
+const DEFAULT_DISPLAY_NAME = "You";
+
 const FALLBACK_SETTINGS: SettingsSummary = {
   user: { id: "local", display_name: "You" },
   app_version: "0.4.0",
@@ -54,6 +61,10 @@ export default function Sidebar() {
 
   const settings = settingsQuery.data ?? FALLBACK_SETTINGS;
   const systems = systemsQuery.data ?? [];
+  const displayName =
+    settings.user.display_name === DEFAULT_DISPLAY_NAME
+      ? "나"
+      : settings.user.display_name;
 
   return (
     <aside className="flex w-[360px] shrink-0 flex-col border-r border-border bg-background max-[900px]:order-2 max-[900px]:w-full max-[900px]:border-b max-[900px]:border-r-0">
@@ -110,9 +121,7 @@ export default function Sidebar() {
       <footer className="border-t border-border p-4">
         <div className="text-xs text-foreground/70">
           사용자{" "}
-          <span className="text-foreground">
-            {settings.user.display_name}
-          </span>
+          <span className="text-foreground">{displayName}</span>
         </div>
         <div className="mt-1 flex items-center gap-3">
           <button

--- a/packages/frontend/src/components/layout/Sidebar.tsx
+++ b/packages/frontend/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import { useUIStore } from "@/state/uiStore";
 const TYPES: Array<{ id: ProjectType; label: string }> = [
   { id: "prototype", label: "프로토타입" },
   { id: "slide_deck", label: "슬라이드 덱" },
+  { id: "graphic", label: "그래픽" },
   { id: "from_template", label: "템플릿" },
   { id: "other", label: "기타" },
 ];
@@ -92,13 +93,15 @@ export default function Sidebar() {
         </div>
       </header>
 
-      <nav className="flex gap-0.5 border-b border-border px-4">
+      <nav aria-label="새 프로젝트 유형" className="flex min-h-11 gap-0.5 overflow-x-auto border-b border-border px-4 [scrollbar-width:thin]">
         {TYPES.map((t) => (
           <button
             key={t.id}
+            type="button"
+            aria-pressed={activeType === t.id}
             onClick={() => setActiveType(t.id)}
             className={[
-              "px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
+              "min-h-11 shrink-0 whitespace-nowrap px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
               activeType === t.id
                 ? "border-foreground text-foreground"
                 : "border-transparent text-foreground/70 hover:text-foreground",

--- a/packages/frontend/src/components/modes/ModePanel.tsx
+++ b/packages/frontend/src/components/modes/ModePanel.tsx
@@ -13,6 +13,7 @@ import EditPanel from "./EditPanel";
 import SelectorReadOnlyPanel from "./SelectorReadOnlyPanel";
 import TweaksPanel from "./TweaksPanel";
 import type { TweakChangePreview } from "./TweaksPanel";
+import QualityPanel, { type QualityPanelBinding } from "./QualityPanel";
 
 /**
  * Right-side mode pane. Renders nothing when no mode is active so the canvas
@@ -50,6 +51,7 @@ export default function ModePanel({
   onUndoDraw,
   onRedoDraw,
   onClearDraw,
+  quality,
 }: {
   mode: CanvasMode | null;
   selection: SelectedNode | null;
@@ -84,11 +86,12 @@ export default function ModePanel({
   onUndoDraw: () => void;
   onRedoDraw: () => void;
   onClearDraw: () => void;
+  quality: QualityPanelBinding;
 }) {
   if (!mode) return null;
 
   return (
-    <aside className="w-[320px] shrink-0 border-l border-border bg-background flex flex-col min-h-0 overflow-hidden max-[900px]:w-full max-[900px]:max-h-[48vh] max-[900px]:border-l-0 max-[900px]:border-t">
+    <aside className="w-[320px] shrink-0 border-l border-border bg-background flex flex-col min-h-0 overflow-hidden max-[900px]:w-full max-[900px]:max-h-[48vh] max-[900px]:shrink max-[900px]:border-l-0 max-[900px]:border-t">
       {mode === "select" && (
         <SelectorReadOnlyPanel
           selection={selection}
@@ -124,6 +127,7 @@ export default function ModePanel({
           onClear={onClearEdit}
         />
       )}
+      {mode === "quality" && <QualityPanel quality={quality} />}
       {mode === "draw" && (
         <DrawPanel
           tool={drawTool}

--- a/packages/frontend/src/components/modes/QualityFindingCard.tsx
+++ b/packages/frontend/src/components/modes/QualityFindingCard.tsx
@@ -1,0 +1,47 @@
+import type { DesignAuditFinding } from "@bg/shared";
+import { AlertTriangle, Eye, FileCode2, ShieldCheck, Wrench } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { designAuditActionAvailability, type DesignAuditActionContext } from "@/lib/design-audit-state";
+import { DESIGN_AUDIT_ACTION_COPY, DESIGN_AUDIT_CHECK_COPY } from "./design-audit-copy";
+
+export type RevealResult = "found" | "not_found" | null;
+
+export default function QualityFindingCard({ finding, actionContext, revealResult, onOpenFile, onReveal, onApplySafeFix }: {
+  readonly finding: DesignAuditFinding;
+  readonly actionContext: DesignAuditActionContext;
+  readonly revealResult: RevealResult;
+  readonly onOpenFile: (finding: DesignAuditFinding) => void;
+  readonly onReveal: (finding: DesignAuditFinding) => void;
+  readonly onApplySafeFix: (finding: DesignAuditFinding) => void;
+}) {
+  const actions = designAuditActionAvailability(finding, actionContext);
+  const mustFix = finding.severity === "must_fix";
+  return (
+    <article className="min-w-0 rounded-md border border-border bg-background p-3">
+      <div className="flex items-start gap-2">
+        <span className={mustFix ? "mt-0.5 text-destructive" : "mt-0.5 text-warning"} aria-hidden="true">
+          {mustFix ? <AlertTriangle className="h-4 w-4" /> : <Wrench className="h-4 w-4" />}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-semibold">{DESIGN_AUDIT_CHECK_COPY[finding.check_code]}</div>
+          <div className="mt-0.5 text-[11px] text-muted-foreground">{mustFix ? "고쳐야 할 문제" : "권장 개선"}</div>
+        </div>
+      </div>
+      <p className="mt-2 break-keep text-xs leading-relaxed">{DESIGN_AUDIT_ACTION_COPY[finding.targeted_action]}</p>
+      <div className="mt-2 min-w-0 rounded bg-muted px-2 py-1.5 font-mono text-[10px] leading-relaxed text-muted-foreground" title={finding.evidence}>
+        <span className="block font-sans font-medium text-foreground">검사 근거</span>
+        <span className="block max-h-12 overflow-hidden break-words">{finding.evidence}</span>
+        {(finding.measured !== undefined || finding.threshold !== undefined) && <span className="mt-1 block">측정 {finding.measured ?? "-"} / 기준 {finding.threshold ?? "-"}</span>}
+      </div>
+      <div className="mt-2 min-w-0 truncate font-mono text-[10px] text-muted-foreground" title={`${finding.source.rel_path}${finding.source.node_bg_id ? ` · ${finding.source.node_bg_id}` : ""}`}>
+        {finding.source.rel_path}{finding.source.node_bg_id ? ` · ${finding.source.node_bg_id}` : " · 강조할 위치 정보 없음"}
+      </div>
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        {actions.canOpenFile && <Button type="button" variant="outline" size="sm" className="h-8 px-2 max-[900px]:min-h-11" onClick={() => onOpenFile(finding)}><FileCode2 />파일 열기</Button>}
+        {actions.canReveal && <Button type="button" variant="outline" size="sm" className="h-8 px-2 max-[900px]:min-h-11" onClick={() => onReveal(finding)}><Eye />위치 보기</Button>}
+        {finding.safe_fix && <Button type="button" variant="outline" size="sm" className="h-8 px-2 max-[900px]:min-h-11" disabled={!actions.canApplySafeFix} title={!actionContext.current ? "현재 결과가 아니어서 안전 수정을 적용할 수 없어요" : actionContext.running ? "검사가 끝난 뒤 안전 수정을 적용할 수 있어요" : actions.applying ? "안전 수정을 적용하고 있어요" : actionContext.pendingFindingId !== null ? "다른 안전 수정을 적용하고 있어요" : undefined} onClick={() => onApplySafeFix(finding)}><ShieldCheck />{actions.applying ? "적용 중" : "안전 수정 적용"}</Button>}
+      </div>
+      {revealResult !== null && <p className="mt-2 break-keep text-[11px] text-muted-foreground">{revealResult === "found" ? "캔버스에서 위치를 강조했어요." : "현재 렌더링에서 위치를 찾지 못했어요."}</p>}
+    </article>
+  );
+}

--- a/packages/frontend/src/components/modes/QualityPanel.tsx
+++ b/packages/frontend/src/components/modes/QualityPanel.tsx
@@ -1,0 +1,98 @@
+import type { DesignAuditFinding } from "@bg/shared";
+import { AlertCircle, CircleHelp, Loader2, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { designAuditControlAvailability, groupDesignAuditResult, type DesignAuditActionContext, type DesignAuditViewState } from "@/lib/design-audit-state";
+import QualityFindingCard, { type RevealResult } from "./QualityFindingCard";
+import { DESIGN_AUDIT_CHECK_COPY, DESIGN_AUDIT_ERROR_COPY, DESIGN_AUDIT_STATUS_COPY, DESIGN_AUDIT_UNKNOWN_COPY } from "./design-audit-copy";
+
+export type QualityPanelBinding = {
+  readonly state: DesignAuditViewState;
+  readonly pendingFindingId: string | null;
+  readonly focusedFindingId: string | null;
+  readonly revealResult: RevealResult;
+  readonly onRetry: () => void;
+  readonly onOpenFile: (finding: DesignAuditFinding) => void;
+  readonly onReveal: (finding: DesignAuditFinding) => void;
+  readonly onApplySafeFix: (finding: DesignAuditFinding) => void;
+};
+
+export default function QualityPanel({ quality }: { readonly quality: QualityPanelBinding }) {
+  const running = "running" in quality.state && quality.state.running;
+  const report = reportFromState(quality.state);
+  const current = !running && (quality.state.kind === "error_warm" ? quality.state.current : quality.state.kind === "must_fix" || quality.state.kind === "recommended" || quality.state.kind === "ready");
+  const actionContext: DesignAuditActionContext = { current, running, pendingFindingId: quality.pendingFindingId };
+  const controls = designAuditControlAvailability(actionContext);
+  const grouped = report === null ? null : groupDesignAuditResult(report);
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <header className="shrink-0 border-b border-border px-4 py-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold">품질 점검</h2>
+            <p role="status" aria-live="polite" className="mt-1 text-pretty break-keep text-xs leading-relaxed text-muted-foreground">{statusCopy(quality.state)}</p>
+          </div>
+          <Button type="button" variant="outline" size="sm" className="h-8 shrink-0 px-2 max-[900px]:min-h-11" disabled={!controls.canRetry || quality.state.kind === "unavailable"} onClick={quality.onRetry}>
+            {running ? <Loader2 className="motion-safe:animate-spin" /> : <RefreshCw />}다시 검사
+          </Button>
+        </div>
+        {(quality.state.kind === "error_cold" || quality.state.kind === "error_warm") && <p role="alert" className="mt-2 text-pretty break-keep rounded border border-destructive/30 bg-destructive/10 px-2 py-1.5 text-xs text-foreground">{DESIGN_AUDIT_ERROR_COPY[quality.state.errorCode]}</p>}
+        {(quality.state.kind === "stale" || quality.state.kind === "error_warm" && !quality.state.current) && <p className="mt-2 text-pretty break-keep rounded bg-warning/15 px-2 py-1.5 text-xs text-foreground">{"이전 결과예요. 현재 결과물에는 안전 수정을 적용할\u00A0수\u00A0없어요."}</p>}
+      </header>
+      <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden p-3 [scrollbar-gutter:stable]">
+        {report === null ? <ColdState kind={quality.state.kind} /> : grouped && <>
+          <FindingGroup title="고쳐야 할 문제" findings={grouped.mustFix} emptyCopy="고쳐야 할 문제가 없어요." actionContext={actionContext} quality={quality} />
+          <FindingGroup title="권장 개선" findings={grouped.recommended} emptyCopy="권장 개선이 없어요." actionContext={actionContext} quality={quality} />
+          <section className="mt-4" aria-labelledby="quality-unknown-title">
+            <h3 id="quality-unknown-title" className="mb-2 text-xs font-semibold">확인하지 못한 항목</h3>
+            {grouped.unknown.length === 0 ? <p className="text-xs text-muted-foreground">확인하지 못한 항목이 없어요.</p> : <div className="space-y-2">{grouped.unknown.map((item) => <article key={item.code} className="rounded-md border border-warning/50 bg-warning/10 p-3">
+              <div className="flex items-start gap-2"><CircleHelp className="mt-0.5 h-4 w-4 shrink-0 text-warning" /><div className="min-w-0"><div className="text-xs font-semibold">{DESIGN_AUDIT_CHECK_COPY[item.code]}</div><div className="mt-0.5 text-[11px] text-muted-foreground">{DESIGN_AUDIT_STATUS_COPY[item.status]}</div></div></div>
+              <p className="mt-2 break-keep text-xs leading-relaxed">{DESIGN_AUDIT_UNKNOWN_COPY[item.reason]} <strong>{"통과로 볼\u00A0수\u00A0없어요."}</strong></p>
+            </article>)}</div>}
+          </section>
+          <details className="mt-4 rounded-md border border-border px-3 py-2">
+            <summary className="cursor-pointer text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">통과한 검사 {grouped.passedCount}개</summary>
+            <p className="mt-2 break-keep text-xs text-muted-foreground">명시적으로 통과한 검사만 포함해요.</p>
+          </details>
+        </>}
+      </div>
+    </div>
+  );
+}
+
+function FindingGroup({ title, findings, emptyCopy, actionContext, quality }: { readonly title: string; readonly findings: readonly DesignAuditFinding[]; readonly emptyCopy: string; readonly actionContext: DesignAuditActionContext; readonly quality: QualityPanelBinding }) {
+  return <section className="mb-4"><h3 className="mb-2 text-xs font-semibold">{title} <span className="font-normal text-muted-foreground">{findings.length}</span></h3>
+    {findings.length === 0 ? <p className="text-xs text-muted-foreground">{emptyCopy}</p> : <div className="space-y-2">{findings.map((finding) => <QualityFindingCard key={finding.id} finding={finding} actionContext={actionContext} revealResult={quality.focusedFindingId === finding.id ? quality.revealResult : null} onOpenFile={quality.onOpenFile} onReveal={quality.onReveal} onApplySafeFix={quality.onApplySafeFix} />)}</div>}
+  </section>;
+}
+
+function ColdState({ kind }: { readonly kind: DesignAuditViewState["kind"] }) {
+  if (kind === "loading") return <div className="flex items-center gap-2 text-pretty text-xs text-muted-foreground"><Loader2 className="h-4 w-4 motion-safe:animate-spin" />{"결과물을 검사하고\u00A0있어요."}</div>;
+  if (kind === "unavailable") return <div className="flex items-start gap-2 text-xs text-muted-foreground"><AlertCircle className="mt-0.5 h-4 w-4 shrink-0" /><p className="break-keep">렌더링할 결과물이 생기면 품질 점검을 사용할 수 있어요.</p></div>;
+  return <div className="flex items-start gap-2 text-xs text-muted-foreground"><AlertCircle className="mt-0.5 h-4 w-4 shrink-0" /><p className="break-keep">표시할 이전 검사 결과가 없어요. 다시 검사해 주세요.</p></div>;
+}
+
+function reportFromState(state: DesignAuditViewState) {
+  switch (state.kind) {
+    case "error_warm": case "stale": case "must_fix": case "recommended": case "ready": return state.report;
+    case "loading": case "error_cold": case "unavailable": return null;
+    default: return assertNever(state);
+  }
+}
+function statusCopy(state: DesignAuditViewState): string {
+  switch (state.kind) {
+    // `\u00A0` binds only the Korean auxiliary units (`-고 있다`, `-지 않다`)
+    // so an ending never orphans onto its own line in the narrow panel.
+    case "loading": return "결과물을 처음 검사하고\u00A0있어요.";
+    case "error_cold": return "검사 결과를 불러오지 못했어요.";
+    case "error_warm": return "최근 결과를 보여드려요. 새 검사는 완료되지\u00A0않았어요.";
+    case "stale": return state.running ? "이전 결과를 보여드리며 현재 결과물을 검사하고\u00A0있어요." : "결과물이 바뀌어 이전 검사 결과를 보여드려요.";
+    case "must_fix": return state.running ? "최근 결과를 보여드리며 다시 검사하고\u00A0있어요." : "내보내기 전에 고쳐야 할 문제가 있어요.";
+    case "recommended": return state.running ? "최근 결과를 보여드리며 다시 검사하고\u00A0있어요." : "고쳐야 할 문제는 없고 권장 개선이 있어요.";
+    case "ready": return state.running ? "통과한 최근 결과를 보여드리며 다시 검사하고\u00A0있어요." : "현재 결과물이 모든 품질 검사를 통과했어요.";
+    case "unavailable": return "렌더링 가능한 결과물이 아직 없어요.";
+    default: return assertNever(state);
+  }
+}
+function assertNever(value: never): never {
+  throw new TypeError(`Unexpected quality state: ${String(value)}`);
+}

--- a/packages/frontend/src/components/modes/design-audit-copy.ts
+++ b/packages/frontend/src/components/modes/design-audit-copy.ts
@@ -1,0 +1,32 @@
+import type { DesignAuditCheckCode, DesignAuditCheckStatus, DesignAuditTargetedAction, DesignAuditUnknownReason } from "@bg/shared";
+import type { DesignAuditErrorCode } from "@/lib/design-audit-state";
+
+export const DESIGN_AUDIT_CHECK_COPY = {
+  text_overflow: "텍스트 넘침", element_overlap: "요소 겹침", minimum_text_size: "최소 글자 크기", contrast: "색상 대비",
+  narrow_width: "좁은 화면", duplicate_node_id: "중복 요소 ID", missing_image: "이미지 참조", token_usage: "디자인 토큰 사용",
+} as const satisfies Record<DesignAuditCheckCode, string>;
+
+export const DESIGN_AUDIT_STATUS_COPY = {
+  pass: "통과", fail: "문제 발견", skipped: "검사 건너뜀", unmeasurable: "측정할 수 없음",
+} as const satisfies Record<DesignAuditCheckStatus, string>;
+
+export const DESIGN_AUDIT_ACTION_COPY = {
+  expand_or_reflow_text: "텍스트 영역을 넓히거나 재배치하세요", separate_overlapping_elements: "겹친 요소를 분리하세요",
+  set_minimum_font_size: "글자 크기를 최소 기준 이상으로 조정하세요", increase_color_contrast: "전경과 배경의 대비를 높이세요",
+  repair_narrow_layout: "좁은 화면 레이아웃을 조정하세요", assign_unique_node_ids: "요소마다 고유한 ID를 지정하세요",
+  restore_image_reference: "유효한 이미지 참조를 복구하세요", replace_literal_with_token: "직접 입력한 값을 디자인 토큰으로 바꾸세요",
+} as const satisfies Record<DesignAuditTargetedAction, string>;
+
+export const DESIGN_AUDIT_UNKNOWN_COPY = {
+  no_measurable_candidates: "측정할 수 있는 대상이 없어요", unresolvable_rendering: "렌더링 결과를 확인할 수 없어요",
+  tokens_not_exposed: "사용된 디자인 토큰 정보가 노출되지 않았어요",
+} as const satisfies Record<DesignAuditUnknownReason, string>;
+
+export const DESIGN_AUDIT_ERROR_COPY = {
+  project_not_found: "프로젝트를 찾을 수 없어요.", project_path_unavailable: "프로젝트 파일 경로에 접근할 수 없어요.",
+  stale_artifact_identity: "결과물이 변경됐어요. 다시 검사해 주세요.", audit_unavailable: "지금은 렌더링 품질 검사를 실행할 수 없어요.",
+  stale_revision: "결과물이 변경됐어요. 다시 검사해 주세요.", stale_artifact_digest: "결과물이 변경됐어요. 다시 검사해 주세요.",
+  stale_file_hash: "수정할 파일이 변경됐어요. 다시 검사해 주세요.", stale_node_fingerprint: "수정할 요소가 변경됐어요. 다시 검사해 주세요.",
+  file_not_found: "수정할 파일을 찾을 수 없어요. 다시 검사해 주세요.", node_not_found: "수정할 요소를 찾을 수 없어요. 다시 검사해 주세요.",
+  network_error: "품질 검사 서버에 연결할 수 없어요.", unknown_error: "요청을 완료하지 못했어요. 다시 시도해 주세요.",
+} as const satisfies Record<DesignAuditErrorCode, string>;

--- a/packages/frontend/src/components/modes/types.ts
+++ b/packages/frontend/src/components/modes/types.ts
@@ -1,1 +1,1 @@
-export type CanvasMode = "select" | "tweaks" | "comment" | "edit" | "draw";
+export type CanvasMode = "select" | "tweaks" | "comment" | "edit" | "draw" | "quality";

--- a/packages/frontend/src/components/project/ArtifactTabs.tsx
+++ b/packages/frontend/src/components/project/ArtifactTabs.tsx
@@ -1,4 +1,5 @@
-import { X, FileCode, Palette, Folder } from "lucide-react";
+import { useCallback, useEffect, useRef } from "react";
+import { Compass, FileCode, Folder, Palette, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ArtifactTab } from "@/types/project";
 
@@ -13,45 +14,79 @@ export default function ArtifactTabs({
   onSelect: (id: string) => void;
   onClose?: (id: string) => void;
 }) {
+  const tabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const revealActiveTab = useCallback(() => {
+    tabRefs.current[activeId]?.scrollIntoView({
+      block: "nearest",
+      inline: "nearest",
+    });
+  }, [activeId]);
+
+  useEffect(() => {
+    revealActiveTab();
+  }, [revealActiveTab]);
+
   return (
-    <div className="flex items-stretch h-full px-2">
-      {tabs.map((t) => {
-        const Icon =
-          t.kind === "design_system"
-            ? Palette
-            : t.kind === "design_files"
-              ? Folder
-              : FileCode;
-        const isActive = t.id === activeId;
+    <div
+      className="flex h-full w-full min-w-0 items-stretch overflow-x-auto overflow-y-hidden px-2"
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          revealActiveTab();
+        }
+      }}
+    >
+      {tabs.map((tab) => {
+        const Icon = tabIcon(tab.kind);
+        const isActive = tab.id === activeId;
         return (
-          <button
-            key={t.id}
-            onClick={() => onSelect(t.id)}
-            className={cn(
-              "group h-full px-3 flex items-center gap-2 text-xs border-b-2 transition-colors",
-              isActive
-                ? "border-foreground text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground",
-            )}
-          >
-            <Icon className="h-3.5 w-3.5 shrink-0" />
-            <span className="max-w-[180px] truncate">{t.title}</span>
-            {t.closeable && (
-              <span
-                role="button"
-                tabIndex={0}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onClose?.(t.id);
-                }}
-                className="ml-1 p-0.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground"
+          <div key={tab.id} className="group flex h-full shrink-0 items-center">
+            <button
+              ref={(node) => {
+                tabRefs.current[tab.id] = node;
+              }}
+              type="button"
+              onClick={() => onSelect(tab.id)}
+              className={cn(
+                "flex h-full items-center gap-2 border-b-2 px-3 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
+                isActive
+                  ? "border-foreground text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground",
+                tab.closeable && "pr-1.5",
+              )}
+            >
+              <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              <span className="max-w-[180px] truncate">{tab.title}</span>
+            </button>
+            {tab.closeable ? (
+              <button
+                type="button"
+                onClick={() => onClose?.(tab.id)}
+                className="mr-1 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+                aria-label={`${tab.title} 탭 닫기`}
               >
-                <X className="h-3 w-3" />
-              </span>
-            )}
-          </button>
+                <X className="h-3 w-3" aria-hidden="true" />
+              </button>
+            ) : null}
+          </div>
         );
       })}
     </div>
   );
+}
+
+function tabIcon(kind: ArtifactTab["kind"]) {
+  switch (kind) {
+    case "design_system":
+      return Palette;
+    case "design_files":
+      return Folder;
+    case "directions":
+      return Compass;
+    case "file":
+      return FileCode;
+    default: {
+      const unreachable: never = kind;
+      return unreachable;
+    }
+  }
 }

--- a/packages/frontend/src/components/project/ArtifactTabs.tsx
+++ b/packages/frontend/src/components/project/ArtifactTabs.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import { Compass, FileCode, Folder, Palette, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ArtifactTab } from "@/types/project";
@@ -14,21 +14,49 @@ export default function ArtifactTabs({
   onSelect: (id: string) => void;
   onClose?: (id: string) => void;
 }) {
-  const tabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const groupRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const [overflowing, setOverflowing] = useState(false);
+
+  // Centre the whole active group — label button AND close button — inside the
+  // scrollport. Measuring the group (not the label button) is what keeps the
+  // close affordance on screen at 375px, where the strip is narrower than its
+  // content. Layout-bound and instant: no animation, no timer.
   const revealActiveTab = useCallback(() => {
-    tabRefs.current[activeId]?.scrollIntoView({
-      block: "nearest",
-      inline: "nearest",
+    const container = scrollRef.current;
+    const group = groupRefs.current[activeId];
+    if (container === null || group === null || group === undefined) return;
+    const maxScroll = container.scrollWidth - container.clientWidth;
+    setOverflowing(maxScroll > 1);
+    if (maxScroll <= 0) return;
+    const centered =
+      group.offsetLeft - (container.clientWidth - group.offsetWidth) / 2;
+    container.scrollTo({
+      left: Math.max(0, Math.min(centered, maxScroll)),
+      behavior: "auto",
     });
   }, [activeId]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     revealActiveTab();
-  }, [revealActiveTab]);
+    const container = scrollRef.current;
+    if (container === null) return;
+    const observer = new ResizeObserver(() => revealActiveTab());
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [revealActiveTab, tabs.length]);
 
   return (
     <div
-      className="flex h-full w-full min-w-0 items-stretch overflow-x-auto overflow-y-hidden px-2"
+      ref={scrollRef}
+      className={cn(
+        "relative flex h-full w-full min-w-0 items-stretch overflow-x-auto overflow-y-hidden px-2",
+        // Edge fade + snap only while the strip actually overflows, so a
+        // fitting strip carries no decoration and an overflowing one shows
+        // where content continues.
+        overflowing &&
+          "snap-x snap-proximity [mask-image:linear-gradient(to_right,transparent_0px,#000_12px,#000_calc(100%-12px),transparent_100%)] focus-within:[mask-image:none]",
+      )}
       onBlur={(event) => {
         if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
           revealActiveTab();
@@ -39,11 +67,14 @@ export default function ArtifactTabs({
         const Icon = tabIcon(tab.kind);
         const isActive = tab.id === activeId;
         return (
-          <div key={tab.id} className="group flex h-full shrink-0 items-center">
+          <div
+            key={tab.id}
+            ref={(node) => {
+              groupRefs.current[tab.id] = node;
+            }}
+            className="group flex h-full shrink-0 snap-center items-center"
+          >
             <button
-              ref={(node) => {
-                tabRefs.current[tab.id] = node;
-              }}
               type="button"
               onClick={() => onSelect(tab.id)}
               className={cn(
@@ -61,7 +92,7 @@ export default function ArtifactTabs({
               <button
                 type="button"
                 onClick={() => onClose?.(tab.id)}
-                className="mr-1 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+                className="mr-1 max-[900px]:min-h-11 max-[900px]:min-w-11 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
                 aria-label={`${tab.title} 탭 닫기`}
               >
                 <X className="h-3 w-3" aria-hidden="true" />

--- a/packages/frontend/src/components/project/ProjectTopBar.tsx
+++ b/packages/frontend/src/components/project/ProjectTopBar.tsx
@@ -36,7 +36,7 @@ export default function ProjectTopBar({
           </div>
         </div>
       </div>
-      <div className="flex-1 min-w-0 overflow-x-auto">{tabsSlot}</div>
+      <div className="min-w-0 flex-1 overflow-hidden">{tabsSlot}</div>
       <div className="px-3 flex items-center gap-2 shrink-0 max-[900px]:px-2 max-[900px]:gap-1">
         <Button
           variant="ghost"

--- a/packages/frontend/src/components/project/ProjectTopBar.tsx
+++ b/packages/frontend/src/components/project/ProjectTopBar.tsx
@@ -3,18 +3,22 @@ import { Home, Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { ReactNode } from "react";
 import type { ProjectDetail } from "@bg/shared";
-import ExportMenu from "@/components/export/ExportMenu";
+import ExportMenu, { type ExportQualityGate } from "@/components/export/ExportMenu";
 
 export default function ProjectTopBar({
   project,
   tabsSlot,
   onPresent,
   canPresent,
+  qualityGate,
+  onOpenQuality,
 }: {
   project: ProjectDetail;
   tabsSlot?: ReactNode;
   onPresent?: () => void;
   canPresent: boolean;
+  qualityGate: ExportQualityGate;
+  onOpenQuality: () => void;
 }) {
   const displayName = stripInternalProjectTag(project.name);
   return (
@@ -29,7 +33,7 @@ export default function ProjectTopBar({
         </Link>
         <div className="flex items-center min-w-0">
           <div
-            className="text-sm font-medium w-[180px] truncate max-[900px]:w-[96px]"
+            className="text-sm font-medium w-[180px] truncate max-[900px]:w-[96px] max-[480px]:w-[72px]"
             title={displayName}
           >
             {displayName}
@@ -41,7 +45,7 @@ export default function ProjectTopBar({
         <Button
           variant="ghost"
           size="sm"
-          className="gap-1.5 max-[900px]:w-8 max-[900px]:justify-center max-[900px]:gap-0 max-[900px]:px-0 max-[900px]:text-[0px]"
+          className="gap-1.5 max-[900px]:min-h-11 max-[900px]:min-w-11 max-[900px]:justify-center max-[900px]:gap-0 max-[900px]:px-0 max-[900px]:text-[0px]"
           onClick={onPresent}
           disabled={!canPresent || !onPresent}
           title={
@@ -52,7 +56,7 @@ export default function ProjectTopBar({
         >
           <Play className="h-3.5 w-3.5" /> Present
         </Button>
-        <ExportMenu projectId={project.id} projectType={project.type} />
+        <ExportMenu projectId={project.id} projectType={project.type} qualityGate={qualityGate} onOpenQuality={onOpenQuality} />
       </div>
     </header>
   );

--- a/packages/frontend/src/components/project/ProjectTopBar.tsx
+++ b/packages/frontend/src/components/project/ProjectTopBar.tsx
@@ -56,7 +56,7 @@ export default function ProjectTopBar({
         >
           <Play className="h-3.5 w-3.5" /> Present
         </Button>
-        <ExportMenu projectId={project.id} projectType={project.type} qualityGate={qualityGate} onOpenQuality={onOpenQuality} />
+        <ExportMenu projectId={project.id} projectType={project.type} projectOptionsJson={project.options_json} qualityGate={qualityGate} onOpenQuality={onOpenQuality} />
       </div>
     </header>
   );

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -62,6 +62,10 @@
     --muted-foreground: 94 100 108;  /* grey-600 */
     --accent: 0 79 255;              /* blue-500 (brand) */
     --accent-foreground: 255 255 255;
+    --success: 0 206 120;           /* green-500 */
+    --success-foreground: 23 25 26;
+    --warning: 252 166 61;          /* yellow-500 */
+    --warning-foreground: 23 25 26;
     --destructive: 217 45 32;        /* red-700 */
     --destructive-foreground: 255 255 255;
     --border: 220 228 234;           /* grey-100 */
@@ -86,6 +90,12 @@
 
   body {
     @apply bg-background text-foreground font-sans antialiased;
+  }
+}
+
+@layer components {
+  [data-radix-popper-content-wrapper]:has([data-export-menu-content]) {
+    z-index: 100 !important;
   }
 }
 

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -38,6 +38,7 @@
     /* Accents */
     --color-green-500: #00ce78;
     --color-red-500: #ff524c;
+    --color-red-700: #d92d20;
     --color-orange-500: #ff7659;
     --color-yellow-100: #fff5e4;
     --color-yellow-500: #fca63d;
@@ -58,10 +59,10 @@
     --secondary: 241 243 245;        /* grey-50 */
     --secondary-foreground: 23 25 26;
     --muted: 241 243 245;            /* grey-50 */
-    --muted-foreground: 117 123 128; /* grey-500 */
+    --muted-foreground: 94 100 108;  /* grey-600 */
     --accent: 0 79 255;              /* blue-500 (brand) */
     --accent-foreground: 255 255 255;
-    --destructive: 255 82 76;        /* red-500 */
+    --destructive: 217 45 32;        /* red-700 */
     --destructive-foreground: 255 255 255;
     --border: 220 228 234;           /* grey-100 */
     --input: 220 228 234;            /* grey-100 */

--- a/packages/frontend/src/lib/design-audit-state.ts
+++ b/packages/frontend/src/lib/design-audit-state.ts
@@ -1,0 +1,90 @@
+import type { DesignAuditCheck, DesignAuditFinding, DesignAuditResult } from "@bg/shared";
+import { ApiError } from "@/api/client";
+
+export type DesignAuditErrorCode = "project_not_found" | "project_path_unavailable" | "stale_artifact_identity" | "audit_unavailable" | "stale_revision" | "stale_artifact_digest" | "stale_file_hash" | "stale_node_fingerprint" | "file_not_found" | "node_not_found" | "network_error" | "unknown_error";
+export type DesignAuditActionContext = { readonly current: boolean; readonly running: boolean; readonly pendingFindingId: string | null };
+export type DesignAuditUnknownCheck = DesignAuditCheck & { readonly status: "skipped" | "unmeasurable"; readonly reason: NonNullable<DesignAuditCheck["reason"]> };
+export type DesignAuditGroups = {
+  readonly mustFix: readonly DesignAuditFinding[];
+  readonly recommended: readonly DesignAuditFinding[];
+  readonly unknown: readonly DesignAuditUnknownCheck[];
+  readonly passedCount: number;
+};
+export type DesignAuditViewState =
+  | { readonly kind: "loading" }
+  | { readonly kind: "error_cold"; readonly errorCode: DesignAuditErrorCode }
+  | { readonly kind: "error_warm"; readonly report: DesignAuditResult; readonly errorCode: DesignAuditErrorCode; readonly current: boolean }
+  | { readonly kind: "stale"; readonly report: DesignAuditResult; readonly running: boolean }
+  | { readonly kind: "must_fix" | "recommended" | "ready"; readonly report: DesignAuditResult; readonly running: boolean }
+  | { readonly kind: "unavailable" };
+
+type ViewInput = {
+  readonly renderable: boolean;
+  readonly report: DesignAuditResult | null;
+  readonly pending: boolean;
+  readonly rerunning: boolean;
+  readonly errorCode: DesignAuditErrorCode | null;
+  readonly currentDigest: string;
+};
+
+export function preferDesignAuditResult(current: DesignAuditResult | null, incoming: DesignAuditResult | null, projectId: string): DesignAuditResult | null {
+  const validCurrent = current?.project_id === projectId ? current : null;
+  if (incoming?.project_id !== projectId) return validCurrent;
+  if (validCurrent === null) return incoming;
+  if (incoming.artifact_revision !== validCurrent.artifact_revision) return incoming.artifact_revision > validCurrent.artifact_revision ? incoming : validCurrent;
+  return incoming.created_at > validCurrent.created_at ? incoming : validCurrent;
+}
+
+export function isDesignAuditCurrent(report: DesignAuditResult, currentDigest: string): boolean {
+  return report.artifact_digest === currentDigest;
+}
+
+export function groupDesignAuditResult(report: DesignAuditResult): DesignAuditGroups {
+  const findings = report.checks.flatMap((item) => item.findings);
+  const unknown = report.checks.filter((item): item is DesignAuditUnknownCheck =>
+    (item.status === "skipped" || item.status === "unmeasurable") && item.reason !== null,
+  );
+  return {
+    mustFix: findings.filter((item) => item.severity === "must_fix"),
+    recommended: findings.filter((item) => item.severity === "recommended"),
+    unknown,
+    passedCount: report.checks.filter((item) => item.status === "pass").length,
+  };
+}
+
+export function designAuditActionAvailability(finding: DesignAuditFinding, context: DesignAuditActionContext) {
+  const applying = context.pendingFindingId === finding.id;
+  return {
+    canOpenFile: finding.source.rel_path.length > 0,
+    canReveal: finding.source.node_bg_id !== null,
+    canApplySafeFix: context.current && !context.running && context.pendingFindingId === null && finding.safe_fix !== undefined,
+    applying,
+  } as const;
+}
+
+export function designAuditControlAvailability(context: Pick<DesignAuditActionContext, "running" | "pendingFindingId">) {
+  return { canRetry: !context.running && context.pendingFindingId === null } as const;
+}
+
+export function designAuditErrorCode(error: unknown): DesignAuditErrorCode {
+  if (error instanceof ApiError) {
+    switch (error.code) {
+      case "project_not_found": case "project_path_unavailable": case "stale_artifact_identity": case "audit_unavailable":
+      case "stale_revision": case "stale_artifact_digest": case "stale_file_hash": case "stale_node_fingerprint":
+      case "file_not_found": case "node_not_found": case "network_error": return error.code;
+      default: return "unknown_error";
+    }
+  }
+  return error instanceof TypeError ? "network_error" : "unknown_error";
+}
+
+export function designAuditViewState(input: ViewInput): DesignAuditViewState {
+  if (!input.renderable) return { kind: "unavailable" };
+  if (input.report === null) {
+    if (input.errorCode !== null) return { kind: "error_cold", errorCode: input.errorCode };
+    return { kind: "loading" };
+  }
+  if (input.errorCode !== null) return { kind: "error_warm", report: input.report, errorCode: input.errorCode, current: isDesignAuditCurrent(input.report, input.currentDigest) };
+  if (!isDesignAuditCurrent(input.report, input.currentDigest)) return { kind: "stale", report: input.report, running: input.rerunning || input.pending };
+  return { kind: input.report.overall_status, report: input.report, running: input.rerunning || input.pending };
+}

--- a/packages/frontend/src/lib/design-direction-state.ts
+++ b/packages/frontend/src/lib/design-direction-state.ts
@@ -1,0 +1,90 @@
+import type { DesignDirectionState, NormalizedEvent } from "@bg/shared";
+
+/**
+ * Ordering and action availability for the design-direction workflow.
+ *
+ * The backend is the single writer: every snapshot is published as a
+ * `design.direction_state` event AND returned from the mutation that caused
+ * it, so the frontend sees the same state through two channels that can
+ * arrive in any order. These helpers decide which snapshot is newer without
+ * timers, polling, or arrival-order guesses.
+ */
+
+export type DirectionActions = {
+  readonly canGenerate: boolean;
+  readonly canCancel: boolean;
+  readonly canRetry: boolean;
+  readonly canSelect: boolean;
+  readonly canUndo: boolean;
+};
+
+export type DirectionProgress = { readonly resolved: number; readonly total: number };
+
+/**
+ * `updated_at` comes from the backend clock and never moves backwards;
+ * `selection_revision` breaks ties for select/undo pairs that land inside the
+ * same millisecond (both keep the same `updated_at` granularity).
+ */
+function isNewer(candidate: DesignDirectionState, incumbent: DesignDirectionState): boolean {
+  if (candidate.updated_at !== incumbent.updated_at) {
+    return candidate.updated_at > incumbent.updated_at;
+  }
+  return candidate.selection_revision > incumbent.selection_revision;
+}
+
+/** Newest direction snapshot carried by an unordered event batch (replay or live). */
+export function latestDirectionState(
+  events: readonly NormalizedEvent[],
+): DesignDirectionState | null {
+  let latest: DesignDirectionState | null = null;
+  for (const event of events) {
+    if (event.type !== "design.direction_state") continue;
+    if (latest === null || isNewer(event.state, latest)) latest = event.state;
+  }
+  return latest;
+}
+
+/** Cache merge for the GET/mutation channel against whatever SSE already wrote. */
+export function preferDirectionState(
+  current: DesignDirectionState | null,
+  incoming: DesignDirectionState | null,
+): DesignDirectionState | null {
+  if (incoming === null) return current;
+  if (current === null) return incoming;
+  return isNewer(incoming, current) ? incoming : current;
+}
+
+/** Real slot progress — never a synthetic percentage. */
+export function directionProgress(state: DesignDirectionState): DirectionProgress {
+  return {
+    resolved: state.directions.filter((slot) => slot.status !== "pending").length,
+    total: state.directions.length,
+  };
+}
+
+export function directionActions(state: DesignDirectionState | null): DirectionActions {
+  if (state === null) {
+    return { canGenerate: true, canCancel: false, canRetry: false, canSelect: false, canUndo: false };
+  }
+  switch (state.status) {
+    case "loading":
+      // Selection and undo stay closed while the renderer owns the snapshot:
+      // its next publish is built from the pre-selection state it captured.
+      return { canGenerate: false, canCancel: true, canRetry: false, canSelect: false, canUndo: false };
+    case "ready":
+    case "partial":
+    case "failed":
+    case "cancelled":
+      return {
+        canGenerate: true,
+        canCancel: false,
+        canRetry: state.directions.some((slot) => slot.status === "failed" || slot.status === "cancelled"),
+        canSelect: state.directions.some((slot) => slot.status === "ready"),
+        canUndo: state.selection_history.length > 0,
+      };
+    default: {
+      const unreachable: never = state.status;
+      return unreachable;
+    }
+  }
+}

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -3,29 +3,30 @@
  */
 
 /**
- * Returns a human-friendly relative label like "Today", "Yesterday",
- * or a locale date for anything older. Matches the label convention
- * shown in the Home cards (ref/스크린샷 2026-04-22 093043.png).
+ * Returns a human-friendly relative label like "오늘", "어제", or an
+ * explicit ko-KR date for anything older. A timestamp in the future
+ * (clock skew) collapses to "오늘". Matches the label convention shown
+ * in the Home cards (ref/스크린샷 2026-04-22 093043.png).
  */
 export function formatRelativeDay(ts: number, now: number = Date.now()): string {
   const diffMs = now - ts;
   const dayMs = 24 * 60 * 60 * 1000;
 
-  if (diffMs < 0) return "Today";
-  if (diffMs < dayMs) return "Today";
-  if (diffMs < 2 * dayMs) return "Yesterday";
+  if (diffMs < 0) return "오늘";
+  if (diffMs < dayMs) return "오늘";
+  if (diffMs < 2 * dayMs) return "어제";
   if (diffMs < 7 * dayMs) {
     const days = Math.floor(diffMs / dayMs);
-    return `${days} days ago`;
+    return `${days}일 전`;
   }
-  return new Date(ts).toLocaleDateString();
+  return new Date(ts).toLocaleDateString("ko-KR");
 }
 
 const PROJECT_TYPE_LABEL: Record<string, string> = {
-  prototype: "Prototype",
-  slide_deck: "Slide deck",
-  from_template: "Template",
-  other: "Other",
+  prototype: "프로토타입",
+  slide_deck: "슬라이드 덱",
+  from_template: "템플릿",
+  other: "기타",
 };
 
 export function projectTypeLabel(type: string): string {

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -25,6 +25,7 @@ export function formatRelativeDay(ts: number, now: number = Date.now()): string 
 const PROJECT_TYPE_LABEL: Record<string, string> = {
   prototype: "프로토타입",
   slide_deck: "슬라이드 덱",
+  graphic: "그래픽",
   from_template: "템플릿",
   other: "기타",
 };

--- a/packages/frontend/src/lib/graphic-preview.ts
+++ b/packages/frontend/src/lib/graphic-preview.ts
@@ -1,0 +1,43 @@
+import type { GraphicCanvasV1 } from "@bg/shared";
+
+export type GraphicPreviewSize = {
+  readonly width: number;
+  readonly height: number;
+};
+
+export type GraphicPreviewFit = {
+  readonly scale: number;
+  readonly x: number;
+  readonly y: number;
+  readonly renderedWidth: number;
+  readonly renderedHeight: number;
+};
+
+export function buildGraphicPreviewInjection(canvas: GraphicCanvasV1): string {
+  const config = JSON.stringify(canvas);
+  return `<style data-bg-graphic-preview-style>
+html[data-bg-graphic-preview="fit"] { width: 100% !important; height: 100% !important; overflow: hidden !important; background: #f1f3f5 !important; }
+html[data-bg-graphic-preview="fit"] > body { position: absolute !important; inset: 0 auto auto 0 !important; margin: 0 !important; width: var(--bg-graphic-canvas-width) !important; height: var(--bg-graphic-canvas-height) !important; overflow: hidden !important; transform: translate(var(--bg-graphic-preview-x,0px), var(--bg-graphic-preview-y,0px)) scale(var(--bg-graphic-preview-scale,1)) !important; transform-origin: top left !important; }
+html[data-bg-graphic-preview="fit"] [data-graphic-artboard] { contain: layout paint !important; }
+</style><script data-bg-graphic-preview-runtime>(function(){const canvas=${config};const applyFit=()=>{const scale=Math.min(innerWidth/canvas.width,innerHeight/canvas.height,1);const x=(innerWidth-canvas.width*scale)/2;const y=(innerHeight-canvas.height*scale)/2;const root=document.documentElement;root.dataset.bgGraphicPreview="fit";root.style.setProperty("--bg-graphic-canvas-width",canvas.width+"px");root.style.setProperty("--bg-graphic-canvas-height",canvas.height+"px");root.style.setProperty("--bg-graphic-preview-scale",String(scale));root.style.setProperty("--bg-graphic-preview-x",x+"px");root.style.setProperty("--bg-graphic-preview-y",y+"px")};const install=()=>{window.addEventListener("resize",applyFit);applyFit()};if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",install,{once:true})}else{install()}})();<\/script>`;
+}
+
+export function computeGraphicPreviewFit(
+  container: GraphicPreviewSize,
+  canvas: GraphicPreviewSize,
+): GraphicPreviewFit {
+  const scale = Math.min(
+    container.width / canvas.width,
+    container.height / canvas.height,
+    1,
+  );
+  const renderedWidth = canvas.width * scale;
+  const renderedHeight = canvas.height * scale;
+  return {
+    scale,
+    x: (container.width - renderedWidth) / 2,
+    y: (container.height - renderedHeight) / 2,
+    renderedWidth,
+    renderedHeight,
+  };
+}

--- a/packages/frontend/src/lib/graphic-project.ts
+++ b/packages/frontend/src/lib/graphic-project.ts
@@ -1,0 +1,20 @@
+import {
+  UpgradeContractError,
+  decodeContract,
+  parseGraphicCanvasV1,
+  type GraphicCanvasV1,
+  type ProjectType,
+} from "@bg/shared";
+
+export function parseProjectGraphicCanvas(
+  projectType: ProjectType,
+  optionsJson: string | null,
+): GraphicCanvasV1 | null {
+  if (projectType !== "graphic") return null;
+  try {
+    return parseGraphicCanvasV1(decodeContract(optionsJson)["graphic_canvas"]);
+  } catch (error) {
+    if (error instanceof UpgradeContractError) return null;
+    throw error;
+  }
+}

--- a/packages/frontend/src/lib/project-creation.ts
+++ b/packages/frontend/src/lib/project-creation.ts
@@ -16,10 +16,16 @@ import type {
   DesignSystemSummary,
   ProjectType,
 } from "@bg/shared";
+import { GRAPHIC_CANVAS_LIMITS } from "@bg/shared";
 
 export const BRIEF_LOCALE = "ko";
 export const AUDIENCE_MAX_LENGTH = 200;
 export const OBJECTIVE_MAX_LENGTH = 1000;
+export const GRAPHIC_PRESETS = [
+  { label: "정사각형", width: 1080, height: 1080 },
+  { label: "SNS", width: 1200, height: 628 },
+  { label: "세로형", width: 1080, height: 1920 },
+] as const;
 
 export type BriefChoice<T> = { readonly value: T; readonly label: string };
 
@@ -64,6 +70,8 @@ export type ProjectDraft = {
   readonly visualMood: DesignBriefVisualMood;
   readonly density: DesignBriefDensity;
   readonly outputSize: DesignBriefOutputSize;
+  readonly graphicWidth: number;
+  readonly graphicHeight: number;
   readonly useSpeakerNotes: boolean;
   readonly copyAsIs: boolean;
 };
@@ -81,6 +89,8 @@ export const INITIAL_BRIEF_FORM: BriefForm = {
   visualMood: "formal",
   density: "balanced",
   outputSize: "responsive",
+  graphicWidth: 1080,
+  graphicHeight: 1080,
   useSpeakerNotes: false,
   copyAsIs: false,
 };
@@ -94,7 +104,10 @@ export type DraftProblem =
   | "audience_invalid"
   | "objective_invalid"
   | "design_system_required"
-  | "design_system_not_selectable";
+  | "design_system_not_selectable"
+  | "graphic_width_invalid"
+  | "graphic_height_invalid"
+  | "graphic_pixel_limit";
 
 export type BuildResult =
   | { readonly ok: true; readonly request: CreateProjectRequest }
@@ -107,6 +120,9 @@ export const PROBLEM_MESSAGE: Record<DraftProblem, string> = {
   design_system_required: "사용할 템플릿을 선택해 주세요.",
   design_system_not_selectable:
     "선택한 디자인 시스템은 지금 사용할 수 없어요. 목록에서 다시 골라 주세요.",
+  graphic_width_invalid: "너비는 320~4096 사이의 정수로 입력해 주세요.",
+  graphic_height_invalid: "높이는 240~4096 사이의 정수로 입력해 주세요.",
+  graphic_pixel_limit: "전체 픽셀은 1,600만 이하가 되도록 크기를 줄여 주세요.",
 };
 
 /**
@@ -158,6 +174,26 @@ export function buildCreateProjectRequest(
     return { ok: false, problem: "objective_invalid" };
   }
 
+  if (draft.type === "graphic") {
+    if (
+      !Number.isSafeInteger(draft.graphicWidth) ||
+      draft.graphicWidth < GRAPHIC_CANVAS_LIMITS.minWidth ||
+      draft.graphicWidth > GRAPHIC_CANVAS_LIMITS.maxWidth
+    ) {
+      return { ok: false, problem: "graphic_width_invalid" };
+    }
+    if (
+      !Number.isSafeInteger(draft.graphicHeight) ||
+      draft.graphicHeight < GRAPHIC_CANVAS_LIMITS.minHeight ||
+      draft.graphicHeight > GRAPHIC_CANVAS_LIMITS.maxHeight
+    ) {
+      return { ok: false, problem: "graphic_height_invalid" };
+    }
+    if (draft.graphicWidth * draft.graphicHeight > GRAPHIC_CANVAS_LIMITS.maxPixels) {
+      return { ok: false, problem: "graphic_pixel_limit" };
+    }
+  }
+
   const selectable = selectableDesignSystems(systems, draft.type);
   const designSystemId = keepSelectedDesignSystemId(
     draft.designSystemId,
@@ -185,7 +221,7 @@ export function buildCreateProjectRequest(
           : "selected_design_system",
     visual_mood: draft.visualMood,
     density: draft.density,
-    output_size: draft.outputSize,
+    output_size: draft.type === "graphic" ? "custom" : draft.outputSize,
   };
 
   return {
@@ -201,6 +237,15 @@ export function buildCreateProjectRequest(
           : {}),
         ...(draft.type === "from_template"
           ? { copy_as_is: draft.copyAsIs }
+          : {}),
+        ...(draft.type === "graphic"
+          ? {
+              graphic_canvas: {
+                schema_version: 1 as const,
+                width: draft.graphicWidth,
+                height: draft.graphicHeight,
+              },
+            }
           : {}),
         design_brief: brief,
       },

--- a/packages/frontend/src/types/project.ts
+++ b/packages/frontend/src/types/project.ts
@@ -27,7 +27,7 @@ export interface SelectedNode {
 export interface ArtifactTab {
   id: string;
   title: string;
-  kind: "design_system" | "design_files" | "file";
+  kind: "design_system" | "design_files" | "directions" | "file";
   relPath?: string;
   closeable: boolean;
 }

--- a/packages/frontend/src/views/HomeView.tsx
+++ b/packages/frontend/src/views/HomeView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus, Search } from "lucide-react";
 import { useNavigate } from "react-router-dom";
@@ -46,6 +46,7 @@ export default function HomeView() {
   const pushToast = useUIStore((s) => s.pushToast);
   const [activeTab, setActiveTab] = useState<HomeTab>("recent");
   const [projectQuery, setProjectQuery] = useState("");
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const cliMissingShown = useUIStore((s) => s.cliMissingShown);
   const setCliMissingShown = useUIStore((s) => s.setCliMissingShown);
   const [cliMissingOpen, setCliMissingOpen] = useState(false);
@@ -116,12 +117,12 @@ export default function HomeView() {
     mutationFn: (id: string) => deleteProject(id),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["projects"] });
-      pushToast({ title: "Project deleted", tone: "success" });
+      pushToast({ title: "프로젝트를 삭제했어요", tone: "success" });
       setDeleteTarget(null);
     },
     onError: (err) => {
       pushToast({
-        title: "Delete failed",
+        title: "프로젝트를 삭제하지 못했어요",
         body: err instanceof Error ? err.message : String(err),
         tone: "error",
       });
@@ -132,11 +133,11 @@ export default function HomeView() {
     mutationFn: () => restoreSamples(),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["projects"] });
-      pushToast({ title: "Samples restored", tone: "success" });
+      pushToast({ title: "기본 예제를 복원했어요", tone: "success" });
     },
     onError: (err) => {
       pushToast({
-        title: "Restore failed",
+        title: "예제를 복원하지 못했어요",
         body: err instanceof Error ? err.message : String(err),
         tone: "error",
       });
@@ -147,7 +148,7 @@ export default function HomeView() {
     mutationFn: (id: string) => deleteDesignSystem(id),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["design-systems"] });
-      pushToast({ title: "Design system deleted", tone: "success" });
+      pushToast({ title: "디자인 시스템을 삭제했어요", tone: "success" });
       setDeleteSystemTarget(null);
       setDeleteSystemBlocker(null);
     },
@@ -170,7 +171,7 @@ export default function HomeView() {
         }
       }
       pushToast({
-        title: "Delete failed",
+        title: "디자인 시스템을 삭제하지 못했어요",
         body: err instanceof Error ? err.message : String(err),
         tone: "error",
       });
@@ -181,7 +182,7 @@ export default function HomeView() {
     mutationFn: async () => {
       if (systemImportMode === "upload") {
         if (!systemUploadFile) {
-          throw new Error("Choose a .pptx or .pdf file to upload.");
+          throw new Error("업로드할 .pptx 또는 .pdf 파일을 선택해 주세요.");
         }
         return await uploadDesignSystem(systemUploadFile, {
           name: systemDraftName.trim() || undefined,
@@ -206,19 +207,21 @@ export default function HomeView() {
       pushToast({
         title:
           systemImportMode === "upload"
-            ? "Design file imported"
-            : "Design system imported",
-        body: `${created.system.name} was created as a draft.`,
+            ? "디자인 파일을 가져왔어요"
+            : "디자인 시스템을 가져왔어요",
+        body: `${created.system.name} 초안을 만들었어요. 내용을 확인한 뒤 게시할 수 있어요.`,
         tone: "success",
       });
       navigate(`/systems/${created.system.id}`);
     },
     onError: (err) => {
       const message =
-        err instanceof Error ? err.message : "Failed to import design system";
+        err instanceof Error
+          ? err.message
+          : "디자인 시스템을 가져오지 못했어요. 주소나 파일을 확인한 뒤 다시 시도해 주세요.";
       setSystemImportError(message);
       pushToast({
-        title: "Import failed",
+        title: "디자인 시스템을 가져오지 못했어요",
         body: message,
         tone: "error",
       });
@@ -250,6 +253,23 @@ export default function HomeView() {
   const onProjectDelete = (card: CardViewModel) =>
     setDeleteTarget({ id: card.id, name: card.name });
 
+  // Clearing from an empty-result panel removes the button the user is
+  // standing on, so focus returns to the search field instead of the
+  // document body.
+  const clearProjectQuery = () => {
+    setProjectQuery("");
+    searchInputRef.current?.focus();
+  };
+
+  // The creation form lives in the app shell's sidebar, outside this
+  // view's tree, so the empty state hands off by focusing its name
+  // field by id. Plain focus() also scrolls the control into view,
+  // which is what the narrow layout needs since the sidebar is ordered
+  // below the grid there.
+  const startProject = () => {
+    document.getElementById("project-name")?.focus();
+  };
+
   return (
     <>
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
@@ -260,10 +280,10 @@ export default function HomeView() {
         >
           <div className="flex items-center justify-between gap-4 px-8 pb-4 pt-8 max-[640px]:flex-col max-[640px]:items-stretch max-[640px]:px-4 max-[640px]:pt-4">
             <TabsList className="max-[640px]:grid max-[640px]:h-auto max-[640px]:w-full max-[640px]:grid-cols-2">
-              <TabsTrigger value="recent">Recent</TabsTrigger>
-              <TabsTrigger value="mine">Your designs</TabsTrigger>
-              <TabsTrigger value="examples">Examples</TabsTrigger>
-              <TabsTrigger value="systems">Design systems</TabsTrigger>
+              <TabsTrigger value="recent">최근</TabsTrigger>
+              <TabsTrigger value="mine">내 디자인</TabsTrigger>
+              <TabsTrigger value="examples">예제</TabsTrigger>
+              <TabsTrigger value="systems">디자인 시스템</TabsTrigger>
             </TabsList>
 
             {activeTab === "systems" ? null : (
@@ -273,6 +293,7 @@ export default function HomeView() {
                   className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
                 />
                 <Input
+                  ref={searchInputRef}
                   type="search"
                   aria-label="프로젝트 검색"
                   placeholder="프로젝트 검색"
@@ -280,7 +301,7 @@ export default function HomeView() {
                   onChange={(event) => setProjectQuery(event.target.value)}
                   onKeyDown={(event) => {
                     if (event.key === "Escape") {
-                      setProjectQuery("");
+                      clearProjectQuery();
                     }
                   }}
                   className="pl-8"
@@ -297,8 +318,11 @@ export default function HomeView() {
                 query={projectQuery}
                 isLoading={recentQuery.isPending}
                 error={recentQuery.error}
-                emptyText="최근 프로젝트가 아직 없습니다."
+                emptyText="최근 프로젝트가 아직 없어요."
+                emptyHint="프로젝트 종류를 고르고 이름을 입력하면 여기에 바로 나타나요."
                 onRetry={() => void recentQuery.refetch()}
+                onClearQuery={clearProjectQuery}
+                onStartProject={startProject}
                 onDelete={onProjectDelete}
               />
             </TabsContent>
@@ -310,8 +334,11 @@ export default function HomeView() {
                 query={projectQuery}
                 isLoading={mineQuery.isPending}
                 error={mineQuery.error}
-                emptyText="내 프로젝트가 아직 없습니다."
+                emptyText="내 프로젝트가 아직 없어요."
+                emptyHint="프로젝트 종류를 고르고 이름을 입력하면 만든 프로젝트가 모두 여기에 모여요."
                 onRetry={() => void mineQuery.refetch()}
+                onClearQuery={clearProjectQuery}
+                onStartProject={startProject}
                 onDelete={onProjectDelete}
               />
             </TabsContent>
@@ -319,9 +346,9 @@ export default function HomeView() {
             <TabsContent value="examples">
               <div className="mb-3 flex items-center justify-between">
                 <p className="text-xs text-muted-foreground">
-                  Built-in tutorials, prompt-samples, and template fixtures.
-                  Deleting any of them is fine — Restore samples brings the
-                  built-in set back.
+                  기본으로 들어 있는 튜토리얼, 프롬프트 샘플, 템플릿 예제예요.
+                  지워도 괜찮아요 — ‘예제 복원’을 누르면 기본 세트가 다시
+                  생겨요.
                 </p>
                 <Button
                   size="sm"
@@ -330,8 +357,8 @@ export default function HomeView() {
                   onClick={() => restoreSamplesMutation.mutate()}
                 >
                   {restoreSamplesMutation.isPending
-                    ? "Restoring…"
-                    : "Restore samples"}
+                    ? "복원하는 중..."
+                    : "예제 복원"}
                 </Button>
               </div>
               <ProjectCardSection
@@ -340,8 +367,11 @@ export default function HomeView() {
                 query={projectQuery}
                 isLoading={examplesQuery.isPending}
                 error={examplesQuery.error}
-                emptyText="예제 프로젝트가 아직 없습니다."
+                emptyText="예제 프로젝트가 아직 없어요."
+                emptyHint="‘예제 복원’을 누르면 기본 예제 세트를 다시 받아올 수 있어요."
                 onRetry={() => void examplesQuery.refetch()}
+                onClearQuery={clearProjectQuery}
+                onStartProject={startProject}
                 onDelete={onProjectDelete}
               />
             </TabsContent>
@@ -471,12 +501,12 @@ function SystemsSection({
   return (
     <div className="space-y-4">
       <div className="max-w-3xl rounded-xl border border-border bg-card/70 px-4 py-3 text-sm leading-6 text-muted-foreground">
-        Design systems across draft, review, and published states appear here.
-        Use the <span className="font-medium text-foreground">+</span> tile to
-        import a new design system from a git repository, website URL, or an
-        uploaded `.pptx` / `.pdf`. BurnGuard scaffolds the same canonical
-        output shape as the bundled sample, and uploads go through a compact
-        Python summarizer so the downstream prompt payload stays token-light.
+        초안 · 검토 중 · 게시됨 상태의 디자인 시스템이 모두 여기에 모여요.{" "}
+        <span className="font-medium text-foreground">+</span> 타일을 누르면 Git
+        저장소, 웹사이트 URL, 또는 업로드한 PPTX/PDF 파일에서 새 디자인 시스템을
+        가져올 수 있어요. BurnGuard는 기본 제공 샘플과 같은 표준 출력
+        구조를 만들고, 업로드 파일은 Python 요약 단계를 거쳐 프롬프트에 실리는
+        토큰을 가볍게 유지해요.
       </div>
 
       <CardGrid>
@@ -490,17 +520,17 @@ function SystemsSection({
               <div className="grid h-12 w-12 place-items-center rounded-full border border-current/20 bg-white/70">
                 <Plus className="h-6 w-6" />
               </div>
-              <div className="text-xs font-medium uppercase tracking-[0.16em]">
-                Import
+              <div className="text-xs font-medium tracking-[0.16em]">
+                가져오기
               </div>
             </div>
           </div>
           <div className="p-3">
             <div className="text-sm font-medium text-foreground">
-              Import design system
+              디자인 시스템 가져오기
             </div>
             <div className="mt-0.5 text-xs text-muted-foreground">
-              Git URL, website URL, or PPT/PDF upload
+              Git URL, 웹사이트 URL, 또는 PPTX/PDF 업로드
             </div>
           </div>
         </button>
@@ -517,13 +547,13 @@ function SystemsSection({
       {importOpen ? (
         <div className="rounded-xl border border-border bg-card p-5">
           <div className="text-sm font-medium text-foreground">
-            Import design system
+            디자인 시스템 가져오기
           </div>
           <p className="mt-1 max-w-3xl text-sm leading-6 text-muted-foreground">
-            BurnGuard can ingest a repository or live website directly, or
-            accept a `.pptx` / `.pdf` upload. Uploaded files go through a
-            Python extraction pass that keeps only token-relevant signals and
-            compact page summaries before generating the canonical draft bundle.
+            BurnGuard가 저장소나 웹사이트를 바로 읽어 오거나, PPTX/PDF 업로드를
+            받을 수 있어요. 업로드한 파일은 Python 추출 단계를 거쳐
+            토큰에 필요한 신호와 짧은 페이지 요약만 남긴 뒤 표준 초안 묶음을
+            만들어요.
           </p>
 
           <div className="mt-4 inline-flex rounded-lg border border-border bg-background p-1">
@@ -537,7 +567,7 @@ function SystemsSection({
                   : "text-muted-foreground hover:text-foreground"
               }`}
             >
-              URL import
+              URL로 가져오기
             </button>
             <button
               type="button"
@@ -549,7 +579,7 @@ function SystemsSection({
                   : "text-muted-foreground hover:text-foreground"
               }`}
             >
-              Upload file
+              파일 업로드
             </button>
           </div>
 
@@ -558,7 +588,7 @@ function SystemsSection({
               <>
                 <div className="md:col-span-2">
                   <label className="text-xs font-medium text-muted-foreground">
-                    Source URL
+                    원본 URL
                   </label>
                   <Input
                     value={sourceUrl}
@@ -571,7 +601,7 @@ function SystemsSection({
 
                 <div>
                   <label className="text-xs font-medium text-muted-foreground">
-                    Source type
+                    원본 종류
                   </label>
                   <select
                     value={sourceType}
@@ -587,15 +617,15 @@ function SystemsSection({
                     disabled={isPending}
                     className="mt-1.5 flex h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:opacity-50"
                   >
-                    <option value="auto">Auto-detect</option>
-                    <option value="github">Git repository</option>
-                    <option value="website">Website</option>
-                    <option value="figma">Figma file</option>
+                    <option value="auto">자동 감지</option>
+                    <option value="github">Git 저장소</option>
+                    <option value="website">웹사이트</option>
+                    <option value="figma">Figma 파일</option>
                   </select>
                   {sourceType === "figma" && (
                     <p className="mt-1 text-[11px] text-muted-foreground">
-                      Requires a Figma personal access token. Set it in
-                      Settings → Figma access.
+                      Figma 개인 액세스 토큰이 필요해요. 설정 → Figma 액세스에서
+                      먼저 등록해 주세요.
                     </p>
                   )}
                 </div>
@@ -604,7 +634,7 @@ function SystemsSection({
               <>
                 <div className="md:col-span-2">
                   <label className="text-xs font-medium text-muted-foreground">
-                    Upload file
+                    업로드할 파일
                   </label>
                   <input
                     type="file"
@@ -616,28 +646,29 @@ function SystemsSection({
                     className="mt-1.5 block h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm file:mr-3 file:rounded-md file:border-0 file:bg-accent/10 file:px-2.5 file:py-1.5 file:text-xs file:font-medium file:text-accent"
                   />
                   <p className="mt-1 text-xs text-muted-foreground">
-                    Supported: `.pptx`, `.pdf` · Max 48 MB
+                    지원 형식: PPTX, PDF · 최대 48 MB
                     {uploadFile
-                      ? ` · Selected: ${uploadFile.name} (${formatBytes(uploadFile.size)})`
+                      ? ` · 선택한 파일: ${uploadFile.name} (${formatBytes(uploadFile.size)})`
                       : ""}
                   </p>
                   {uploadTooLarge && uploadFile ? (
                     <p className="mt-1 text-xs text-destructive">
-                      {uploadFile.name} is {formatBytes(uploadFile.size)} — the
-                      backend accepts up to 48 MB. Export a trimmed version or
-                      split the deck into multiple uploads.
+                      선택한 {uploadFile.name} 크기는{" "}
+                      {formatBytes(uploadFile.size)}예요. 최대 48 MB까지 올릴 수
+                      있으니 용량을 줄여 다시 내보내거나 파일을 나눠서 올려
+                      주세요.
                     </p>
                   ) : null}
                 </div>
 
                 <div className="rounded-md border border-border bg-background px-3 py-2 text-xs leading-5 text-muted-foreground">
-                  Python pass:
+                  Python 추출 항목:
                   <div className="mt-1 font-mono text-[11px] text-foreground">
-                    fonts / colors
+                    폰트 / 색상
                     <br />
-                    headings / body
+                    제목 / 본문
                     <br />
-                    page summaries
+                    페이지 요약
                     <br />
                     upload-manifest.json
                   </div>
@@ -647,19 +678,19 @@ function SystemsSection({
 
             <div className="md:col-span-2">
               <label className="text-xs font-medium text-muted-foreground">
-                Draft name
+                초안 이름
               </label>
               <Input
                 value={draftName}
                 onChange={(e) => onDraftNameChange(e.target.value)}
-                placeholder="Optional override"
+                placeholder="비워 두면 원본 이름을 그대로 써요"
                 disabled={isPending}
                 className="mt-1.5"
               />
             </div>
 
             <div className="rounded-md border border-border bg-background px-3 py-2 text-xs leading-5 text-muted-foreground">
-              Output:
+              생성 결과:
               <div className="mt-1 font-mono text-[11px] text-foreground">
                 README.md
                 <br />
@@ -680,14 +711,14 @@ function SystemsSection({
             <Button variant="cta" disabled={!canImport} onClick={onImport}>
               {isPending
                 ? importMode === "upload"
-                  ? "Uploading..."
-                  : "Importing..."
+                  ? "올리는 중..."
+                  : "가져오는 중..."
                 : importMode === "upload"
-                  ? "Upload design file"
-                  : "Import design system"}
+                  ? "디자인 파일 올리기"
+                  : "디자인 시스템 가져오기"}
             </Button>
             <Button variant="outline" disabled={isPending} onClick={onToggleImport}>
-              Cancel
+              취소
             </Button>
           </div>
         </div>

--- a/packages/frontend/src/views/HomeView.tsx
+++ b/packages/frontend/src/views/HomeView.tsx
@@ -17,10 +17,12 @@ import {
 } from "@/api/home";
 import CardGrid from "@/components/home/CardGrid";
 import {
+  filterHomeCards,
   projectToCard,
   systemToCard,
   type CardViewModel,
 } from "@/components/home/mappers";
+import ProjectCardSection from "@/components/home/ProjectCardSection";
 import ProjectCard from "@/components/home/ProjectCard";
 import DeleteDesignSystemDialog from "@/components/home/DeleteDesignSystemDialog";
 import DeleteProjectDialog from "@/components/home/DeleteProjectDialog";
@@ -43,6 +45,7 @@ export default function HomeView() {
   const queryClient = useQueryClient();
   const pushToast = useUIStore((s) => s.pushToast);
   const [activeTab, setActiveTab] = useState<HomeTab>("recent");
+  const [projectQuery, setProjectQuery] = useState("");
   const cliMissingShown = useUIStore((s) => s.cliMissingShown);
   const setCliMissingShown = useUIStore((s) => s.setCliMissingShown);
   const [cliMissingOpen, setCliMissingOpen] = useState(false);
@@ -237,6 +240,9 @@ export default function HomeView() {
   const recentCards = (recentQuery.data ?? []).map(projectToCard);
   const mineCards = (mineQuery.data ?? []).map(projectToCard);
   const exampleCards = (examplesQuery.data ?? []).map(projectToCard);
+  const filteredRecentCards = filterHomeCards(recentCards, projectQuery);
+  const filteredMineCards = filterHomeCards(mineCards, projectQuery);
+  const filteredExampleCards = filterHomeCards(exampleCards, projectQuery);
   const systemCards = (systemsQuery.data ?? []).map((system, index) =>
     systemToCard(system, index),
   );
@@ -252,33 +258,60 @@ export default function HomeView() {
           onValueChange={(value) => setActiveTab(value as HomeTab)}
           className="flex flex-1 flex-col"
         >
-          <div className="flex items-center justify-between gap-4 px-8 pb-4 pt-8">
-            <TabsList>
+          <div className="flex items-center justify-between gap-4 px-8 pb-4 pt-8 max-[640px]:flex-col max-[640px]:items-stretch max-[640px]:px-4 max-[640px]:pt-4">
+            <TabsList className="max-[640px]:grid max-[640px]:h-auto max-[640px]:w-full max-[640px]:grid-cols-2">
               <TabsTrigger value="recent">Recent</TabsTrigger>
               <TabsTrigger value="mine">Your designs</TabsTrigger>
               <TabsTrigger value="examples">Examples</TabsTrigger>
               <TabsTrigger value="systems">Design systems</TabsTrigger>
             </TabsList>
 
-            <div className="relative max-w-xs w-full">
-              <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input placeholder="Search" className="pl-8" />
-            </div>
+            {activeTab === "systems" ? null : (
+              <div className="relative w-full max-w-xs max-[640px]:max-w-none">
+                <Search
+                  aria-hidden="true"
+                  className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                />
+                <Input
+                  type="search"
+                  aria-label="프로젝트 검색"
+                  placeholder="프로젝트 검색"
+                  value={projectQuery}
+                  onChange={(event) => setProjectQuery(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Escape") {
+                      setProjectQuery("");
+                    }
+                  }}
+                  className="pl-8"
+                />
+              </div>
+            )}
           </div>
 
-          <div className="px-8 pb-8">
+          <div className="px-8 pb-8 max-[640px]:px-4">
             <TabsContent value="recent">
-              <CardSection
-                cards={recentCards}
-                emptyText="No recent projects yet."
+              <ProjectCardSection
+                cards={filteredRecentCards}
+                sourceCount={recentCards.length}
+                query={projectQuery}
+                isLoading={recentQuery.isPending}
+                error={recentQuery.error}
+                emptyText="최근 프로젝트가 아직 없습니다."
+                onRetry={() => void recentQuery.refetch()}
                 onDelete={onProjectDelete}
               />
             </TabsContent>
 
             <TabsContent value="mine">
-              <CardSection
-                cards={mineCards}
-                emptyText="No personal projects yet."
+              <ProjectCardSection
+                cards={filteredMineCards}
+                sourceCount={mineCards.length}
+                query={projectQuery}
+                isLoading={mineQuery.isPending}
+                error={mineQuery.error}
+                emptyText="내 프로젝트가 아직 없습니다."
+                onRetry={() => void mineQuery.refetch()}
                 onDelete={onProjectDelete}
               />
             </TabsContent>
@@ -301,9 +334,14 @@ export default function HomeView() {
                     : "Restore samples"}
                 </Button>
               </div>
-              <CardSection
-                cards={exampleCards}
-                emptyText="No template-based examples yet."
+              <ProjectCardSection
+                cards={filteredExampleCards}
+                sourceCount={exampleCards.length}
+                query={projectQuery}
+                isLoading={examplesQuery.isPending}
+                error={examplesQuery.error}
+                emptyText="예제 프로젝트가 아직 없습니다."
+                onRetry={() => void examplesQuery.refetch()}
                 onDelete={onProjectDelete}
               />
             </TabsContent>
@@ -655,36 +693,6 @@ function SystemsSection({
         </div>
       ) : null}
     </div>
-  );
-}
-
-function CardSection({
-  cards,
-  emptyText,
-  onDelete,
-}: {
-  cards: CardViewModel[];
-  emptyText: string;
-  onDelete?: (card: CardViewModel) => void;
-}) {
-  if (cards.length === 0) {
-    return (
-      <div className="rounded-xl border border-dashed border-border bg-card/50 p-16 text-center text-sm text-muted-foreground">
-        {emptyText}
-      </div>
-    );
-  }
-
-  return (
-    <CardGrid>
-      {cards.map((card) => (
-        <ProjectCard
-          key={card.id}
-          {...card}
-          onDelete={onDelete ? () => onDelete(card) : undefined}
-        />
-      ))}
-    </CardGrid>
   );
 }
 

--- a/packages/frontend/src/views/ProjectView.tsx
+++ b/packages/frontend/src/views/ProjectView.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -10,6 +11,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
   Comment,
+  DesignDirectionState,
   FileInfo,
   NormalizedEvent,
   PatchFileRequest,
@@ -17,6 +19,7 @@ import type {
   ProjectDetail,
   SessionInfo,
 } from "@bg/shared";
+import { parseDesignDirectionState } from "@bg/shared";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import {
   getArtifacts,
@@ -35,6 +38,14 @@ import {
 } from "@/api/comments";
 import { getSettings } from "@/api/home";
 import {
+  cancelDesignDirections,
+  generateDesignDirections,
+  getDesignDirectionState,
+  retryDesignDirections,
+  selectDesignDirection,
+  undoDesignDirectionSelection,
+} from "@/api/design-directions";
+import {
   interruptSession,
   listSessionEvents,
   sendUserEvent,
@@ -42,6 +53,8 @@ import {
   subscribeSessionStream,
 } from "@/api/session";
 import ChatPane from "@/components/chat/ChatPane";
+import { DirectionsView } from "@/components/directions/DirectionsView";
+import { DirectionStatusBar } from "@/components/directions/DirectionStatusBar";
 import PermissionDialog, {
   type PermissionRequest,
 } from "@/components/chat/PermissionDialog";
@@ -73,6 +86,10 @@ import DesignFilesView from "@/views/DesignFilesView";
 import DesignSystemView from "@/views/DesignSystemView";
 import { useUIStore } from "@/state/uiStore";
 import type { ArtifactTab, SelectedNode } from "@/types/project";
+import {
+  latestDirectionState,
+  preferDirectionState,
+} from "@/lib/design-direction-state";
 
 export default function ProjectView() {
   const { id } = useParams();
@@ -136,6 +153,7 @@ export default function ProjectView() {
   );
   const [refreshTick, setRefreshTick] = useState(0);
   const [sendPending, setSendPending] = useState(false);
+  const [directionActionError, setDirectionActionError] = useState<Error | null>(null);
   const seenEventIdsRef = useRef(new Set<string>());
   const latestEventTsRef = useRef<number | undefined>(undefined);
   const activeTabIdRef = useRef(activeTabId);
@@ -174,6 +192,73 @@ export default function ProjectView() {
   const settingsQuery = useQuery({
     queryKey: ["settings"],
     queryFn: getSettings,
+  });
+  const directionQueryKey = useMemo(
+    () => ["project", id, "design-directions"] as const,
+    [id],
+  );
+  const directionQuery = useQuery({
+    queryKey: directionQueryKey,
+    queryFn: async () => {
+      const incoming = await getDesignDirectionState(id ?? "");
+      const current =
+        queryClient.getQueryData<DesignDirectionState | null>(directionQueryKey) ?? null;
+      return preferDirectionState(current, incoming);
+    },
+    enabled: Boolean(id),
+  });
+  const mergeDirectionCache = useCallback(
+    (incoming: DesignDirectionState | null) => {
+      queryClient.setQueryData<DesignDirectionState | null>(
+        directionQueryKey,
+        (current) => preferDirectionState(current ?? null, incoming),
+      );
+    },
+    [directionQueryKey, queryClient],
+  );
+
+  const generateDirectionsMutation = useMutation({
+    mutationFn: () => generateDesignDirections(id ?? ""),
+    onMutate: () => setDirectionActionError(null),
+    onSuccess: mergeDirectionCache,
+    onError: setDirectionActionError,
+  });
+  const cancelDirectionsMutation = useMutation({
+    mutationFn: () => cancelDesignDirections(id ?? ""),
+    onMutate: () => setDirectionActionError(null),
+    onSuccess: mergeDirectionCache,
+    onError: setDirectionActionError,
+  });
+  const retryDirectionsMutation = useMutation({
+    mutationFn: () => retryDesignDirections(id ?? ""),
+    onMutate: () => setDirectionActionError(null),
+    onSuccess: mergeDirectionCache,
+    onError: setDirectionActionError,
+  });
+  const selectDirectionMutation = useMutation({
+    mutationFn: (input: {
+      readonly generationId: string;
+      readonly revision: number;
+      readonly directionId: string;
+    }) =>
+      selectDesignDirection(id ?? "", {
+        generation_id: input.generationId,
+        expected_selection_revision: input.revision,
+        direction_id: input.directionId,
+      }),
+    onMutate: () => setDirectionActionError(null),
+    onSuccess: mergeDirectionCache,
+    onError: setDirectionActionError,
+  });
+  const undoDirectionMutation = useMutation({
+    mutationFn: (input: { readonly generationId: string; readonly revision: number }) =>
+      undoDesignDirectionSelection(id ?? "", {
+        generation_id: input.generationId,
+        expected_selection_revision: input.revision,
+      }),
+    onMutate: () => setDirectionActionError(null),
+    onSuccess: mergeDirectionCache,
+    onError: setDirectionActionError,
   });
 
   const refreshMutation = useMutation({
@@ -378,6 +463,7 @@ export default function ProjectView() {
     setDrawResetKey("");
     setPresentOpen(false);
     setDecidedToolCallIds(new Set());
+    setDirectionActionError(null);
     setRefreshTick(0);
   }, [id]);
 
@@ -538,7 +624,9 @@ export default function ProjectView() {
   useEffect(() => {
     if (!replayQuery.data) return;
     appendEvents(replayQuery.data, seenEventIdsRef, latestEventTsRef, setEvents);
-  }, [replayQuery.data]);
+    const latest = latestDirectionState(replayQuery.data);
+    mergeDirectionCache(latest === null ? null : parseDesignDirectionState(latest));
+  }, [mergeDirectionCache, replayQuery.data]);
 
   useEffect(() => {
     const sessionId = sessionQuery.data?.id;
@@ -549,6 +637,9 @@ export default function ProjectView() {
 
     const connect = () => {
       cleanup = subscribeSessionStream(sessionId, (event) => {
+        if (event.type === "design.direction_state") {
+          mergeDirectionCache(parseDesignDirectionState(event.state));
+        }
         appendEvents([event], seenEventIdsRef, latestEventTsRef, setEvents);
         setSessionState((current) => applyEventToSession(current, event));
         if (
@@ -583,7 +674,7 @@ export default function ProjectView() {
       active = false;
       cleanup();
     };
-  }, [id, queryClient, replayQuery.status, sessionQuery.data?.id]);
+  }, [id, mergeDirectionCache, queryClient, replayQuery.status, sessionQuery.data?.id]);
 
   useEffect(() => {
     const project = projectQuery.data;
@@ -595,7 +686,21 @@ export default function ProjectView() {
   const files: FileInfo[] = filesQuery.data ?? [];
   const artifacts = artifactsQuery.data ?? null;
   const session = sessionState;
-  const composerDisabled = sendPending || session?.status === "running";
+  const directionState = directionQuery.data ?? null;
+  const directionActionPending =
+    generateDirectionsMutation.isPending ||
+    cancelDirectionsMutation.isPending ||
+    retryDirectionsMutation.isPending ||
+    selectDirectionMutation.isPending ||
+    undoDirectionMutation.isPending;
+  const directionError =
+    directionActionError ??
+    (directionState === null && directionQuery.error instanceof Error
+      ? directionQuery.error
+      : null);
+  const directionLoading = directionState?.status === "loading";
+  const chatComposerDisabled = sendPending || session?.status === "running";
+  const composerDisabled = chatComposerDisabled || directionLoading;
 
   // Turn clock. When the composer flips from idle to busy we stamp a
   // start time; a 1s ticker then drives re-renders so `canInterrupt`
@@ -603,21 +708,21 @@ export default function ProjectView() {
   const [turnStartedAt, setTurnStartedAt] = useState<number | null>(null);
   const [nowTs, setNowTs] = useState(() => Date.now());
   useEffect(() => {
-    if (composerDisabled) {
+    if (chatComposerDisabled) {
       setTurnStartedAt((prev) => prev ?? Date.now());
     } else {
       setTurnStartedAt(null);
     }
-  }, [composerDisabled]);
+  }, [chatComposerDisabled]);
   useEffect(() => {
-    if (!composerDisabled) return;
+    if (!chatComposerDisabled) return;
     const handle = window.setInterval(() => setNowTs(Date.now()), 1000);
     return () => window.clearInterval(handle);
-  }, [composerDisabled]);
+  }, [chatComposerDisabled]);
   const abortThresholdMs =
     settingsQuery.data?.chat_abort_threshold_ms ?? 300_000;
   const canInterrupt =
-    composerDisabled &&
+    chatComposerDisabled &&
     turnStartedAt != null &&
     nowTs - turnStartedAt >= abortThresholdMs;
 
@@ -792,6 +897,14 @@ export default function ProjectView() {
           interruptPending={interruptMutation.isPending}
           onInterrupt={() => interruptMutation.mutate()}
           composerInitialText={composerPrefill}
+          statusSlot={
+            <DirectionStatusBar
+              state={directionState}
+              cancelPending={cancelDirectionsMutation.isPending}
+              onOpen={() => setActiveTabId("directions")}
+              onCancel={() => cancelDirectionsMutation.mutate()}
+            />
+          }
           onSend={async (text, attachedFiles, signal) => {
             if (composerDisabled) {
               return;
@@ -847,6 +960,34 @@ export default function ProjectView() {
             onOpenInCanvas={(relPath) =>
               openFileAsTab(relPath, setOpenFileTabs, setActiveTabId)
             }
+          />
+        )}
+
+        {activeTab?.kind === "directions" && (
+          <DirectionsView
+            state={directionState}
+            recovering={directionQuery.isLoading}
+            actionPending={directionActionPending}
+            cancelPending={cancelDirectionsMutation.isPending}
+            error={directionError}
+            onGenerate={() => generateDirectionsMutation.mutate()}
+            onCancel={() => cancelDirectionsMutation.mutate()}
+            onRetry={() => retryDirectionsMutation.mutate()}
+            onSelect={(directionId) => {
+              if (directionState === null) return;
+              selectDirectionMutation.mutate({
+                generationId: directionState.generation_id,
+                revision: directionState.selection_revision,
+                directionId,
+              });
+            }}
+            onUndo={() => {
+              if (directionState === null) return;
+              undoDirectionMutation.mutate({
+                generationId: directionState.generation_id,
+                revision: directionState.selection_revision,
+              });
+            }}
           />
         )}
 
@@ -1057,6 +1198,12 @@ function buildTabs(
       id: "design-system",
       title: project?.design_system_name ?? "Design System",
       kind: "design_system",
+      closeable: false,
+    },
+    {
+      id: "directions",
+      title: "방향 정하기",
+      kind: "directions",
       closeable: false,
     },
     {

--- a/packages/frontend/src/views/ProjectView.tsx
+++ b/packages/frontend/src/views/ProjectView.tsx
@@ -792,7 +792,7 @@ export default function ProjectView() {
           interruptPending={interruptMutation.isPending}
           onInterrupt={() => interruptMutation.mutate()}
           composerInitialText={composerPrefill}
-          onSend={async (text, attachedFiles) => {
+          onSend={async (text, attachedFiles, signal) => {
             if (composerDisabled) {
               return;
             }
@@ -808,17 +808,20 @@ export default function ProjectView() {
                 type: "user.message",
                 text,
                 files: attachedFiles,
-              });
+              }, { signal });
             } catch (error) {
               clearSendPending(sendPendingTimeoutRef, setSendPending);
-              pushToast({
-                title:
-                  error instanceof ApiError && error.status === 409
-                    ? "Turn already running"
-                    : "Could not send message",
-                body: error instanceof Error ? error.message : String(error),
-                tone: "error",
-              });
+              if (!(error instanceof DOMException && error.name === "AbortError")) {
+                pushToast({
+                  title:
+                    error instanceof ApiError && error.status === 409
+                      ? "Turn already running"
+                      : "Could not send message",
+                  body: error instanceof Error ? error.message : String(error),
+                  tone: "error",
+                });
+              }
+              throw error;
             }
           }}
           onOpenFile={(relPath) =>

--- a/packages/frontend/src/views/ProjectView.tsx
+++ b/packages/frontend/src/views/ProjectView.tsx
@@ -94,6 +94,7 @@ import {
   latestDirectionState,
   preferDirectionState,
 } from "@/lib/design-direction-state";
+import { parseProjectGraphicCanvas } from "@/lib/graphic-project";
 import {
   designAuditErrorCode,
   designAuditViewState,
@@ -757,6 +758,12 @@ export default function ProjectView() {
   }, [projectQuery.data]);
 
   const project = projectQuery.data ?? null;
+  const graphicCanvas = useMemo(
+    () => project === null
+      ? null
+      : parseProjectGraphicCanvas(project.type, project.options_json),
+    [project],
+  );
   const files: FileInfo[] = filesQuery.data ?? [];
   const artifacts = artifactsQuery.data ?? null;
   const session = sessionState;
@@ -1120,6 +1127,7 @@ export default function ProjectView() {
               onUndo={() => undoMutation.mutate()}
               qualityFocusedNodeId={auditFocus?.relPath === activeRelPath ? auditFocus.nodeBgId : null}
               onQualityRevealResult={handleQualityRevealResult}
+              graphicCanvas={graphicCanvas}
               comments={comments}
               activeRelPath={activeRelPath}
               activeSlideIdx={activeSlideIdx}

--- a/packages/frontend/src/views/ProjectView.tsx
+++ b/packages/frontend/src/views/ProjectView.tsx
@@ -56,6 +56,7 @@ import {
   subscribeSessionStream,
 } from "@/api/session";
 import ChatPane from "@/components/chat/ChatPane";
+import { visualSourceSendErrorCopy } from "@/components/chat/attachment-intake";
 import { DirectionsView } from "@/components/directions/DirectionsView";
 import { DirectionStatusBar } from "@/components/directions/DirectionStatusBar";
 import PermissionDialog, {
@@ -1008,6 +1009,7 @@ export default function ProjectView() {
         <ChatPane
           events={events}
           session={session}
+          projectFiles={files}
           composerDisabled={composerDisabled}
           canInterrupt={canInterrupt}
           interruptPending={interruptMutation.isPending}
@@ -1046,7 +1048,7 @@ export default function ProjectView() {
                     error instanceof ApiError && error.status === 409
                       ? "Turn already running"
                       : "Could not send message",
-                  body: error instanceof Error ? error.message : String(error),
+                  body: visualSourceSendErrorCopy(error),
                   tone: "error",
                 });
               }

--- a/packages/frontend/src/views/ProjectView.tsx
+++ b/packages/frontend/src/views/ProjectView.tsx
@@ -11,6 +11,8 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
   Comment,
+  DesignAuditFinding,
+  DesignAuditResult,
   DesignDirectionState,
   FileInfo,
   NormalizedEvent,
@@ -29,8 +31,9 @@ import {
   refreshArtifacts,
 } from "@/api/project";
 import { apiFetch, ApiError } from "@/api/client";
+import { getProjectDesignAudit, retryProjectDesignAudit } from "@/api/design-audit";
 import { restoreCheckpoint } from "@/api/checkpoints";
-import { getFileUndoInfo, undoLastFilePatch } from "@/api/files";
+import { getFileUndoInfo, patchProjectFile, undoLastFilePatch } from "@/api/files";
 import {
   createProjectComment,
   listProjectComments,
@@ -75,6 +78,7 @@ import { getProjectDraws, putProjectDraws } from "@/api/draws";
 import PresentOverlay from "@/components/present/PresentOverlay";
 import ModePanel from "@/components/modes/ModePanel";
 import { selectedNodeToTweaksTarget } from "@/components/modes/SelectorReadOnlyPanel";
+import { DESIGN_AUDIT_ERROR_COPY } from "@/components/modes/design-audit-copy";
 import {
   buildTweakChangePreview,
   type TweakChangePreview,
@@ -90,6 +94,13 @@ import {
   latestDirectionState,
   preferDirectionState,
 } from "@/lib/design-direction-state";
+import {
+  designAuditErrorCode,
+  designAuditViewState,
+  groupDesignAuditResult,
+  isDesignAuditCurrent,
+  preferDesignAuditResult,
+} from "@/lib/design-audit-state";
 
 export default function ProjectView() {
   const { id } = useParams();
@@ -139,6 +150,9 @@ export default function ProjectView() {
   const [tweakReview, setTweakReview] = useState<TweakChangePreview | null>(
     null,
   );
+  const [auditFocus, setAuditFocus] = useState<{ readonly findingId: string; readonly nodeBgId: string; readonly relPath: string } | null>(null);
+  const [auditRevealResult, setAuditRevealResult] = useState<"found" | "not_found" | null>(null);
+  const [auditActionError, setAuditActionError] = useState<Error | null>(null);
   const tweaksUndoRef = useRef<TweaksUndoFrame[]>([]);
   const tweaksRedoRef = useRef<TweaksUndoFrame[]>([]);
   const [presentOpen, setPresentOpen] = useState(false);
@@ -158,6 +172,7 @@ export default function ProjectView() {
   const latestEventTsRef = useRef<number | undefined>(undefined);
   const activeTabIdRef = useRef(activeTabId);
   const sendPendingTimeoutRef = useRef<number | null>(null);
+  const turnTouchedFilesRef = useRef(false);
 
   const projectQuery = useQuery({
     queryKey: ["project", id],
@@ -179,6 +194,19 @@ export default function ProjectView() {
     queryFn: () => getArtifacts(id!),
     enabled: Boolean(id),
   });
+  const designAuditQueryKey = useMemo(() => ["project", id, "design-audit"] as const, [id]);
+  const designAuditQuery = useQuery({
+    queryKey: designAuditQueryKey,
+    queryFn: async () => {
+      const incoming = await getProjectDesignAudit(id ?? "");
+      const current = queryClient.getQueryData<DesignAuditResult | null>(designAuditQueryKey) ?? null;
+      return preferDesignAuditResult(current, incoming, id ?? "");
+    },
+    enabled: Boolean(id && artifactsQuery.data?.entrypoint_url),
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  });
+  const invalidateDesignAudit = useCallback(() => queryClient.invalidateQueries({ queryKey: designAuditQueryKey }), [designAuditQueryKey, queryClient]);
   const replayQuery = useQuery({
     queryKey: ["session", sessionQuery.data?.id, "events"],
     queryFn: () => listSessionEvents(sessionQuery.data!.id),
@@ -261,6 +289,34 @@ export default function ProjectView() {
     onError: setDirectionActionError,
   });
 
+  const mergeDesignAuditCache = useCallback((incoming: DesignAuditResult) => {
+    queryClient.setQueryData<DesignAuditResult | null>(designAuditQueryKey, (current) => preferDesignAuditResult(current ?? null, incoming, id ?? ""));
+  }, [designAuditQueryKey, id, queryClient]);
+  const retryDesignAuditMutation = useMutation({
+    mutationFn: () => retryProjectDesignAudit(id ?? ""),
+    onMutate: () => setAuditActionError(null),
+    onSuccess: mergeDesignAuditCache,
+    onError: (error) => setAuditActionError(error instanceof Error ? error : new Error(String(error))),
+  });
+  const safeFixMutation = useMutation({
+    mutationFn: (input: { readonly findingId: string; readonly relPath: string; readonly request: PatchFileRequest }) =>
+      patchProjectFile(id ?? "", input.relPath, input.request),
+    onSuccess: async (_response, input) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["project", id] }),
+        queryClient.invalidateQueries({ queryKey: ["project", id, "files"] }),
+        queryClient.invalidateQueries({ queryKey: ["project", id, "artifacts"] }),
+        queryClient.invalidateQueries({ queryKey: ["project", id, "fs", input.relPath, "undo-info"] }),
+        invalidateDesignAudit(),
+      ]);
+      setRefreshTick((value) => value + 1);
+      pushToast({ title: "안전 수정을 적용했어요", tone: "success" });
+    },
+    onError: (error) => {
+      pushToast({ title: "안전 수정을 적용하지 못했어요", body: DESIGN_AUDIT_ERROR_COPY[designAuditErrorCode(error)], tone: "error" });
+    },
+  });
+
   const refreshMutation = useMutation({
     mutationFn: () => refreshArtifacts(id!),
     onSuccess: async () => {
@@ -269,6 +325,7 @@ export default function ProjectView() {
         queryClient.invalidateQueries({
           queryKey: ["project", id, "artifacts"],
         }),
+        invalidateDesignAudit(),
       ]);
       setRefreshTick((value) => value + 1);
     },
@@ -380,6 +437,7 @@ export default function ProjectView() {
       void queryClient.invalidateQueries({
         queryKey: ["project", id, "fs", variables.relPath, "undo-info"],
       });
+      void invalidateDesignAudit();
       setRefreshTick((value) => value + 1);
     },
     onError: (error) => {
@@ -418,6 +476,7 @@ export default function ProjectView() {
         queryClient.invalidateQueries({
           queryKey: ["project", id, "fs", variables.relPath, "undo-info"],
         }),
+        invalidateDesignAudit(),
       ]);
       setRefreshTick((value) => value + 1);
     },
@@ -464,6 +523,10 @@ export default function ProjectView() {
     setPresentOpen(false);
     setDecidedToolCallIds(new Set());
     setDirectionActionError(null);
+    setAuditFocus(null);
+    setAuditRevealResult(null);
+    setAuditActionError(null);
+    turnTouchedFilesRef.current = false;
     setRefreshTick(0);
   }, [id]);
 
@@ -478,6 +541,7 @@ export default function ProjectView() {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ["project", id, "files"] }),
         queryClient.invalidateQueries({ queryKey: ["project", id, "artifacts"] }),
+        invalidateDesignAudit(),
       ]);
       setRefreshTick((value) => value + 1);
       pushToast({ title: "Turn reverted", tone: "info" });
@@ -651,6 +715,16 @@ export default function ProjectView() {
           clearSendPending(sendPendingTimeoutRef, setSendPending);
         }
 
+        if (event.type === "file.changed") turnTouchedFilesRef.current = true;
+        if (event.type === "status.idle" && turnTouchedFilesRef.current) {
+          turnTouchedFilesRef.current = false;
+          void Promise.all([
+            queryClient.invalidateQueries({ queryKey: ["project", id, "artifacts"] }),
+            invalidateDesignAudit(),
+          ]);
+        }
+        if (event.type === "status.error") turnTouchedFilesRef.current = false;
+
         if (event.type === "file.changed" && id) {
           openFileAsTab(event.path, setOpenFileTabs, setActiveTabId);
           if (activeTabIdRef.current === event.path) {
@@ -674,7 +748,7 @@ export default function ProjectView() {
       active = false;
       cleanup();
     };
-  }, [id, mergeDirectionCache, queryClient, replayQuery.status, sessionQuery.data?.id]);
+  }, [id, invalidateDesignAudit, mergeDirectionCache, queryClient, replayQuery.status, sessionQuery.data?.id]);
 
   useEffect(() => {
     const project = projectQuery.data;
@@ -739,6 +813,33 @@ export default function ProjectView() {
       });
     },
   });
+  useEffect(() => {
+    if (designAuditQuery.dataUpdatedAt > 0) setAuditActionError(null);
+  }, [designAuditQuery.dataUpdatedAt]);
+  const auditReport = designAuditQuery.data ?? null;
+  const auditError = auditActionError ?? (designAuditQuery.error instanceof Error ? designAuditQuery.error : null);
+  const auditState = designAuditViewState({
+    renderable: Boolean(artifactsQuery.data?.entrypoint_url), report: auditReport,
+    pending: designAuditQuery.isFetching, rerunning: retryDesignAuditMutation.isPending,
+    errorCode: auditError === null ? null : designAuditErrorCode(auditError),
+    currentDigest: artifactsQuery.data?.current_digest ?? "",
+  });
+  const openQuality = useCallback(() => {
+    const detail = projectQuery.data;
+    if (!artifactsQuery.data?.entrypoint_url || !detail) {
+      pushToast({ title: "품질 점검을 열 수 없어요", body: "렌더링 가능한 결과물이 아직 없어요.", tone: "warn" });
+      return;
+    }
+    if (!openFileTabs.some((tab) => tab.id === activeTabId)) openFileAsTab(detail.entrypoint, setOpenFileTabs, setActiveTabId);
+    setMode("quality");
+  }, [activeTabId, artifactsQuery.data?.entrypoint_url, openFileTabs, projectQuery.data, pushToast]);
+  const qualityGate = auditReport !== null && isDesignAuditCurrent(auditReport, artifactsQuery.data?.current_digest ?? "") && auditReport.overall_status === "must_fix"
+    ? { mustFixCount: groupDesignAuditResult(auditReport).mustFix.length } : null;
+
+  const handleQualityRevealResult = useCallback((nodeBgId: string, found: boolean) => {
+    if (auditFocus?.nodeBgId === nodeBgId) setAuditRevealResult(found ? "found" : "not_found");
+  }, [auditFocus?.nodeBgId]);
+
   const tabs = useMemo(
     () => buildTabs(project, openFileTabs),
     [openFileTabs, project],
@@ -812,13 +913,14 @@ export default function ProjectView() {
         queryClient.invalidateQueries({
           queryKey: ["project", id, "artifacts"],
         }),
+        invalidateDesignAudit(),
       ]);
       setSelection(null);
       setTweaksTarget(null);
       setTweakReview(null);
-      setMode(null);
+      setMode((current) => current === "quality" ? current : null);
       setRefreshTick((value) => value + 1);
-      pushToast({ title: "Last save undone", tone: "success" });
+      pushToast({ title: "마지막 저장을 실행 취소했어요", tone: "success" });
     },
     onError: (err) => {
       pushToast({
@@ -834,6 +936,11 @@ export default function ProjectView() {
       setActiveTabId(tabs[0]?.id ?? "design-system");
     }
   }, [activeTabId, tabs]);
+
+  useEffect(() => {
+    if (mode !== "quality") { setAuditFocus(null); setAuditRevealResult(null); }
+  }, [mode]);
+  useEffect(() => { setAuditFocus(null); setAuditRevealResult(null); }, [auditReport?.artifact_digest, auditReport?.created_at]);
 
   const isLoading =
     projectQuery.isLoading ||
@@ -872,6 +979,8 @@ export default function ProjectView() {
           Boolean(canvasSrc)
         }
         onPresent={() => setPresentOpen(true)}
+        qualityGate={qualityGate}
+        onOpenQuality={openQuality}
         tabsSlot={
           <ArtifactTabs
             tabs={tabs}
@@ -888,7 +997,7 @@ export default function ProjectView() {
           />
         }
       />
-      <div className="flex min-h-0 flex-1 overflow-hidden max-[900px]:flex-col max-[900px]:overflow-y-auto">
+      <div className="flex min-h-0 flex-1 overflow-hidden max-[900px]:flex-col">
         <ChatPane
           events={events}
           session={session}
@@ -1009,6 +1118,8 @@ export default function ProjectView() {
               canUndo={Boolean(undoInfoQuery.data?.can_undo)}
               undoPending={undoMutation.isPending}
               onUndo={() => undoMutation.mutate()}
+              qualityFocusedNodeId={auditFocus?.relPath === activeRelPath ? auditFocus.nodeBgId : null}
+              onQualityRevealResult={handleQualityRevealResult}
               comments={comments}
               activeRelPath={activeRelPath}
               activeSlideIdx={activeSlideIdx}
@@ -1048,6 +1159,28 @@ export default function ProjectView() {
             />
             <ModePanel
               mode={mode}
+              quality={{
+                state: auditState,
+                pendingFindingId: safeFixMutation.isPending ? safeFixMutation.variables?.findingId ?? null : null,
+                focusedFindingId: auditFocus?.findingId ?? null,
+                revealResult: auditRevealResult,
+                onRetry: () => { if (!safeFixMutation.isPending && !designAuditQuery.isFetching && !retryDesignAuditMutation.isPending) retryDesignAuditMutation.mutate(); },
+                onOpenFile: (finding) => openFileAsTab(finding.source.rel_path, setOpenFileTabs, setActiveTabId),
+                onReveal: (finding) => {
+                  openFileAsTab(finding.source.rel_path, setOpenFileTabs, setActiveTabId);
+                  setMode("quality");
+                  if (finding.source.node_bg_id !== null) {
+                    setAuditFocus({ findingId: finding.id, nodeBgId: finding.source.node_bg_id, relPath: finding.source.rel_path });
+                    setAuditRevealResult(null);
+                  }
+                },
+                onApplySafeFix: (finding) => {
+                  if (finding.safe_fix === undefined || auditReport === null || designAuditQuery.isFetching || retryDesignAuditMutation.isPending || safeFixMutation.isPending || !isDesignAuditCurrent(auditReport, artifacts.current_digest)) return;
+                  openFileAsTab(finding.safe_fix.rel_path, setOpenFileTabs, setActiveTabId);
+                  if (finding.source.node_bg_id !== null) setAuditFocus({ findingId: finding.id, nodeBgId: finding.source.node_bg_id, relPath: finding.source.rel_path });
+                  safeFixMutation.mutate({ findingId: finding.id, relPath: finding.safe_fix.rel_path, request: finding.safe_fix.request });
+                },
+              }}
               selection={selection}
               onPromoteToTweaks={() => {
                 const target = selectedNodeToTweaksTarget(selection);

--- a/packages/frontend/tailwind.config.ts
+++ b/packages/frontend/tailwind.config.ts
@@ -36,6 +36,14 @@ export default {
           DEFAULT: "rgb(var(--accent) / <alpha-value>)",
           foreground: "rgb(var(--accent-foreground) / <alpha-value>)",
         },
+        success: {
+          DEFAULT: "rgb(var(--success) / <alpha-value>)",
+          foreground: "rgb(var(--success-foreground) / <alpha-value>)",
+        },
+        warning: {
+          DEFAULT: "rgb(var(--warning) / <alpha-value>)",
+          foreground: "rgb(var(--warning-foreground) / <alpha-value>)",
+        },
         destructive: {
           DEFAULT: "rgb(var(--destructive) / <alpha-value>)",
           foreground: "rgb(var(--destructive-foreground) / <alpha-value>)",

--- a/packages/frontend/tests/composer-intake.test.ts
+++ b/packages/frontend/tests/composer-intake.test.ts
@@ -4,7 +4,7 @@ import {
   COMPOSER_ATTACHMENT_LIMITS,
   COMPOSER_SUPPORTED_EXTENSIONS,
   planAttachmentIntake,
-  readyAttachmentFiles,
+  readyAttachmentSources,
   resolveSendOutcome,
   type IntakeItem,
 } from "../src/components/chat/attachment-intake";
@@ -20,7 +20,7 @@ function file(name: string, type = "", sizeBytes = 8): File {
 }
 
 function ready(name: string, sizeBytes = 8): IntakeItem {
-  return { status: "ready", file: file(name, "application/pdf", sizeBytes) };
+  return { id: crypto.randomUUID(), status: "ready", file: file(name, "application/pdf", sizeBytes), role: "ordinary_content" };
 }
 
 describe("composer attachment intake", () => {
@@ -28,14 +28,14 @@ describe("composer attachment intake", () => {
     const items = planAttachmentIntake([], [file("deck.pdf", "application/pdf")]);
 
     expect(items).toMatchObject([{ status: "ready" }]);
-    expect(readyAttachmentFiles(items).map((entry) => entry.name)).toEqual(["deck.pdf"]);
+    expect(readyAttachmentSources(items).map((entry) => entry.file.name)).toEqual(["deck.pdf"]);
   });
 
   test("Given an empty queue When a source kind the extractor cannot process is added Then it is rejected as unsupported and never queued for send", () => {
     const items = planAttachmentIntake([], [file("notes.txt", "text/plain")]);
 
     expect(items).toMatchObject([{ status: "rejected", reason: "unsupported_kind" }]);
-    expect(readyAttachmentFiles(items)).toEqual([]);
+    expect(readyAttachmentSources(items)).toEqual([]);
   });
 
   test("Given the queue is already at the backend count limit When one more supported source is added Then it is rejected without disturbing the queued files", () => {
@@ -45,14 +45,14 @@ describe("composer attachment intake", () => {
 
     expect(items).toHaveLength(COMPOSER_ATTACHMENT_LIMITS.maxCount + 1);
     expect(items.at(-1)).toMatchObject({ status: "rejected", reason: "count_exceeded" });
-    expect(readyAttachmentFiles(items)).toHaveLength(COMPOSER_ATTACHMENT_LIMITS.maxCount);
+    expect(readyAttachmentSources(items)).toHaveLength(COMPOSER_ATTACHMENT_LIMITS.maxCount);
   });
 
   test("Given a file past the backend per-file limit When it is added Then it is rejected as too large", () => {
     const items = planAttachmentIntake([], [file("huge.pdf", "application/pdf", COMPOSER_ATTACHMENT_LIMITS.maxBytesPerFile + 1)]);
 
     expect(items).toMatchObject([{ status: "rejected", reason: "too_large" }]);
-    expect(readyAttachmentFiles(items)).toEqual([]);
+    expect(readyAttachmentSources(items)).toEqual([]);
   });
 
   test("Given queued files near the backend total limit When another supported file would cross it Then it is rejected on total size", () => {
@@ -62,13 +62,13 @@ describe("composer attachment intake", () => {
     const items = planAttachmentIntake(current, [file("c.pdf", "application/pdf", 9 * megabyte)]);
 
     expect(items.at(-1)).toMatchObject({ status: "rejected", reason: "total_exceeded" });
-    expect(readyAttachmentFiles(items).map((entry) => entry.name)).toEqual(["a.pdf", "b.pdf"]);
+    expect(readyAttachmentSources(items).map((entry) => entry.file.name)).toEqual(["a.pdf", "b.pdf"]);
   });
 
   test("Given the backend extractor's supported kinds When the composer screens the same names Then the composer mirror matches the backend verdict", () => {
     const probes = ["deck.pdf", "deck.PDF", "slides.pptx", "notes.txt", "photo.png", "archive.zip", "noextension"];
 
-    const composerVerdicts = probes.map((name) => readyAttachmentFiles(planAttachmentIntake([], [file(name)])).length === 1);
+    const composerVerdicts = probes.map((name) => readyAttachmentSources(planAttachmentIntake([], [file(name)])).length === 1);
     const backendVerdicts = probes.map((name) => inferUploadKind(name, null) !== null);
 
     expect(composerVerdicts).toEqual(backendVerdicts);

--- a/packages/frontend/tests/composer-intake.test.ts
+++ b/packages/frontend/tests/composer-intake.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { ApiError } from "../src/api/client";
+import {
+  COMPOSER_ATTACHMENT_LIMITS,
+  COMPOSER_SUPPORTED_EXTENSIONS,
+  planAttachmentIntake,
+  readyAttachmentFiles,
+  resolveSendOutcome,
+  type IntakeItem,
+} from "../src/components/chat/attachment-intake";
+// The backend owns the truth about which sources its extractor can process.
+// Importing it here pins the composer mirror to that authority at test time;
+// the composer itself must not import backend code into the browser bundle.
+import { inferUploadKind } from "../../backend/src/services/upload-kind";
+
+function file(name: string, type = "", sizeBytes = 8): File {
+  const value = new File([new Uint8Array(Math.min(sizeBytes, 1024))], name, { type });
+  if (sizeBytes > 1024) Object.defineProperty(value, "size", { value: sizeBytes });
+  return value;
+}
+
+function ready(name: string, sizeBytes = 8): IntakeItem {
+  return { status: "ready", file: file(name, "application/pdf", sizeBytes) };
+}
+
+describe("composer attachment intake", () => {
+  test("Given an empty queue When a supported source is added Then it is queued ready for send", () => {
+    const items = planAttachmentIntake([], [file("deck.pdf", "application/pdf")]);
+
+    expect(items).toMatchObject([{ status: "ready" }]);
+    expect(readyAttachmentFiles(items).map((entry) => entry.name)).toEqual(["deck.pdf"]);
+  });
+
+  test("Given an empty queue When a source kind the extractor cannot process is added Then it is rejected as unsupported and never queued for send", () => {
+    const items = planAttachmentIntake([], [file("notes.txt", "text/plain")]);
+
+    expect(items).toMatchObject([{ status: "rejected", reason: "unsupported_kind" }]);
+    expect(readyAttachmentFiles(items)).toEqual([]);
+  });
+
+  test("Given the queue is already at the backend count limit When one more supported source is added Then it is rejected without disturbing the queued files", () => {
+    const current = Array.from({ length: COMPOSER_ATTACHMENT_LIMITS.maxCount }, (_, i) => ready(`deck-${i}.pdf`));
+
+    const items = planAttachmentIntake(current, [file("extra.pdf", "application/pdf")]);
+
+    expect(items).toHaveLength(COMPOSER_ATTACHMENT_LIMITS.maxCount + 1);
+    expect(items.at(-1)).toMatchObject({ status: "rejected", reason: "count_exceeded" });
+    expect(readyAttachmentFiles(items)).toHaveLength(COMPOSER_ATTACHMENT_LIMITS.maxCount);
+  });
+
+  test("Given a file past the backend per-file limit When it is added Then it is rejected as too large", () => {
+    const items = planAttachmentIntake([], [file("huge.pdf", "application/pdf", COMPOSER_ATTACHMENT_LIMITS.maxBytesPerFile + 1)]);
+
+    expect(items).toMatchObject([{ status: "rejected", reason: "too_large" }]);
+    expect(readyAttachmentFiles(items)).toEqual([]);
+  });
+
+  test("Given queued files near the backend total limit When another supported file would cross it Then it is rejected on total size", () => {
+    const megabyte = 1024 * 1024;
+    const current = [ready("a.pdf", 9 * megabyte), ready("b.pdf", 9 * megabyte)];
+
+    const items = planAttachmentIntake(current, [file("c.pdf", "application/pdf", 9 * megabyte)]);
+
+    expect(items.at(-1)).toMatchObject({ status: "rejected", reason: "total_exceeded" });
+    expect(readyAttachmentFiles(items).map((entry) => entry.name)).toEqual(["a.pdf", "b.pdf"]);
+  });
+
+  test("Given the backend extractor's supported kinds When the composer screens the same names Then the composer mirror matches the backend verdict", () => {
+    const probes = ["deck.pdf", "deck.PDF", "slides.pptx", "notes.txt", "photo.png", "archive.zip", "noextension"];
+
+    const composerVerdicts = probes.map((name) => readyAttachmentFiles(planAttachmentIntake([], [file(name)])).length === 1);
+    const backendVerdicts = probes.map((name) => inferUploadKind(name, null) !== null);
+
+    expect(composerVerdicts).toEqual(backendVerdicts);
+    expect([...COMPOSER_SUPPORTED_EXTENSIONS]).toEqual([".pdf", ".pptx"]);
+  });
+});
+
+describe("composer send outcome", () => {
+  test("Given a request aborted by the user When the outcome is resolved Then it reports cancellation rather than failure", () => {
+    expect(resolveSendOutcome(new DOMException("aborted", "AbortError"))).toMatchObject({ kind: "cancelled" });
+  });
+
+  test("Given a typed backend rejection When the outcome is resolved Then it carries the backend error code for retry", () => {
+    const outcome = resolveSendOutcome(new ApiError("unsupported_file_kind", "Unsupported source kind", 415, { files: ["notes.txt"] }));
+
+    expect(outcome).toMatchObject({ kind: "failed", code: "unsupported_file_kind" });
+  });
+
+  test("Given an untyped transport failure When the outcome is resolved Then it still resolves to a retryable failure", () => {
+    expect(resolveSendOutcome(new Error("boom"))).toMatchObject({ kind: "failed", code: "unknown" });
+  });
+});

--- a/packages/frontend/tests/design-audit-state.test.ts
+++ b/packages/frontend/tests/design-audit-state.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import type { DesignAuditCheck, DesignAuditFinding, DesignAuditResult } from "@bg/shared";
+import { ApiError } from "../src/api/client";
+import { designAuditActionAvailability, designAuditControlAvailability, designAuditErrorCode, designAuditViewState, groupDesignAuditResult, isDesignAuditCurrent, preferDesignAuditResult } from "../src/lib/design-audit-state";
+import { DESIGN_AUDIT_ERROR_COPY } from "../src/components/modes/design-audit-copy";
+
+const DIGEST_A = "a".repeat(64);
+const DIGEST_B = "b".repeat(64);
+function finding(overrides: Partial<DesignAuditFinding> = {}): DesignAuditFinding {
+  return { id: "finding-1", check_code: "contrast", severity: "must_fix", source: { rel_path: "index.html", node_bg_id: "hero-title" }, evidence: "Contrast ratio 2.1 is below 4.5", measured: 2.1, threshold: 4.5, targeted_action: "increase_color_contrast", ...overrides };
+}
+function check(overrides: Partial<DesignAuditCheck>): DesignAuditCheck {
+  return { code: "contrast", status: "pass", reason: null, findings: [], ...overrides };
+}
+function result(overrides: Partial<DesignAuditResult> = {}): DesignAuditResult {
+  const checks: readonly DesignAuditCheck[] = [check({ code: "text_overflow" }), check({ code: "element_overlap" }), check({ code: "minimum_text_size" }), check({ code: "contrast" }), check({ code: "narrow_width" }), check({ code: "duplicate_node_id" }), check({ code: "missing_image" }), check({ code: "token_usage" })];
+  return { schema_version: 1, project_id: "project-1", artifact_revision: 2, artifact_digest: DIGEST_A, created_at: 100, overall_status: "ready", checks, ...overrides };
+}
+
+describe("preferDesignAuditResult", () => {
+  test("Given snapshots for different projects When merging Then only the current project is accepted", () => {
+    const current = result();
+    const other = result({ project_id: "project-2", artifact_revision: 9 });
+    expect(preferDesignAuditResult(current, other, "project-1")).toBe(current);
+    expect(preferDesignAuditResult(null, other, "project-1")).toBeNull();
+  });
+  test("Given out-of-order snapshots When merging Then revision and creation time decide freshness", () => {
+    const current = result({ artifact_revision: 3, created_at: 100 });
+    expect(preferDesignAuditResult(current, result({ artifact_revision: 2, created_at: 999 }), "project-1")).toBe(current);
+    const newer = result({ artifact_revision: 3, created_at: 101 });
+    expect(preferDesignAuditResult(current, newer, "project-1")).toBe(newer);
+  });
+});
+
+describe("design audit grouping and actions", () => {
+  test("Given fail, unknown, and pass checks When grouped Then unknown never contributes to pass", () => {
+    const report = result({ overall_status: "must_fix", checks: [
+      check({ code: "text_overflow", status: "fail", findings: [finding({ check_code: "text_overflow", targeted_action: "expand_or_reflow_text" })] }),
+      check({ code: "element_overlap", status: "fail", findings: [finding({ id: "recommended", check_code: "element_overlap", severity: "recommended", targeted_action: "separate_overlapping_elements" })] }),
+      check({ code: "minimum_text_size" }), check({ code: "contrast" }),
+      check({ code: "narrow_width", status: "unmeasurable", reason: "unresolvable_rendering" }),
+      check({ code: "duplicate_node_id" }), check({ code: "missing_image" }),
+      check({ code: "token_usage", status: "skipped", reason: "tokens_not_exposed" }),
+    ] });
+    const grouped = groupDesignAuditResult(report);
+    expect(grouped.mustFix.map((item) => item.id)).toEqual(["finding-1"]);
+    expect(grouped.recommended.map((item) => item.id)).toEqual(["recommended"]);
+    expect(grouped.unknown.map((item) => [item.code, item.status, item.reason])).toEqual([["narrow_width", "unmeasurable", "unresolvable_rendering"], ["token_usage", "skipped", "tokens_not_exposed"]]);
+    expect(grouped.passedCount).toBe(4);
+  });
+  test("Given a stale safe-fix finding When resolving actions Then reveal stays available and mutation is closed", () => {
+    const withFix = finding({ safe_fix: { kind: "patch_html_node", rel_path: "index.html", request: { node_bg_id: "hero-title", styles: { "font-size": "12px" } } } });
+    expect(designAuditActionAvailability(withFix, { current: false, running: false, pendingFindingId: null })).toEqual({ canOpenFile: true, canReveal: true, canApplySafeFix: false, applying: false });
+  });
+  test("Given a running audit or pending fix When resolving actions Then rerun and every fix are mutually excluded", () => {
+    const withFix = finding({ safe_fix: { kind: "patch_html_node", rel_path: "index.html", request: { node_bg_id: "hero-title", styles: { "font-size": "12px" } } } });
+    expect(designAuditActionAvailability(withFix, { current: true, running: true, pendingFindingId: null }).canApplySafeFix).toBe(false);
+    expect(designAuditActionAvailability(withFix, { current: true, running: false, pendingFindingId: "other" })).toMatchObject({ canApplySafeFix: false, applying: false });
+    expect(designAuditActionAvailability(withFix, { current: true, running: false, pendingFindingId: withFix.id })).toMatchObject({ canApplySafeFix: false, applying: true });
+    expect(designAuditControlAvailability({ running: false, pendingFindingId: withFix.id }).canRetry).toBe(false);
+    expect(designAuditControlAvailability({ running: true, pendingFindingId: null }).canRetry).toBe(false);
+    expect(designAuditControlAvailability({ running: false, pendingFindingId: null }).canRetry).toBe(true);
+  });
+});
+
+describe("design audit state", () => {
+  test("Given report and artifact identities When comparing Then only equal digests are current", () => {
+    expect(isDesignAuditCurrent(result(), DIGEST_A)).toBe(true);
+    expect(isDesignAuditCurrent(result(), DIGEST_B)).toBe(false);
+  });
+  test("Given every query condition When deriving Then the closed view-state variants are returned", () => {
+    const current = result();
+    const mustFix = result({ overall_status: "must_fix", checks: current.checks.map((item) => item.code === "contrast" ? check({ code: "contrast", status: "fail", findings: [finding()] }) : item) });
+    const recommended = result({ overall_status: "recommended", checks: current.checks.map((item) => item.code === "token_usage" ? check({ code: "token_usage", status: "skipped", reason: "tokens_not_exposed" }) : item) });
+    expect(designAuditViewState({ renderable: false, report: null, pending: false, rerunning: false, errorCode: null, currentDigest: DIGEST_A }).kind).toBe("unavailable");
+    expect(designAuditViewState({ renderable: true, report: null, pending: true, rerunning: false, errorCode: null, currentDigest: DIGEST_A }).kind).toBe("loading");
+    expect(designAuditViewState({ renderable: true, report: null, pending: false, rerunning: false, errorCode: "audit_unavailable", currentDigest: DIGEST_A }).kind).toBe("error_cold");
+    expect(designAuditViewState({ renderable: true, report: current, pending: false, rerunning: false, errorCode: "network_error", currentDigest: DIGEST_A }).kind).toBe("error_warm");
+    expect(designAuditViewState({ renderable: true, report: result({ artifact_digest: DIGEST_B }), pending: false, rerunning: false, errorCode: null, currentDigest: DIGEST_A }).kind).toBe("stale");
+    expect(designAuditViewState({ renderable: true, report: mustFix, pending: false, rerunning: false, errorCode: null, currentDigest: DIGEST_A }).kind).toBe("must_fix");
+    expect(designAuditViewState({ renderable: true, report: recommended, pending: false, rerunning: false, errorCode: null, currentDigest: DIGEST_A }).kind).toBe("recommended");
+    expect(designAuditViewState({ renderable: true, report: current, pending: false, rerunning: true, errorCode: null, currentDigest: DIGEST_A })).toMatchObject({ kind: "ready", running: true });
+  });
+  test("Given bounded and unknown API errors When mapping Then a closed machine code is returned", () => {
+    expect(designAuditErrorCode(new ApiError("project_path_unavailable", "x", 503))).toBe("project_path_unavailable");
+    expect(designAuditErrorCode(new ApiError("stale_revision", "raw", 409))).toBe("stale_revision");
+    expect(designAuditErrorCode(new ApiError("stale_node_fingerprint", "raw", 422))).toBe("stale_node_fingerprint");
+    expect(designAuditErrorCode(new ApiError("node_not_found", "raw", 404))).toBe("node_not_found");
+    expect(designAuditErrorCode(new ApiError("file_not_found", "raw", 404))).toBe("file_not_found");
+    expect(designAuditErrorCode(new ApiError("unexpected", "x", 500))).toBe("unknown_error");
+    expect(designAuditErrorCode(new TypeError("offline"))).toBe("network_error");
+    expect(Object.keys(DESIGN_AUDIT_ERROR_COPY).sort()).toEqual([
+      "audit_unavailable", "file_not_found", "network_error", "node_not_found", "project_not_found", "project_path_unavailable",
+      "stale_artifact_digest", "stale_artifact_identity", "stale_file_hash", "stale_node_fingerprint", "stale_revision", "unknown_error",
+    ]);
+  });
+});

--- a/packages/frontend/tests/design-direction-state.test.ts
+++ b/packages/frontend/tests/design-direction-state.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  DesignDirectionSlot,
+  DesignDirectionState,
+  DesignDirectionStatus,
+  NormalizedEvent,
+} from "@bg/shared";
+import {
+  directionActions,
+  directionProgress,
+  latestDirectionState,
+  preferDirectionState,
+} from "../src/lib/design-direction-state";
+
+function slot(
+  id: "editorial" | "modular" | "narrative",
+  order: number,
+  status: DesignDirectionSlot["status"],
+): DesignDirectionSlot {
+  return {
+    id,
+    order,
+    layout_key: id,
+    title: id,
+    summary: id,
+    style_facts: [id],
+    status,
+    preview_url: status === "ready" ? `/preview/${id}` : null,
+    error: status === "failed" || status === "cancelled" ? `${id} failed` : null,
+  };
+}
+
+function state(
+  overrides: Partial<DesignDirectionState> & {
+    readonly status: DesignDirectionStatus;
+    readonly updated_at: number;
+  },
+): DesignDirectionState {
+  return {
+    schema_version: 1,
+    project_id: "p1",
+    session_id: "s1",
+    generation_id: "g1",
+    content_outline: ["outline"],
+    directions: [
+      slot("editorial", 0, "pending"),
+      slot("modular", 1, "pending"),
+      slot("narrative", 2, "pending"),
+    ],
+    selected_id: null,
+    selection_revision: 0,
+    selection_history: [],
+    error: null,
+    ...overrides,
+  };
+}
+
+const loading = state({ status: "loading", updated_at: 100 });
+const partial = state({
+  status: "partial",
+  updated_at: 200,
+  directions: [
+    slot("editorial", 0, "ready"),
+    slot("modular", 1, "failed"),
+    slot("narrative", 2, "ready"),
+  ],
+});
+const selected = state({
+  ...partial,
+  status: "partial",
+  updated_at: 300,
+  selected_id: "editorial",
+  selection_revision: 1,
+  selection_history: [null],
+});
+
+function directionEvent(id: string, value: DesignDirectionState): NormalizedEvent {
+  return { id, ts: value.updated_at, type: "design.direction_state", state: value };
+}
+
+describe("latestDirectionState", () => {
+  test("Given out-of-order direction events When deriving Then the newest snapshot wins", () => {
+    const events: readonly NormalizedEvent[] = [
+      directionEvent("e2", partial),
+      directionEvent("e1", loading),
+      directionEvent("e3", selected),
+      { id: "e4", ts: 999, type: "status.running" },
+    ];
+    expect(latestDirectionState(events)).toBe(selected);
+  });
+
+  test("Given same-millisecond snapshots When deriving Then the higher selection revision wins", () => {
+    const undone = state({ ...selected, updated_at: 300, selected_id: null, selection_revision: 2, selection_history: [] });
+    expect(latestDirectionState([directionEvent("e2", undone), directionEvent("e1", selected)])).toBe(undone);
+  });
+
+  test("Given no direction events When deriving Then no state is produced", () => {
+    expect(latestDirectionState([{ id: "e1", ts: 1, type: "status.running" }])).toBeNull();
+    expect(latestDirectionState([])).toBeNull();
+  });
+});
+
+describe("preferDirectionState", () => {
+  test("Given a stale mutation response after a newer event When merging Then the newer event state is kept", () => {
+    expect(preferDirectionState(partial, loading)).toBe(partial);
+  });
+
+  test("Given a newer mutation response When merging Then it replaces the cached state", () => {
+    expect(preferDirectionState(partial, selected)).toBe(selected);
+  });
+
+  test("Given an empty cache When merging Then the incoming state is adopted", () => {
+    expect(preferDirectionState(null, loading)).toBe(loading);
+    expect(preferDirectionState(loading, null)).toBe(loading);
+    expect(preferDirectionState(null, null)).toBeNull();
+  });
+});
+
+describe("directionProgress", () => {
+  test("Given a loading generation with one resolved slot When counted Then resolved and total are reported", () => {
+    const running = state({
+      status: "loading",
+      updated_at: 150,
+      directions: [slot("editorial", 0, "ready"), slot("modular", 1, "pending"), slot("narrative", 2, "pending")],
+    });
+    expect(directionProgress(running)).toEqual({ resolved: 1, total: 3 });
+    expect(directionProgress(partial)).toEqual({ resolved: 3, total: 3 });
+  });
+});
+
+describe("directionActions", () => {
+  test("Given no direction state When resolving actions Then only generate is available", () => {
+    expect(directionActions(null)).toEqual({
+      canGenerate: true,
+      canCancel: false,
+      canRetry: false,
+      canSelect: false,
+      canUndo: false,
+    });
+  });
+
+  test("Given a loading generation When resolving actions Then only cancel is available", () => {
+    expect(directionActions(loading)).toEqual({
+      canGenerate: false,
+      canCancel: true,
+      canRetry: false,
+      canSelect: false,
+      canUndo: false,
+    });
+  });
+
+  test("Given a partial generation When resolving actions Then retry and selection are available without undo", () => {
+    expect(directionActions(partial)).toEqual({
+      canGenerate: true,
+      canCancel: false,
+      canRetry: true,
+      canSelect: true,
+      canUndo: false,
+    });
+  });
+
+  test("Given a cancelled generation with a ready slot When resolving actions Then retry and selection stay available", () => {
+    const cancelled = state({
+      status: "cancelled",
+      updated_at: 220,
+      directions: [slot("editorial", 0, "ready"), slot("modular", 1, "cancelled"), slot("narrative", 2, "cancelled")],
+    });
+    expect(directionActions(cancelled).canRetry).toBe(true);
+    expect(directionActions(cancelled).canSelect).toBe(true);
+  });
+
+  test("Given a selection with history When resolving actions Then undo is available", () => {
+    expect(directionActions(selected).canUndo).toBe(true);
+  });
+
+  test("Given a fully ready generation When resolving actions Then retry is unavailable", () => {
+    const ready = state({
+      status: "ready",
+      updated_at: 400,
+      directions: [slot("editorial", 0, "ready"), slot("modular", 1, "ready"), slot("narrative", 2, "ready")],
+    });
+    expect(directionActions(ready).canRetry).toBe(false);
+    expect(directionActions(ready).canSelect).toBe(true);
+  });
+});

--- a/packages/frontend/tests/error-card.test.ts
+++ b/packages/frontend/tests/error-card.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import ErrorCard from "../src/components/chat/blocks/ErrorCard";
+
+test("Given a sanitized parent-path turn failure When modeled for UI Then no host path renders and retry/report remain available", () => {
+  const raw = "/private/Users/alice/project/.attachments/source.pdf";
+  const html = renderToStaticMarkup(createElement(ErrorCard, {
+    message: "프로젝트 파일에 안전하게 접근할 수 없어요. 다시 시도해 주세요.",
+    recoverable: true,
+  }));
+  expect(html).not.toContain(raw);
+  expect(html).not.toContain("/private/");
+  expect(html).toContain("프로젝트 파일에 안전하게 접근할 수 없어요");
+  expect(html).toContain("Retry");
+  expect(html).toContain("Report");
+});

--- a/packages/frontend/tests/graphic-export-options.test.ts
+++ b/packages/frontend/tests/graphic-export-options.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildExportMenuModel,
+  buildExportRetryRequest,
+} from "../src/components/export/export-options";
+
+describe("graphic export menu model", () => {
+  test("Given persisted graphic dimensions When modeled Then only exact DPR1 PNG is exposed", () => {
+    expect(buildExportMenuModel("graphic", JSON.stringify({
+      use_speaker_notes: false,
+      copy_as_is: false,
+      design_brief: null,
+      graphic_canvas: { schema_version: 1, width: 1200, height: 628 },
+    }))).toEqual({
+      ok: true,
+      options: [{
+        key: "graphic-png",
+        format: "png",
+        options: { png_width: 1200, png_height: 628, png_dpr: 1 },
+        label: "PNG · 1200×628",
+      }],
+    });
+  });
+
+  test.each([null, "{", JSON.stringify({ graphic_canvas: null })])(
+    "Given missing or malformed persisted dimensions When modeled Then no wrong-size action is exposed",
+    (optionsJson) => {
+      const model = buildExportMenuModel("graphic", optionsJson);
+      expect(model.ok).toBe(false);
+      if (model.ok) throw new TypeError("expected invalid graphic export model");
+      expect(model.options).toEqual([]);
+    },
+  );
+
+  test("Given graphic PNG retry When requested Then persisted exact options are reused", () => {
+    const model = buildExportMenuModel("graphic", JSON.stringify({
+      graphic_canvas: { schema_version: 1, width: 1200, height: 628 },
+    }));
+
+    expect(buildExportRetryRequest("graphic", "png", model)).toEqual({
+      format: "png",
+      options: { png_width: 1200, png_height: 628, png_dpr: 1 },
+    });
+  });
+
+  test("Given a standard retry When requested Then existing format-only semantics remain", () => {
+    const model = buildExportMenuModel("prototype", null);
+    expect(buildExportRetryRequest("prototype", "html_zip", model)).toEqual({
+      format: "html_zip",
+    });
+  });
+
+  test("Given a non-graphic project When modeled Then existing actions remain available", () => {
+    const model = buildExportMenuModel("prototype", null);
+    expect(model.ok).toBe(true);
+    if (!model.ok) throw new TypeError("expected normal export model");
+    expect(model.options.filter((option) => option.disabledReason === undefined).map((option) => option.format)).toEqual(["html_zip", "handoff"]);
+    expect(model.options.filter((option) => option.disabledReason === "deck_only").map((option) => option.format)).toEqual(["pdf", "pdf", "pdf", "pptx", "pptx"]);
+  });
+});

--- a/packages/frontend/tests/graphic-preview.test.ts
+++ b/packages/frontend/tests/graphic-preview.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { buildSandboxedArtifactSrcDoc } from "../src/components/canvas/frame-bridge";
+import { computeGraphicPreviewFit } from "../src/lib/graphic-preview";
+import { parseProjectGraphicCanvas } from "../src/lib/graphic-project";
+
+const GRAPHIC_HTML = "<!doctype html><html><head><title>Graphic</title></head><body><main data-graphic-artboard><h1 data-bg-node-id=title>Title</h1></main></body></html>";
+const BASE_HREF = "http://local/api/projects/p/fs/index.html";
+
+describe("graphic preview fit", () => {
+  test.each([
+    [{ width: 375, height: 315 }, { width: 1200, height: 628 }, { scale: 0.3125, x: 0, y: 59.375, renderedWidth: 375, renderedHeight: 196.25 }],
+    [{ width: 375, height: 315 }, { width: 1080, height: 1920 }, { scale: 0.1640625, x: 98.90625, y: 0, renderedWidth: 177.1875, renderedHeight: 315 }],
+    [{ width: 768, height: 500 }, { width: 1080, height: 1080 }, { scale: 0.46296296296296297, x: 134, y: 0, renderedWidth: 500, renderedHeight: 500 }],
+    [{ width: 1280, height: 900 }, { width: 320, height: 240 }, { scale: 1, x: 480, y: 330, renderedWidth: 320, renderedHeight: 240 }],
+  ] as const)("Given container and canvas When fitted Then the whole artboard is centered without upscale", (container, canvas, expected) => {
+    expect(computeGraphicPreviewFit(container, canvas)).toEqual(expected);
+  });
+
+  test("Given strict graphic dimensions When sandboxed Then fit runtime is bounded and coordinate-coherent", () => {
+    const sourceHash = createHash("sha256").update(GRAPHIC_HTML).digest("hex");
+    const srcDoc = buildSandboxedArtifactSrcDoc(GRAPHIC_HTML, BASE_HREF, {
+      graphicCanvas: { schema_version: 1, width: 1200, height: 628 },
+    });
+    const runtime = srcDoc.match(/<script data-bg-graphic-preview-runtime>([\s\S]*?)<\/script>/u)?.[1] ?? "";
+
+    expect(createHash("sha256").update(GRAPHIC_HTML).digest("hex")).toBe(sourceHash);
+    expect(runtime).toContain('const canvas={"schema_version":1,"width":1200,"height":628}');
+    const listener = 'window.addEventListener("resize",applyFit)';
+    expect(runtime).toContain(listener);
+    expect(runtime.match(/addEventListener\("resize"/gu)).toHaveLength(1);
+    expect(runtime.indexOf(listener)).toBeLessThan(runtime.indexOf("applyFit()"));
+    expect(runtime).not.toContain("document.body");
+    expect(runtime).not.toContain("setInterval");
+    expect(runtime).not.toContain("setTimeout");
+    expect(srcDoc).toContain("transform: translate(var(--bg-graphic-preview-x,0px), var(--bg-graphic-preview-y,0px)) scale(var(--bg-graphic-preview-scale,1)) !important;");
+    expect(srcDoc).toContain("getBoundingClientRect");
+    expect(srcDoc).toContain("document.elementFromPoint");
+    expect(srcDoc).toContain('data-bg-graphic-preview="fit"');
+    expect(srcDoc).toContain("--bg-graphic-preview-scale");
+  });
+
+  test("Given non-graphic sandbox options When built Then prior output stays byte-identical", () => {
+    expect(buildSandboxedArtifactSrcDoc(GRAPHIC_HTML, BASE_HREF, {})).toBe(
+      buildSandboxedArtifactSrcDoc(GRAPHIC_HTML, BASE_HREF),
+    );
+    expect(buildSandboxedArtifactSrcDoc(GRAPHIC_HTML, BASE_HREF)).not.toContain("data-bg-graphic-preview-runtime");
+  });
+
+  test("Given malformed stored dimensions When parsed Then no preview runtime can be enabled", () => {
+    expect(parseProjectGraphicCanvas("graphic", JSON.stringify({
+      graphic_canvas: {
+        schema_version: 1,
+        width: "</script><script>globalThis.breakout=true</script>",
+        height: 628,
+      },
+    }))).toBeNull();
+    expect(parseProjectGraphicCanvas("prototype", JSON.stringify({
+      graphic_canvas: { schema_version: 1, width: 1200, height: 628 },
+    }))).toBeNull();
+  });
+});

--- a/packages/frontend/tests/graphic-project-creation.test.ts
+++ b/packages/frontend/tests/graphic-project-creation.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { parseDesignBriefV1, type CreateProjectRequest } from "@bg/shared";
+import {
+  buildCreateProjectRequest,
+  type BuildResult,
+  type ProjectDraft,
+} from "../src/lib/project-creation";
+
+function draft(overrides: Partial<ProjectDraft> = {}): ProjectDraft {
+  return {
+    name: "SNS 그래픽",
+    type: "graphic",
+    backendId: "claude-code",
+    designSystemId: null,
+    audience: "SNS 방문자",
+    objective: "행사 참여를 안내한다",
+    contentSource: "none",
+    visualMood: "friendly",
+    density: "balanced",
+    outputSize: "responsive",
+    graphicWidth: 1080,
+    graphicHeight: 1080,
+    useSpeakerNotes: false,
+    copyAsIs: false,
+    ...overrides,
+  };
+}
+
+function expectRequest(result: BuildResult): CreateProjectRequest {
+  if (!result.ok) throw new TypeError(`expected request: ${result.problem}`);
+  return result.request;
+}
+
+describe("graphic project creation", () => {
+  test.each([
+    [1080, 1080],
+    [1200, 628],
+    [1080, 1920],
+    [1440, 900],
+  ])("builds exact default preset and custom graphic dimensions", (width, height) => {
+    const request = expectRequest(buildCreateProjectRequest(draft({
+      graphicWidth: width,
+      graphicHeight: height,
+    }), []));
+
+    expect(request.options?.graphic_canvas).toEqual({
+      schema_version: 1,
+      width,
+      height,
+    });
+    expect(parseDesignBriefV1(request.options?.design_brief)).toMatchObject({
+      output_type: "graphic",
+      output_size: "custom",
+    });
+  });
+
+  test.each([
+    [319, 1080, "graphic_width_invalid"],
+    [4097, 1080, "graphic_width_invalid"],
+    [1080.5, 1080, "graphic_width_invalid"],
+    [1080, 239, "graphic_height_invalid"],
+    [1080, 4097, "graphic_height_invalid"],
+    [4000, 4001, "graphic_pixel_limit"],
+  ] as const)("rejects invalid graphic dimensions before create", (width, height, problem) => {
+    expect(buildCreateProjectRequest(draft({
+      graphicWidth: width,
+      graphicHeight: height,
+    }), [])).toEqual({ ok: false, problem });
+  });
+
+  test("keeps non-graphic request options unchanged", () => {
+    const request = expectRequest(buildCreateProjectRequest(draft({
+      type: "prototype",
+      graphicWidth: 1200,
+      graphicHeight: 628,
+    }), []));
+    expect(request.options?.graphic_canvas).toBeUndefined();
+    expect(parseDesignBriefV1(request.options?.design_brief).output_size).toBe("responsive");
+  });
+});

--- a/packages/frontend/tests/home-search.test.ts
+++ b/packages/frontend/tests/home-search.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import type { CardViewModel } from "../src/components/home/mappers";
+import { filterHomeCards } from "../src/components/home/mappers";
+
+const cards: readonly CardViewModel[] = [
+  {
+    id: "quarterly-report",
+    name: "분기 보고서",
+    subtitle: "슬라이드 덱 · 오늘",
+    href: "/projects/quarterly-report",
+    tintClass: "bg-slate-100",
+  },
+  {
+    id: "launch-poster",
+    name: "Launch Poster",
+    subtitle: "프로토타입 · 어제",
+    href: "/projects/launch-poster",
+    tintClass: "bg-rose-100",
+  },
+];
+
+describe("filterHomeCards", () => {
+  test("Given a normalized title query When filtering Then only matching titles remain", () => {
+    expect(filterHomeCards(cards, "  분기   보고서  ")).toEqual([
+      cards[0],
+    ]);
+  });
+
+  test("Given a case-insensitive title query When filtering Then subtitle text does not create a match", () => {
+    expect(filterHomeCards(cards, "launch")).toEqual([cards[1]]);
+    expect(filterHomeCards(cards, "슬라이드")).toEqual([]);
+  });
+
+  test("Given an empty query When filtering Then every card remains available", () => {
+    expect(filterHomeCards(cards, " \n\t ")).toEqual(cards);
+  });
+});

--- a/packages/frontend/tests/project-creation.test.ts
+++ b/packages/frontend/tests/project-creation.test.ts
@@ -49,6 +49,8 @@ function draft(overrides: Partial<ProjectDraft> = {}): ProjectDraft {
     visualMood: "formal",
     density: "balanced",
     outputSize: "widescreen-16x9",
+    graphicWidth: 1080,
+    graphicHeight: 1080,
     useSpeakerNotes: false,
     copyAsIs: false,
     ...overrides,

--- a/packages/frontend/tests/project-thumbnail.test.ts
+++ b/packages/frontend/tests/project-thumbnail.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { resolveThumbnailSource } from "../src/components/home/thumbnail-source";
+
+const url = "/api/projects/p1/thumbnail?v=aaa";
+const nextUrl = "/api/projects/p1/thumbnail?v=bbb";
+
+describe("resolveThumbnailSource", () => {
+  test("Given a thumbnail URL that has not failed When resolved Then the real image URL is used", () => {
+    expect(resolveThumbnailSource(url, null)).toBe(url);
+  });
+
+  test("Given a thumbnail URL that already failed to load When resolved Then the placeholder is used", () => {
+    expect(resolveThumbnailSource(url, url)).toBeNull();
+  });
+
+  test("Given a changed thumbnail URL after an earlier failure When resolved Then the new URL is retried", () => {
+    expect(resolveThumbnailSource(nextUrl, url)).toBe(nextUrl);
+  });
+
+  test("Given no thumbnail URL When resolved Then the placeholder is used", () => {
+    expect(resolveThumbnailSource(null, null)).toBeNull();
+    expect(resolveThumbnailSource(undefined, null)).toBeNull();
+    expect(resolveThumbnailSource("", null)).toBeNull();
+  });
+});

--- a/packages/frontend/tests/session-multipart.test.ts
+++ b/packages/frontend/tests/session-multipart.test.ts
@@ -97,18 +97,26 @@ describe("multipart user event upload", () => {
     expect(failure).toMatchObject({ name: "AbortError" });
   });
 
-  test("Given a successful multipart upload When it is sent Then the message text and every file ride the same form request", async () => {
+  test("Given a successful multipart upload When it is sent Then text files and strict visual roles ride the same form request", async () => {
     let sentBody: FormData | null = null;
     await installAuthorizedFetch(async (_input, init) => {
       sentBody = init?.body instanceof FormData ? init.body : null;
       return Response.json({ data: { accepted: true } });
     });
 
-    await sendUserEvent("session-1", { type: "user.message", text: "봐줘", files: [upload()] });
+    await sendUserEvent("session-1", {
+      type: "user.message",
+      text: "봐줘",
+      files: [{ id: "upload-deck", file: upload(), role: "immutable_reference" }],
+    });
 
     const form = sentBody as FormData | null;
     expect(form?.get("type")).toBe("user.message");
     expect(form?.get("text")).toBe("봐줘");
     expect(form?.getAll("files")).toHaveLength(1);
+    expect(JSON.parse(String(form?.get("visual_sources")))).toEqual({
+      schema_version: 1,
+      sources: [{ source_type: "upload", upload_id: "upload-deck", file_index: 0, role: "immutable_reference" }],
+    });
   });
 });

--- a/packages/frontend/tests/session-multipart.test.ts
+++ b/packages/frontend/tests/session-multipart.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { ApiError, bootstrapApiAuthority } from "../src/api/client";
+import { sendUserEvent } from "../src/api/session";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function upload(): File {
+  return new File([new Uint8Array(4)], "notes.txt", { type: "text/plain" });
+}
+
+async function installAuthorizedFetch(
+  handleRequest: (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Response | Promise<Response>,
+): Promise<void> {
+  globalThis.fetch = mock(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === "/api/bootstrap") {
+        return Response.json({ data: { capability: "launch-token" } });
+      }
+      return await handleRequest(input, init);
+    },
+  ) as typeof fetch;
+  await bootstrapApiAuthority();
+}
+
+describe("multipart user event upload", () => {
+  test("Given API authority When a multipart message is sent Then the capability protects the request", async () => {
+    let sentHeaders: Headers | null = null;
+    await installAuthorizedFetch((_input, init) => {
+      sentHeaders = new Headers(init?.headers);
+      return Response.json({ data: { accepted: true } });
+    });
+
+    await sendUserEvent("session-1", {
+      type: "user.message",
+      text: "봐줘",
+      files: [upload()],
+    });
+
+    expect(sentHeaders?.get("x-burnguard-capability")).toBe("launch-token");
+  });
+
+  test("Given a structured backend rejection When a multipart message is sent Then the typed code and details reach the caller", async () => {
+    await installAuthorizedFetch(async () =>
+      Response.json({ error: { code: "unsupported_file_kind", message: "Unsupported source kind", details: { files: ["notes.txt"], supported_kinds: ["pdf", "pptx"] } } }, { status: 415 }),
+    );
+
+    const failure = await sendUserEvent("session-1", { type: "user.message", text: "봐줘", files: [upload()] }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(ApiError);
+    expect(failure).toMatchObject({ code: "unsupported_file_kind", status: 415, details: { files: ["notes.txt"] } });
+  });
+
+  test("Given a non-JSON transport failure When a multipart message is sent Then it still surfaces a typed API error", async () => {
+    await installAuthorizedFetch(async () =>
+      new Response("gateway down", {
+        status: 502,
+        statusText: "Bad Gateway",
+      }),
+    );
+
+    const failure = await sendUserEvent("session-1", { type: "user.message", text: "봐줘", files: [upload()] }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(ApiError);
+    expect(failure).toMatchObject({ code: "network_error", status: 502 });
+  });
+
+  test("Given a caller-supplied abort signal When a multipart message is sent Then the signal reaches the request and cancellation propagates", async () => {
+    const controller = new AbortController();
+    let seenSignal: AbortSignal | null = null;
+    await installAuthorizedFetch(async (_input, init) => {
+      seenSignal = init?.signal ?? null;
+      return await new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+      });
+    });
+
+    const pending = sendUserEvent("session-1", { type: "user.message", text: "봐줘", files: [upload()] }, { signal: controller.signal });
+    controller.abort();
+    const failure = await pending.then(() => null, (error: unknown) => error);
+
+    expect(seenSignal).toBe(controller.signal);
+    expect(failure).toMatchObject({ name: "AbortError" });
+  });
+
+  test("Given a successful multipart upload When it is sent Then the message text and every file ride the same form request", async () => {
+    let sentBody: FormData | null = null;
+    await installAuthorizedFetch(async (_input, init) => {
+      sentBody = init?.body instanceof FormData ? init.body : null;
+      return Response.json({ data: { accepted: true } });
+    });
+
+    await sendUserEvent("session-1", { type: "user.message", text: "봐줘", files: [upload()] });
+
+    const form = sentBody as FormData | null;
+    expect(form?.get("type")).toBe("user.message");
+    expect(form?.get("text")).toBe("봐줘");
+    expect(form?.getAll("files")).toHaveLength(1);
+  });
+});

--- a/packages/frontend/tests/visual-source-selection.test.ts
+++ b/packages/frontend/tests/visual-source-selection.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { ApiError } from "../src/api/client";
+import {
+  planAttachmentIntake,
+  readyAttachmentSources,
+  setAttachmentRole,
+  visualSourceSendErrorCopy,
+} from "../src/components/chat/attachment-intake";
+import { listExistingVisualSources } from "../src/components/chat/visual-source-selection";
+
+function file(name: string, type = "application/pdf"): File {
+  return new File([new Uint8Array(8)], name, { type });
+}
+
+describe("composer visual source roles", () => {
+  test("Given a supported upload When queued Then ordinary content is the default", () => {
+    const items = planAttachmentIntake([], [file("deck.pdf")]);
+
+    expect(readyAttachmentSources(items)).toEqual([{ id: expect.any(String), file: expect.any(File), role: "ordinary_content" }]);
+  });
+
+  test("Given a ready PDF or PPTX When marked as reference Then immutable role crosses the send model", () => {
+    const queued = planAttachmentIntake([], [file("deck.pptx")]);
+    const id = queued[0]?.id ?? "missing";
+    const items = setAttachmentRole(queued, id, "immutable_reference");
+
+    expect(readyAttachmentSources(items)).toEqual([{ id, file: expect.any(File), role: "immutable_reference" }]);
+  });
+
+  test("Given internal provenance errors When mapped for the project toast Then bounded copy hides internal details", () => {
+    const copy = visualSourceSendErrorCopy(new ApiError("invalid_visual_source_provenance", "raw /tmp/private", 409));
+    expect(copy).not.toContain("invalid_visual_source_provenance");
+    expect(copy).not.toContain("/tmp/private");
+  });
+
+  test("Given duplicate filenames When one stable item is marked Then only that upload changes role", () => {
+    const queued = planAttachmentIntake([], [file("deck.pdf"), file("deck.pdf")]);
+    const secondId = queued[1]?.id ?? "missing";
+
+    const sources = readyAttachmentSources(setAttachmentRole(queued, secondId, "immutable_reference"));
+
+    expect(sources.map((source) => [source.id, source.role])).toEqual([
+      [queued[0]?.id, "ordinary_content"],
+      [secondId, "immutable_reference"],
+    ]);
+  });
+});
+
+describe("existing local visual source disclosure", () => {
+  test("Given indexed managed files When listed Then only safe visual candidates appear as editable project files", () => {
+    const sources = listExistingVisualSources([
+      { rel_path: "assets/hero.png", category: "asset", hash: "a".repeat(64) },
+      { rel_path: "docs/reference.pdf", category: "other", hash: "b".repeat(64) },
+      { rel_path: "slides/source.pptx", category: "other", hash: "c".repeat(64) },
+      { rel_path: "index.html", category: "html", hash: "d".repeat(64) },
+      { rel_path: "../escape.png", category: "asset", hash: "e".repeat(64) },
+      { rel_path: "assets/unhashed.webp", category: "asset", hash: null },
+    ]);
+
+    expect(sources).toEqual([
+      { source_type: "existing_project_file", rel_path: "assets/hero.png", status: "editable", sha256: "a".repeat(64) },
+      { source_type: "existing_project_file", rel_path: "docs/reference.pdf", status: "editable", sha256: "b".repeat(64) },
+      { source_type: "existing_project_file", rel_path: "slides/source.pptx", status: "editable", sha256: "c".repeat(64) },
+    ]);
+  });
+
+  test("Given narrow controls and a long inventory When inspected Then controls are touch-sized and inventory scrolls without truncation", async () => {
+    const attachments = await readFile(path.join(import.meta.dir, "../src/components/chat/ComposerAttachments.tsx"), "utf8");
+    const candidates = await readFile(path.join(import.meta.dir, "../src/components/chat/VisualSourceCandidates.tsx"), "utf8");
+    expect(attachments).toContain("max-[900px]:min-h-11");
+    expect(attachments).toContain("max-[900px]:min-w-11");
+    expect(attachments).toContain("focus-visible:ring-2");
+    expect(attachments).toContain("text-xs");
+    expect(candidates).toContain("overflow-y-auto");
+    expect(candidates).not.toContain("slice(0, 4)");
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -19,6 +19,7 @@
     "./graphic": "./src/graphic.ts",
     "./project": "./src/project.ts",
     "./reference-layout": "./src/reference-layout.ts",
+    "./visual-source": "./src/visual-source.ts",
     "./contract-parser": "./src/contract-parser.ts",
     "./export": "./src/export.ts",
     "./extraction-domain": "./src/extraction-domain.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,6 +16,7 @@
     "./design-direction": "./src/design-direction.ts",
     "./design-audit": "./src/design-audit.ts",
     "./home": "./src/home.ts",
+    "./graphic": "./src/graphic.ts",
     "./project": "./src/project.ts",
     "./reference-layout": "./src/reference-layout.ts",
     "./contract-parser": "./src/contract-parser.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,6 +13,7 @@
     "./harness": "./src/harness.ts",
     "./design-system": "./src/design-system.ts",
     "./design-brief": "./src/design-brief.ts",
+    "./design-direction": "./src/design-direction.ts",
     "./home": "./src/home.ts",
     "./project": "./src/project.ts",
     "./reference-layout": "./src/reference-layout.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,6 +14,7 @@
     "./design-system": "./src/design-system.ts",
     "./design-brief": "./src/design-brief.ts",
     "./design-direction": "./src/design-direction.ts",
+    "./design-audit": "./src/design-audit.ts",
     "./home": "./src/home.ts",
     "./project": "./src/project.ts",
     "./reference-layout": "./src/reference-layout.ts",

--- a/packages/shared/src/app.ts
+++ b/packages/shared/src/app.ts
@@ -10,6 +10,7 @@ export type BackendId = "claude-code" | "codex";
 export type ProjectType =
   | "prototype"
   | "slide_deck"
+  | "graphic"
   | "from_template"
   | "other";
 export type DesignSystemStatus = "draft" | "review" | "published";

--- a/packages/shared/src/design-audit.ts
+++ b/packages/shared/src/design-audit.ts
@@ -1,0 +1,115 @@
+import type { PatchFileRequest } from "./file-patch";
+
+export const DESIGN_AUDIT_CHECK_CODES = ["text_overflow", "element_overlap", "minimum_text_size", "contrast", "narrow_width", "duplicate_node_id", "missing_image", "token_usage"] as const;
+export type DesignAuditCheckCode = (typeof DESIGN_AUDIT_CHECK_CODES)[number];
+export type DesignAuditCheckStatus = "pass" | "fail" | "skipped" | "unmeasurable";
+export type DesignAuditOverallStatus = "ready" | "must_fix" | "recommended";
+export type DesignAuditUnknownReason = "no_measurable_candidates" | "unresolvable_rendering" | "tokens_not_exposed";
+export type DesignAuditSeverity = "must_fix" | "recommended";
+export type DesignAuditTargetedAction = "expand_or_reflow_text" | "separate_overlapping_elements" | "set_minimum_font_size" | "increase_color_contrast" | "repair_narrow_layout" | "assign_unique_node_ids" | "restore_image_reference" | "replace_literal_with_token";
+
+export type DesignAuditSafeFix = { readonly kind: "patch_html_node"; readonly rel_path: string; readonly request: PatchFileRequest };
+export type DesignAuditFinding = {
+  readonly id: string;
+  readonly check_code: DesignAuditCheckCode;
+  readonly severity: DesignAuditSeverity;
+  readonly source: { readonly rel_path: string; readonly node_bg_id: string | null };
+  readonly evidence: string;
+  readonly measured?: number;
+  readonly threshold?: number;
+  readonly targeted_action: DesignAuditTargetedAction;
+  readonly safe_fix?: DesignAuditSafeFix;
+};
+export type DesignAuditCheck = { readonly code: DesignAuditCheckCode; readonly status: DesignAuditCheckStatus; readonly reason: DesignAuditUnknownReason | null; readonly findings: readonly DesignAuditFinding[] };
+export type DesignAuditResult = { readonly schema_version: 1; readonly project_id: string; readonly artifact_revision: number; readonly artifact_digest: string; readonly created_at: number; readonly overall_status: DesignAuditOverallStatus; readonly checks: readonly DesignAuditCheck[] };
+
+const SHA256 = /^[0-9a-f]{64}$/u;
+const REL_PATH = /^(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))(?!.*\\)[^\0]{1,512}$/u;
+const SEVERITIES: Readonly<Record<DesignAuditCheckCode, DesignAuditSeverity>> = { text_overflow: "must_fix", element_overlap: "recommended", minimum_text_size: "recommended", contrast: "must_fix", narrow_width: "must_fix", duplicate_node_id: "must_fix", missing_image: "must_fix", token_usage: "recommended" };
+const ACTIONS: Readonly<Record<DesignAuditCheckCode, DesignAuditTargetedAction>> = {
+  text_overflow: "expand_or_reflow_text", element_overlap: "separate_overlapping_elements", minimum_text_size: "set_minimum_font_size", contrast: "increase_color_contrast", narrow_width: "repair_narrow_layout", duplicate_node_id: "assign_unique_node_ids", missing_image: "restore_image_reference", token_usage: "replace_literal_with_token",
+};
+
+export class DesignAuditContractError extends Error {
+  readonly name = "DesignAuditContractError";
+  constructor(readonly path: string) { super(`Invalid design audit result at ${path}`); }
+}
+
+export function parseDesignAuditResult(input: unknown): DesignAuditResult {
+  const root = record(input, "$", ["schema_version", "project_id", "artifact_revision", "artifact_digest", "created_at", "overall_status", "checks"]);
+  if (root["schema_version"] !== 1) invalid("schema_version");
+  const projectId = boundedString(root["project_id"], "project_id", 200);
+  const artifactRevision = safeInteger(root["artifact_revision"], "artifact_revision");
+  const artifactDigest = hash(root["artifact_digest"], "artifact_digest");
+  const createdAt = safeInteger(root["created_at"], "created_at");
+  const overallStatus = oneOf(root["overall_status"], "overall_status", ["ready", "must_fix", "recommended"] as const);
+  const rawChecks = root["checks"];
+  if (!Array.isArray(rawChecks) || rawChecks.length !== DESIGN_AUDIT_CHECK_CODES.length) invalid("checks");
+  const checks = DESIGN_AUDIT_CHECK_CODES.map((code, index) => parseCheck(rawChecks[index], code, `checks.${index}`));
+  const findings = checks.flatMap((check) => check.findings);
+  if (findings.length > 200 || new Set(findings.map((finding) => finding.id)).size !== findings.length) invalid("checks.findings");
+  if (findings.some((finding) => finding.safe_fix !== undefined && (finding.safe_fix.request.expected_revision !== artifactRevision || finding.safe_fix.request.expected_artifact_digest !== artifactDigest))) invalid("checks.findings.safe_fix");
+  const expected: DesignAuditOverallStatus = findings.some((finding) => finding.severity === "must_fix") ? "must_fix" : checks.every((check) => check.status === "pass") ? "ready" : "recommended";
+  if (overallStatus !== expected) invalid("overall_status");
+  return { schema_version: 1, project_id: projectId, artifact_revision: artifactRevision, artifact_digest: artifactDigest, created_at: createdAt, overall_status: overallStatus, checks };
+}
+
+function parseCheck(input: unknown, expectedCode: DesignAuditCheckCode, path: string): DesignAuditCheck {
+  const value = record(input, path, ["code", "status", "reason", "findings"]);
+  if (value["code"] !== expectedCode) invalid(`${path}.code`);
+  const status = oneOf(value["status"], `${path}.status`, ["pass", "fail", "skipped", "unmeasurable"] as const);
+  const reasonValue = value["reason"];
+  const reason = reasonValue === null ? null : oneOf(reasonValue, `${path}.reason`, ["no_measurable_candidates", "unresolvable_rendering", "tokens_not_exposed"] as const);
+  if ((status === "pass" || status === "fail") !== (reason === null)) invalid(`${path}.reason`);
+  if (status === "skipped" && (expectedCode !== "token_usage" || reason !== "tokens_not_exposed")) invalid(`${path}.reason`);
+  if (status === "unmeasurable" && reason === "tokens_not_exposed") invalid(`${path}.reason`);
+  if (!Array.isArray(value["findings"])  || value["findings"].length > 200) invalid(`${path}.findings`);
+  const findings = value["findings"].map((finding, index) => parseFinding(finding, expectedCode, `${path}.findings.${index}`));
+  if ((status === "fail") !== (findings.length > 0)) invalid(`${path}.status`);
+  return { code: expectedCode, status, reason, findings };
+}
+
+function parseFinding(input: unknown, code: DesignAuditCheckCode, path: string): DesignAuditFinding {
+  const raw = plainRecord(input, path);
+  const allowed = ["id", "check_code", "severity", "source", "evidence", "measured", "threshold", "targeted_action", "safe_fix"];
+  exact(raw, allowed, { path, optional: ["measured", "threshold", "safe_fix"] });
+  const id = boundedString(raw["id"], `${path}.id`, 240);
+  if (raw["check_code"] !== code) invalid(`${path}.check_code`);
+  const severity = oneOf(raw["severity"], `${path}.severity`, ["must_fix", "recommended"] as const);
+  if (severity !== SEVERITIES[code]) invalid(`${path}.severity`);
+  const sourceRaw = record(raw["source"], `${path}.source`, ["rel_path", "node_bg_id"]);
+  const relPath = relativePath(sourceRaw["rel_path"], `${path}.source.rel_path`);
+  const nodeValue = sourceRaw["node_bg_id"];
+  const nodeBgId = nodeValue === null ? null : boundedString(nodeValue, `${path}.source.node_bg_id`, 200);
+  const evidence = boundedString(raw["evidence"], `${path}.evidence`, 500);
+  if (raw["targeted_action"] !== ACTIONS[code]) invalid(`${path}.targeted_action`);
+  const measured = optionalFinite(raw["measured"], `${path}.measured`);
+  const threshold = optionalFinite(raw["threshold"], `${path}.threshold`);
+  const safeFix = raw["safe_fix"] === undefined ? undefined : parseSafeFix({ input: raw["safe_fix"], code, relPath, nodeBgId, path: `${path}.safe_fix` });
+  return { id, check_code: code, severity, source: { rel_path: relPath, node_bg_id: nodeBgId }, evidence, ...(measured === undefined ? {} : { measured }), ...(threshold === undefined ? {} : { threshold }), targeted_action: ACTIONS[code], ...(safeFix === undefined ? {} : { safe_fix: safeFix }) };
+}
+
+function parseSafeFix(context: { readonly input: unknown; readonly code: DesignAuditCheckCode; readonly relPath: string; readonly nodeBgId: string | null; readonly path: string }): DesignAuditSafeFix {
+  const { input, code, relPath, nodeBgId, path } = context;
+  if (code !== "minimum_text_size" || nodeBgId === null) invalid(path);
+  const raw = record(input, path, ["kind", "rel_path", "request"]);
+  if (raw["kind"] !== "patch_html_node" || raw["rel_path"] !== relPath) invalid(path);
+  const request = record(raw["request"], `${path}.request`, ["expected_revision", "expected_artifact_digest", "expected_file_hash", "node_bg_id", "node_fingerprint", "styles"]);
+  const styles = record(request["styles"], `${path}.request.styles`, ["font-size"]);
+  if (request["node_bg_id"] !== nodeBgId || styles["font-size"] !== "12px") invalid(`${path}.request`);
+  const parsed: PatchFileRequest = { expected_revision: safeInteger(request["expected_revision"], `${path}.request.expected_revision`), expected_artifact_digest: hash(request["expected_artifact_digest"], `${path}.request.expected_artifact_digest`), expected_file_hash: hash(request["expected_file_hash"], `${path}.request.expected_file_hash`), node_bg_id: nodeBgId, node_fingerprint: hash(request["node_fingerprint"], `${path}.request.node_fingerprint`), styles: { "font-size": "12px" } };
+  return { kind: "patch_html_node", rel_path: relPath, request: parsed };
+}
+
+function record(value: unknown, path: string, keys: readonly string[]): Readonly<Record<string, unknown>> { const output = plainRecord(value, path); exact(output, keys, { path, optional: [] }); return output; }
+function plainRecord(value: unknown, path: string): Readonly<Record<string, unknown>> { if (!isObjectRecord(value)) invalid(path); return value; }
+function isObjectRecord(value: unknown): value is Readonly<Record<string, unknown>> { return typeof value === "object" && value !== null && !Array.isArray(value); }
+function exact(value: Readonly<Record<string, unknown>>, keys: readonly string[], options: { readonly path: string; readonly optional: readonly string[] }): void { const actual = Object.keys(value).sort(); const expected = keys.filter((key) => !options.optional.includes(key) || Object.hasOwn(value, key)).sort(); if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) invalid(options.path); }
+function boundedString(value: unknown, path: string, max: number): string { if (typeof value !== "string" || value.length === 0 || value.length > max || value.includes("\0")) invalid(path); return value; }
+function relativePath(value: unknown, path: string): string { const output = boundedString(value, path, 512); if (!REL_PATH.test(output)) invalid(path); return output; }
+function hash(value: unknown, path: string): string { if (typeof value !== "string" || !SHA256.test(value)) invalid(path); return value; }
+function safeInteger(value: unknown, path: string): number { if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) invalid(path); return value; }
+function optionalFinite(value: unknown, path: string): number | undefined { if (value === undefined) return undefined; if (typeof value !== "number" || !Number.isFinite(value)) invalid(path); return value; }
+function oneOf<const T extends readonly string[]>(value: unknown, path: string, choices: T): T[number] { if (typeof value !== "string" || !choices.includes(value)) invalid(path); return value;
+}
+function invalid(path: string): never { throw new DesignAuditContractError(path); }

--- a/packages/shared/src/design-brief.ts
+++ b/packages/shared/src/design-brief.ts
@@ -8,6 +8,7 @@ import {
 export const DESIGN_BRIEF_OUTPUT_TYPES = [
   "prototype",
   "slide_deck",
+  "graphic",
   "from_template",
   "other",
 ] as const;
@@ -103,6 +104,7 @@ function outputType(value: string): DesignBriefOutputType {
   switch (value) {
     case "prototype":
     case "slide_deck":
+    case "graphic":
     case "from_template":
     case "other":
       return value;

--- a/packages/shared/src/design-direction.ts
+++ b/packages/shared/src/design-direction.ts
@@ -1,0 +1,118 @@
+import {
+  UpgradeContractError,
+  decodeContract,
+  isRecord,
+  requiredArray,
+  requiredNumber,
+  requiredString,
+  stringArray,
+  type UnknownRecord,
+} from "./contract-parser";
+
+export const DESIGN_DIRECTION_LAYOUTS = ["editorial", "modular", "narrative"] as const;
+export const DESIGN_DIRECTION_SLOT_STATUSES = ["pending", "ready", "failed", "cancelled"] as const;
+export const DESIGN_DIRECTION_STATUSES = ["loading", "ready", "partial", "failed", "cancelled"] as const;
+
+export type DesignDirectionLayout = (typeof DESIGN_DIRECTION_LAYOUTS)[number];
+export type DesignDirectionSlotStatus = (typeof DESIGN_DIRECTION_SLOT_STATUSES)[number];
+export type DesignDirectionStatus = (typeof DESIGN_DIRECTION_STATUSES)[number];
+
+export type DesignDirectionSlot = {
+  readonly id: string;
+  readonly order: number;
+  readonly layout_key: DesignDirectionLayout;
+  readonly title: string;
+  readonly summary: string;
+  readonly style_facts: readonly string[];
+  readonly status: DesignDirectionSlotStatus;
+  readonly preview_url: string | null;
+  readonly error: string | null;
+};
+
+export type DesignDirectionState = {
+  readonly schema_version: 1;
+  readonly project_id: string;
+  readonly session_id: string;
+  readonly generation_id: string;
+  readonly status: DesignDirectionStatus;
+  readonly content_outline: readonly string[];
+  readonly directions: readonly DesignDirectionSlot[];
+  readonly selected_id: string | null;
+  readonly selection_revision: number;
+  readonly selection_history: readonly (string | null)[];
+  readonly error: string | null;
+  readonly updated_at: number;
+};
+
+export function parseDesignDirectionState(input: unknown): DesignDirectionState {
+  const record = decodeContract(input);
+  exact(record, ["schema_version", "project_id", "session_id", "generation_id", "status", "content_outline", "directions", "selected_id", "selection_revision", "selection_history", "error", "updated_at"]);
+  if (requiredNumber(record, "schema_version") !== 1) invalid("schema_version");
+  const contentOutline = stringArray(record, "content_outline");
+  if (contentOutline.length === 0 || contentOutline.length > 12 || contentOutline.some((entry) => entry.trim().length === 0)) invalid("content_outline");
+  const rawDirections = requiredArray(record, "directions");
+  if (rawDirections.length !== 3) invalid("directions");
+  const directions = rawDirections.map(parseSlot);
+  if (new Set(directions.map((slot) => slot.id)).size !== 3) invalid("directions.id");
+  if (new Set(directions.map((slot) => slot.layout_key)).size !== 3) invalid("directions.layout_key");
+  for (const [index, slot] of directions.entries()) if (slot.order !== index) invalid(`directions.${index}.order`);
+  const selectedId = nullableString(record, "selected_id");
+  if (selectedId !== null && !directions.some((slot) => slot.id === selectedId && slot.status === "ready")) invalid("selected_id");
+  const selectionRevision = requiredNumber(record, "selection_revision");
+  const selectionHistory = requiredArray(record, "selection_history").map((value, index) => {
+    if (value === null) return null;
+    if (typeof value !== "string" || !directions.some((slot) => slot.id === value && slot.status === "ready")) invalid(`selection_history.${index}`);
+    return value;
+  });
+  if (selectionRevision < selectionHistory.length) invalid("selection_revision");
+  const status = parseStatus(requiredString(record, "status"));
+  validateAggregateStatus(status, directions);
+  return {
+    schema_version: 1,
+    project_id: requiredString(record, "project_id"),
+    session_id: requiredString(record, "session_id"),
+    generation_id: requiredString(record, "generation_id"),
+    status,
+    content_outline: contentOutline,
+    directions,
+    selected_id: selectedId,
+    selection_revision: selectionRevision,
+    selection_history: selectionHistory,
+    error: nullableString(record, "error"),
+    updated_at: requiredNumber(record, "updated_at"),
+  };
+}
+
+function parseSlot(value: unknown, index: number): DesignDirectionSlot {
+  if (!isRecord(value)) invalid(`directions.${index}`);
+  exact(value, ["id", "order", "layout_key", "title", "summary", "style_facts", "status", "preview_url", "error"]);
+  const status = parseSlotStatus(requiredString(value, "status"));
+  const previewUrl = nullableString(value, "preview_url");
+  const error = nullableString(value, "error");
+  if ((status === "ready") !== (previewUrl !== null)) invalid(`directions.${index}.preview_url`);
+  if ((status === "failed" || status === "cancelled") !== (error !== null)) invalid(`directions.${index}.error`);
+  return {
+    id: requiredString(value, "id"), order: requiredNumber(value, "order"),
+    layout_key: parseLayout(requiredString(value, "layout_key")),
+    title: requiredString(value, "title"), summary: requiredString(value, "summary"),
+    style_facts: nonEmptyStrings(value, "style_facts"), status, preview_url: previewUrl, error,
+  };
+}
+
+function validateAggregateStatus(status: DesignDirectionStatus, slots: readonly DesignDirectionSlot[]): void {
+  const statuses = slots.map((slot) => slot.status);
+  if (status === "loading" && statuses.includes("pending")) return;
+  if (status === "ready" && statuses.every((value) => value === "ready")) return;
+  if (status === "partial" && !statuses.includes("pending") && statuses.includes("ready") && statuses.includes("failed")) return;
+  if (status === "failed" && statuses.every((value) => value === "failed")) return;
+  if (status === "cancelled" && !statuses.includes("pending") && statuses.includes("cancelled")) return;
+  invalid("status");
+}
+
+function parseLayout(value: string): DesignDirectionLayout { switch (value) { case "editorial": case "modular": case "narrative": return value; default: return invalid("layout_key"); } }
+function parseSlotStatus(value: string): DesignDirectionSlotStatus { switch (value) { case "pending": case "ready": case "failed": case "cancelled": return value; default: return invalid("slot.status"); } }
+function parseStatus(value: string): DesignDirectionStatus { switch (value) { case "loading": case "ready": case "partial": case "failed": case "cancelled": return value; default: return invalid("status"); } }
+function nullableString(record: UnknownRecord, key: string): string | null { const value = record[key]; if (value === null) return null; if (typeof value !== "string" || value.length === 0) invalid(key); return value; }
+function nonEmptyStrings(record: UnknownRecord, key: string): readonly string[] { const values = stringArray(record, key); if (values.length === 0 || values.length > 8) invalid(key); return values; }
+function exact(record: UnknownRecord, keys: readonly string[]): void { const allowed = new Set(keys); for (const key of Object.keys(record)) if (!allowed.has(key)) invalid(key); for (const key of keys) if (!(key in record)) throw new UpgradeContractError("missing_required_field", key); }
+function invalid(path: string): never { throw new UpgradeContractError("invalid_field", path); }

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -1,4 +1,17 @@
 import type { DesignDirectionState } from "./design-direction";
+import type { UploadedVisualSourceSelection, VisualSourceManifestV1 } from "./visual-source";
+
+export type TurnErrorCode =
+  | "backend_unavailable"
+  | "path_unavailable"
+  | "immutable_reference_mutated"
+  | "immutable_reference_path_unavailable"
+  | "immutable_reference_escaped"
+  | "private_input_unavailable"
+  | "publication_failed"
+  | "operation_conflict"
+  | "operation_cancelled"
+  | "turn_failed";
 
 export type NormalizedEvent =
   | {
@@ -8,6 +21,7 @@ export type NormalizedEvent =
       turnId: string;
       text: string;
       attachmentCount: number;
+      visualSources?: VisualSourceManifestV1;
     }
   | { id: string; ts: number; type: "chat.delta"; turnId: string; text: string }
   | {
@@ -93,6 +107,7 @@ export type NormalizedEvent =
       id: string;
       ts: number;
       type: "status.error";
+      code?: TurnErrorCode;
       message: string;
       recoverable: boolean;
     }
@@ -111,7 +126,12 @@ export type SequencedEventEnvelope = {
 };
 
 export type UserEvent =
-  | { type: "user.message"; text: string; attachments?: string[] }
+  | {
+      type: "user.message";
+      text: string;
+      attachments?: string[];
+      visualSources?: readonly UploadedVisualSourceSelection[];
+    }
   | { type: "user.interrupt" }
   | {
       type: "user.tool_decision";

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -1,3 +1,5 @@
+import type { DesignDirectionState } from "./design-direction";
+
 export type NormalizedEvent =
   | {
       id: string;
@@ -65,6 +67,12 @@ export type NormalizedEvent =
       projectRevision: number;
       projectDigest: string;
       stopReason: import("./export-attempt").ExportStopReason | null;
+    }
+  | {
+      id: string;
+      ts: number;
+      type: "design.direction_state";
+      state: DesignDirectionState;
     }
   | {
       id: string;

--- a/packages/shared/src/graphic.ts
+++ b/packages/shared/src/graphic.ts
@@ -1,0 +1,47 @@
+import {
+  UpgradeContractError,
+  decodeContract,
+  requiredNumber,
+} from "./contract-parser";
+
+export const GRAPHIC_CANVAS_LIMITS = {
+  minWidth: 320,
+  maxWidth: 4096,
+  minHeight: 240,
+  maxHeight: 4096,
+  maxPixels: 16_000_000,
+} as const;
+
+export type GraphicCanvasV1 = {
+  readonly schema_version: 1;
+  readonly width: number;
+  readonly height: number;
+};
+
+export function parseGraphicCanvasV1(input: unknown): GraphicCanvasV1 {
+  const record = decodeContract(input);
+  for (const key of Object.keys(record)) {
+    if (key !== "schema_version" && key !== "width" && key !== "height") {
+      invalid(key);
+    }
+  }
+  if (requiredNumber(record, "schema_version") !== 1) {
+    invalid("schema_version");
+  }
+  const width = requiredNumber(record, "width");
+  const height = requiredNumber(record, "height");
+  if (width < GRAPHIC_CANVAS_LIMITS.minWidth || width > GRAPHIC_CANVAS_LIMITS.maxWidth) {
+    invalid("width");
+  }
+  if (height < GRAPHIC_CANVAS_LIMITS.minHeight || height > GRAPHIC_CANVAS_LIMITS.maxHeight) {
+    invalid("height");
+  }
+  if (width * height > GRAPHIC_CANVAS_LIMITS.maxPixels) {
+    invalid("width");
+  }
+  return { schema_version: 1, width, height };
+}
+
+function invalid(path: string): never {
+  throw new UpgradeContractError("invalid_field", path);
+}

--- a/packages/shared/src/home.ts
+++ b/packages/shared/src/home.ts
@@ -5,6 +5,7 @@ import type {
   ThemeMode,
 } from "./app";
 import type { DesignBriefV1 } from "./design-brief";
+import type { GraphicCanvasV1 } from "./graphic";
 
 export interface ProjectSummary {
   id: string;
@@ -35,6 +36,7 @@ export interface CreateProjectRequest {
     use_speaker_notes?: boolean;
     copy_as_is?: boolean;
     design_brief?: DesignBriefV1;
+    graphic_canvas?: GraphicCanvasV1;
   };
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -23,3 +23,4 @@ export * from "./project";
 export * from "./reference-layout";
 export * from "./research-contract";
 export * from "./settings";
+export * from "./visual-source";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,6 +7,7 @@ export * from "./comment";
 export * from "./contract-parser";
 export * from "./design-system";
 export * from "./design-brief";
+export * from "./design-direction";
 export * from "./events";
 export * from "./export";
 export * from "./export-attempt";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,6 +8,7 @@ export * from "./contract-parser";
 export * from "./design-system";
 export * from "./design-brief";
 export * from "./design-direction";
+export * from "./design-audit";
 export * from "./events";
 export * from "./export";
 export * from "./export-attempt";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -15,6 +15,7 @@ export * from "./export-attempt";
 export * from "./extraction-domain";
 export * from "./extraction-provenance";
 export * from "./file-patch";
+export * from "./graphic";
 export * from "./harness";
 export * from "./home";
 export * from "./learning-contract";

--- a/packages/shared/src/visual-source.ts
+++ b/packages/shared/src/visual-source.ts
@@ -1,0 +1,249 @@
+export const VISUAL_SOURCE_ROLES = ["ordinary_content", "immutable_reference"] as const;
+export type VisualSourceRole = (typeof VISUAL_SOURCE_ROLES)[number];
+
+export type VisualSourceUploadRequestV1 = {
+  readonly schema_version: 1;
+  readonly explicit: boolean;
+  readonly sources: readonly {
+    readonly source_type: "upload";
+    readonly upload_id: string;
+    readonly file_index: number;
+    readonly role: VisualSourceRole;
+  }[];
+};
+
+export type UploadedVisualSourceSelection = {
+  readonly source_type: "uploaded_attachment";
+  readonly attachment_path: string;
+  readonly role: VisualSourceRole;
+};
+
+export type VisualSourceManifestV1 = {
+  readonly schema_version: 1;
+  readonly network_sources: "unsupported";
+  readonly sources: readonly VisualSourceManifestEntry[];
+};
+
+export type VisualSourceManifestEntry =
+  | {
+      readonly source_type: "uploaded_attachment";
+      readonly role: "ordinary_content";
+      readonly role_origin: "explicit" | "legacy_inferred";
+      readonly attachment_id: string;
+      readonly original_name: string;
+      readonly mime_type: string;
+      readonly size_bytes: number;
+      readonly preflight_verified_sha256: string;
+      readonly managed_path: string;
+      readonly provenance: AttachmentProvenance;
+    }
+  | {
+      readonly source_type: "uploaded_attachment";
+      readonly role: "immutable_reference";
+      readonly role_origin: "explicit" | "legacy_inferred";
+      readonly attachment_id: string;
+      readonly original_name: string;
+      readonly mime_type: string;
+      readonly size_bytes: number;
+      readonly preflight_verified_sha256: string;
+      readonly managed_path: string;
+      readonly provenance: AttachmentProvenance;
+      readonly policy: {
+        readonly original_file: "preserve";
+        readonly original_hash: "preserve";
+        readonly never_overwrite: true;
+        readonly never_copy_into_authored_output: true;
+        readonly derived_artifact: "separate";
+      };
+    };
+
+type AttachmentProvenance = {
+  readonly session_id: string;
+  readonly turn_id: string;
+  readonly storage: "managed_attachment";
+};
+
+export class VisualSourceContractError extends Error {
+  readonly name = "VisualSourceContractError";
+  constructor(readonly code: "invalid_visual_sources" | "unsupported_visual_source") {
+    super(code);
+  }
+}
+
+export function parseVisualSourceUploadRequest(value: unknown, fileCount: number): VisualSourceUploadRequestV1 {
+  if (!Number.isSafeInteger(fileCount) || fileCount < 0) fail("invalid_visual_sources");
+  if (value === undefined || value === null || value === "") {
+    return {
+      schema_version: 1,
+      explicit: false,
+      sources: Array.from({ length: fileCount }, (_, fileIndex) => ({
+        source_type: "upload" as const,
+        upload_id: `upload-${fileIndex}`,
+        file_index: fileIndex,
+        role: "ordinary_content" as const,
+      })),
+    };
+  }
+  let parsed: unknown;
+  try {
+    parsed = typeof value === "string" ? JSON.parse(value) : value;
+  } catch {
+    fail("invalid_visual_sources");
+  }
+  if (
+    !record(parsed) ||
+    !exactKeys(parsed, ["schema_version", "sources"]) ||
+    parsed["schema_version"] !== 1 ||
+    !Array.isArray(parsed["sources"])
+  ) fail("invalid_visual_sources");
+  const sources = parsed["sources"].map((source) => parseUploadSource(source));
+  if (
+    sources.length !== fileCount ||
+    new Set(sources.map((source) => source.upload_id)).size !== sources.length
+  ) fail("invalid_visual_sources");
+  const sorted = [...sources].sort((left, right) => left.file_index - right.file_index);
+  if (!sorted.every((source, position) => source.file_index === position)) fail("invalid_visual_sources");
+  return { schema_version: 1, explicit: true, sources: sorted };
+}
+
+export function parseVisualSourceManifest(value: unknown): VisualSourceManifestV1 {
+  if (
+    !record(value) ||
+    !exactKeys(value, ["schema_version", "network_sources", "sources"]) ||
+    value["schema_version"] !== 1 ||
+    value["network_sources"] !== "unsupported" ||
+    !Array.isArray(value["sources"])
+  ) fail("invalid_visual_sources");
+  const sources = value["sources"].map((entry) => parseManifestEntry(entry));
+  if (
+    new Set(sources.map((source) => source.attachment_id)).size !== sources.length ||
+    new Set(sources.map((source) => source.managed_path)).size !== sources.length
+  ) fail("invalid_visual_sources");
+  return { schema_version: 1, network_sources: "unsupported", sources };
+}
+
+export function parseUploadedVisualSourceSelections(value: unknown): readonly UploadedVisualSourceSelection[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) fail("invalid_visual_sources");
+  return value.map((source) => {
+    if (record(source) && unsupportedSourceType(source["source_type"])) fail("unsupported_visual_source");
+    if (
+      !record(source) ||
+      !exactKeys(source, ["source_type", "attachment_path", "role"]) ||
+      source["source_type"] !== "uploaded_attachment" ||
+      !safeSelectionPath(source["attachment_path"]) ||
+      !role(source["role"])
+    ) fail("invalid_visual_sources");
+    return { source_type: "uploaded_attachment", attachment_path: source["attachment_path"], role: source["role"] };
+  });
+}
+
+function parseManifestEntry(value: unknown): VisualSourceManifestEntry {
+  if (
+    !record(value) ||
+    value["source_type"] !== "uploaded_attachment" ||
+    !role(value["role"])
+  ) fail("invalid_visual_sources");
+  const ordinaryKeys = ["source_type", "role", "role_origin", "attachment_id", "original_name", "mime_type", "size_bytes", "preflight_verified_sha256", "managed_path", "provenance"];
+  const immutable = value["role"] === "immutable_reference";
+  if (
+    !exactKeys(value, immutable ? [...ordinaryKeys, "policy"] : ordinaryKeys) ||
+    (value["role_origin"] !== "explicit" && value["role_origin"] !== "legacy_inferred") ||
+    !nonempty(value["attachment_id"]) ||
+    !nonempty(value["original_name"]) ||
+    !nonempty(value["mime_type"]) ||
+    typeof value["size_bytes"] !== "number" ||
+    !Number.isSafeInteger(value["size_bytes"]) ||
+    value["size_bytes"] < 0 ||
+    !sha256(value["preflight_verified_sha256"]) ||
+    !managedAttachmentPath(value["managed_path"]) ||
+    !provenance(value["provenance"])
+  ) fail("invalid_visual_sources");
+  const roleOrigin = value["role_origin"] === "explicit" ? "explicit" as const : "legacy_inferred" as const;
+  const common = {
+    source_type: "uploaded_attachment" as const,
+    role_origin: roleOrigin,
+    attachment_id: value["attachment_id"],
+    original_name: value["original_name"],
+    mime_type: value["mime_type"],
+    size_bytes: value["size_bytes"],
+    preflight_verified_sha256: value["preflight_verified_sha256"],
+    managed_path: value["managed_path"],
+    provenance: value["provenance"],
+  };
+  if (!immutable) return { ...common, role: "ordinary_content" };
+  if (!policy(value["policy"])) fail("invalid_visual_sources");
+  return { ...common, role: "immutable_reference", policy: value["policy"] };
+}
+
+function parseUploadSource(value: unknown): VisualSourceUploadRequestV1["sources"][number] {
+  if (record(value) && unsupportedSourceType(value["source_type"])) fail("unsupported_visual_source");
+  if (
+    !record(value) ||
+    !exactKeys(value, ["source_type", "upload_id", "file_index", "role"]) ||
+    value["source_type"] !== "upload" ||
+    typeof value["upload_id"] !== "string" ||
+    !/^[A-Za-z0-9_-]{1,80}$/u.test(value["upload_id"]) ||
+    typeof value["file_index"] !== "number" ||
+    !Number.isSafeInteger(value["file_index"]) ||
+    value["file_index"] < 0 ||
+    !role(value["role"])
+  ) fail("invalid_visual_sources");
+  return { source_type: "upload", upload_id: value["upload_id"], file_index: value["file_index"], role: value["role"] };
+}
+
+function unsupportedSourceType(value: unknown): boolean {
+  return value === "url" || value === "web" || value === "stock";
+}
+
+function safeSelectionPath(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && !/[\r\n\0]/u.test(value) && !/^https?:\/\//iu.test(value) && !value.split(/[\\/]/u).includes("..");
+}
+
+function managedAttachmentPath(value: unknown): value is string {
+  return safeSelectionPath(value) && /^\.attachments\/[^/]+$/u.test(value);
+}
+
+function provenance(value: unknown): value is AttachmentProvenance {
+  return record(value) &&
+    exactKeys(value, ["session_id", "turn_id", "storage"]) &&
+    nonempty(value["session_id"]) &&
+    nonempty(value["turn_id"]) &&
+    value["storage"] === "managed_attachment";
+}
+
+function policy(value: unknown): value is Extract<VisualSourceManifestEntry, { readonly role: "immutable_reference" }>["policy"] {
+  return record(value) &&
+    exactKeys(value, ["original_file", "original_hash", "never_overwrite", "never_copy_into_authored_output", "derived_artifact"]) &&
+    value["original_file"] === "preserve" &&
+    value["original_hash"] === "preserve" &&
+    value["never_overwrite"] === true &&
+    value["never_copy_into_authored_output"] === true &&
+    value["derived_artifact"] === "separate";
+}
+
+function nonempty(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function sha256(value: unknown): value is string {
+  return typeof value === "string" && /^[a-f0-9]{64}$/u.test(value);
+}
+
+function role(value: unknown): value is VisualSourceRole {
+  return value === "ordinary_content" || value === "immutable_reference";
+}
+
+function record(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(value: Readonly<Record<string, unknown>>, expected: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const sortedExpected = [...expected].sort();
+  return actual.length === sortedExpected.length && actual.every((key, index) => key === sortedExpected[index]);
+}
+
+function fail(code: VisualSourceContractError["code"]): never {
+  throw new VisualSourceContractError(code);
+}


### PR DESCRIPTION
## Summary

Completes the remaining BurnGuard product roadmap on top of `main`:

- controlled Home search and truthful empty/loading/error/no-match states;
- safe local PDF/PPTX intake with cancellation and retry;
- generated, digest-keyed 640x360 project thumbnails with ETag, recovery, and fallback;
- Korean-first first-run affordances and accessible semantic colors;
- three persisted, selectable design directions with prompt propagation and undo;
- rendered post-generation and pre-export design audits with safe fix and undo;
- first-class bounded single-artboard Graphic projects with exact DPR1 PNG export;
- explicit ordinary versus immutable visual-reference roles with durable provenance, replay, path/hash boundaries, and safe prompt inputs.

The branch is intentionally unmerged and auto-merge is not enabled.

## Roadmap to implementation

| Roadmap area | Primary implementation |
|---|---|
| Home search and state clarity | `packages/frontend/src/views/HomeView.tsx`, Home query/state helpers |
| Safe source intake | Composer intake components, backend attachment/extraction boundaries |
| Generated thumbnails | `packages/backend/src/services/project-thumbnails.ts`, Home thumbnail route/card |
| Korean-first UX | Home, project, deletion, import, and navigation surfaces; `DESIGN.md` tokens |
| Selectable directions | shared direction contract, backend workflow/routes/prompt, direction artifact UI |
| Automatic design audit | Chromium audit service/cache, export gate, Quality panel, safe fix/undo |
| Graphic projects | shared `GraphicCanvasV1`, migration/template/prompt, fit preview, exact PNG export |
| Visual-source policy | shared visual-source contract, migrations 0012/0013, attachment roles/provenance, immutable guard, prompt manifest, role UI |

## Atomic commits

1. `3841695` — `feat(home): wire project search states`
2. `1b56c0a` — `feat(import): connect safe source intake states`
3. `1060786` — `feat(projects): generate and serve artifact thumbnails`
4. `f0c34ff` — `feat(home): polish Korean first-run affordances`
5. `ef0541b` — `feat(projects): add selectable design directions`
6. `51a0559` — `feat(projects): add automatic design audits`
7. `5ef4a47` — `feat(graphic): add bounded single-artboard export`
8. `f35757c` — `feat(sources): add immutable visual reference policy`
9. `707e77f` — `test(thumbnails): isolate project list ordering`

## Verification

- Final full suite: **890 passed, 3 inherited failures**, 6,209 assertions, 893 tests across 108 files.
- The three failures are unchanged from `origin/main`:
  - one Bun server request-abort observation timeout in `extraction-website-boundaries.test.ts`;
  - two QA-harness tests that return `ulw_status_failed` while this durable goal is active.
- `bun run typecheck`: passed.
- `bun run build`: passed for the frontend and Windows backend binary.
- Korean brief/purpose/reference regressions: **42 passed**.
- Final visual-source parent gates: backend **45 passed**, frontend **20 passed**.
- Thumbnail suite after deterministic fixture isolation: **23 passed**.
- `git diff --check`: passed.
- `origin/main` (`232180c49a01aa70b463f8309f48155a1a21f0d5`) is an ancestor of head.
- Final head: `707e77f8b85092d7d94608c79dd37dbcd136a835`.

## Browser and artifact evidence

- Aggregate current-tree smoke:
  - `.omo/evidence/ulw/burnguard-roadmap-20260826-v2/G001-implement-the-authoritative-burnguar/a1/`
  - Fresh 1280 lane: **13/13** checks and 12 validated screenshots.
  - Search/Escape, generated thumbnail, project routing, attachment role switching, three distinct directions with persisted selection, and must-fix/recommended/ready audit states passed.
- Home/Korean responsive QA:
  - `.omo/evidence/phase-a-korean-final/`
- Direction workflow:
  - `.omo/evidence/phase-b-directions-final-v5/`
- Automatic design audit:
  - `.omo/evidence/phase-c-design-audit-final/`
- Graphic:
  - `.omo/evidence/phase-d-graphic-final/`
- Visual-source policy:
  - `.omo/evidence/phase-d-visual-sources-final/`

The aggregate lane is explicitly marked **PARTIAL**: generation-submit prompt proof, audit safe-fix/undo, Graphic export, the edge lane, and 768/375 repeats were not re-executed in that lane. Its manifest maps those requirements to their current-feature slice evidence and never claims them as fresh aggregate checks.

## Review receipts

- Graphic visual matrix: 283 assertions, 24 fresh screenshots, PASS.
- Visual-source current-tree QA: 130/131 initial checks; the one raw-path defect was fixed, then the focused live SSE/DB/restart-replay/1280/375 delta passed.
- Visual-source final independent quality review: PASS.
- Visual-source scoped security review: PASS, 23/23 focused checks.
- Phase B and Phase C each received two independent final visual PASS reviews.

## Limitations and inherited issues

- Frontend production build retains the existing approximately 569 kB chunk-size advisory.
- Generic same-user `setsid()` detached-child containment and live-project destination-parent `openat` hardening predate this branch and are not claimed as solved.
- At 375 px, the pre-existing split project layout can leave only 32 px for a long chat error card until the transcript is scrolled.
- The aggregate smoke observed one cold concurrent thumbnail batch returning fallback 503s, plus one boot-time 500 each from backend detection/settings; these were not reproduced or classified as roadmap regressions.
- Four old Phase C backend processes were observed but were not owned or modified by final QA.

## Base, head, and publication state

- Base: `232180c49a01aa70b463f8309f48155a1a21f0d5`
- Head: `707e77f8b85092d7d94608c79dd37dbcd136a835`
- Target: `main`
- Branch push: normal, no force.
- Merge: not performed.
- Auto-merge: not enabled.
- CI state at creation: no checks reported (`statusCheckRollup: []`, `mergeStateStatus: UNKNOWN`).
