### PR TITLE
feat(ux): complete BurnGuard G1-G7 experience

### DIFF
--- a/packages/frontend/src/api/export.ts
+++ b/packages/frontend/src/api/export.ts
@@ -15,11 +15,11 @@ export function formatLabel(format: ExportFormat): string {
     case "png":
       return "PNG";
     case "pptx":
-      return "PowerPoint";
+      return "파워포인트";
     case "html_zip":
-      return "HTML zip";
+      return "HTML ZIP 파일";
     case "handoff":
-      return "Developer handoff";
+      return "개발자 전달용";
   }
 }
 

--- a/packages/frontend/src/components/canvas/Canvas.tsx
+++ b/packages/frontend/src/components/canvas/Canvas.tsx
@@ -21,50 +21,43 @@ import type { CanvasMode } from "@/components/modes/types";
 import type { SelectedNode } from "@/types/project";
 
 const PLACEHOLDER_SRC = `<!doctype html>
-<html>
+<html lang="ko">
 <head>
   <meta charset="utf-8">
   <style>
-    :root { color-scheme: dark; }
+    :root { color-scheme: light; }
     body {
       margin: 0;
-      background: #101318;
-      color: white;
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #f1f3f5;
+      color: #17191a;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Apple SD Gothic Neo", sans-serif;
       display: grid;
       place-items: center;
       min-height: 100vh;
+      word-break: keep-all;
     }
-    .wrap { text-align: center; padding: 48px; }
+    .wrap { text-align: center; padding: 48px; max-width: 480px; }
     .eyebrow {
-      color: #E06B4C;
-      font-size: 12px;
+      color: #004fff;
+      font-size: 11px;
       letter-spacing: 0.14em;
       text-transform: uppercase;
-      margin-bottom: 24px;
+      margin-bottom: 16px;
     }
-    .title {
-      font-size: 120px;
-      line-height: 0.95;
-      letter-spacing: -0.03em;
-      font-weight: 800;
-      color: #fff;
-      margin: 0;
-    }
+    .title { font-size: 22px; font-weight: 700; margin: 0; }
     .subtitle {
-      color: rgba(255,255,255,0.7);
-      font-size: 20px;
+      color: #5e646c;
+      font-size: 14px;
       line-height: 1.6;
-      margin-top: 48px;
-      max-width: 640px;
+      margin-top: 12px;
     }
   </style>
 </head>
 <body>
   <section class="wrap">
     <div class="eyebrow">BurnGuard Canvas</div>
-    <h1 class="title">Artifact preview</h1>
-    <p class="subtitle">Your live project artifact appears here once the backend entrypoint is available.</p>
+    <h1 class="title">아직 표시할 결과물이 없어요</h1>
+    <p class="subtitle">왼쪽 채팅에 만들고 싶은 것을 적어 보내면, 생성된 파일이 이 자리에 바로 나타나요.</p>
   </section>
 </body>
 </html>`;
@@ -213,7 +206,7 @@ export default function Canvas({
         setFrameSrcDoc(null);
         setLoadError({
           status: err.httpStatus,
-          message: err.message || "Failed to load artifact.",
+          message: err.message || "결과물을 불러오지 못했어요.",
         });
       });
 
@@ -293,7 +286,7 @@ export default function Canvas({
           <iframe
             ref={iframeRef}
             key={frameKey}
-            title="Canvas"
+            title="캔버스"
             srcDoc={frameSrcDoc ?? PLACEHOLDER_SRC}
             sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
             allow="fullscreen"
@@ -303,7 +296,7 @@ export default function Canvas({
         ) : (
           <iframe
             ref={iframeRef}
-            title="Canvas placeholder"
+            title="캔버스 자리 표시자"
             srcDoc={PLACEHOLDER_SRC}
             sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
             allow="fullscreen"
@@ -359,7 +352,7 @@ export default function Canvas({
           <div className="pointer-events-none absolute inset-0 grid place-items-center bg-background/80 backdrop-blur-sm">
             <div className="pointer-events-auto max-w-sm rounded border border-destructive/40 bg-background px-4 py-3 text-xs shadow-md">
               <div className="font-semibold text-destructive">
-                Could not load artifact
+                결과물을 불러오지 못했어요
                 {loadError.status ? ` (HTTP ${loadError.status})` : ""}
               </div>
               <div className="mt-1 text-muted-foreground">
@@ -373,7 +366,7 @@ export default function Canvas({
                 }}
                 className="mt-2 inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[11px] font-medium hover:bg-muted"
               >
-                Retry
+                다시 시도
               </button>
             </div>
           </div>

--- a/packages/frontend/src/components/canvas/CanvasTopBar.tsx
+++ b/packages/frontend/src/components/canvas/CanvasTopBar.tsx
@@ -34,7 +34,7 @@ export default function CanvasTopBar({
 }) {
   return (
     <div className="h-10 border-b border-border bg-background flex items-center justify-between px-3 shrink-0 max-[900px]:h-auto max-[900px]:flex-col max-[900px]:items-stretch max-[900px]:px-2">
-      <div className="flex items-center gap-0.5 max-[900px]:grid max-[900px]:grid-cols-6">
+      <div className="flex items-center gap-0.5 max-[900px]:grid max-[900px]:grid-cols-3">
         {MODES.map((m) => {
           const disabled = Boolean(m.phase);
           const active = m.id === mode;
@@ -45,6 +45,7 @@ export default function CanvasTopBar({
                 !disabled && onModeChange(active ? null : m.id)
               }
               disabled={disabled}
+              aria-pressed={active}
               title={
                 disabled
                   ? `${m.phase}단계`

--- a/packages/frontend/src/components/chat/ChatPane.tsx
+++ b/packages/frontend/src/components/chat/ChatPane.tsx
@@ -1,9 +1,10 @@
 import { useState, type ReactNode } from "react";
 import { MessageSquare, MessageCircleMore } from "lucide-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import type { BackendId, FileInfo, NormalizedEvent, SessionInfo } from "@bg/shared";
+import type { BackendId, Comment, FileInfo, NormalizedEvent, SessionInfo } from "@bg/shared";
 import MessageStream from "./MessageStream";
 import Composer from "./Composer";
+import CommentPanel from "@/components/modes/CommentPanel";
 import type { ReadyAttachmentSource } from "./attachment-intake";
 import { switchSessionBackend } from "@/api/session";
 import { useUIStore } from "@/state/uiStore";
@@ -16,6 +17,7 @@ export default function ChatPane({
   session,
   composerDisabled,
   canInterrupt,
+  turnElapsedMs,
   interruptPending,
   onInterrupt,
   onSend,
@@ -25,11 +27,19 @@ export default function ChatPane({
   composerInitialText,
   statusSlot,
   projectFiles,
+  comments,
+  activeRelPath,
+  activeSlideIdx,
+  focusedCommentId,
+  onFocusComment,
+  onUpdateCommentBody,
+  onToggleCommentResolved,
 }: {
   events: NormalizedEvent[];
   session: SessionInfo;
   composerDisabled?: boolean;
   canInterrupt?: boolean;
+  turnElapsedMs?: number | null;
   interruptPending?: boolean;
   onInterrupt?: () => void;
   onSend: (
@@ -43,6 +53,13 @@ export default function ChatPane({
   composerInitialText?: string;
   statusSlot?: ReactNode;
   projectFiles: readonly FileInfo[];
+  comments: Comment[];
+  activeRelPath: string | null;
+  activeSlideIdx: number | null;
+  focusedCommentId: string | null;
+  onFocusComment: (id: string | null) => void;
+  onUpdateCommentBody: (id: string, body: string) => void;
+  onToggleCommentResolved: (id: string, resolved: boolean) => void;
 }) {
   const [tab, setTab] = useState<Tab>("chat");
   const queryClient = useQueryClient();
@@ -57,14 +74,14 @@ export default function ChatPane({
         updated,
       );
       pushToast({
-        title: "Backend switched",
-        body: `Next turn will use ${backendLabel(updated.backend_id)}.`,
+        title: "백엔드를 바꿨어요",
+        body: `다음 턴부터 ${backendLabel(updated.backend_id)}를 사용해요.`,
         tone: "success",
       });
     },
     onError: (err) => {
       pushToast({
-        title: "Could not switch backend",
+        title: "백엔드를 바꾸지 못했어요",
         body: err instanceof Error ? err.message : String(err),
         tone: "error",
       });
@@ -82,7 +99,7 @@ export default function ChatPane({
           setActive={setTab}
           icon={<MessageSquare className="h-3.5 w-3.5" />}
         >
-          Chat
+          채팅
         </ChatTab>
         <ChatTab
           id="comments"
@@ -90,10 +107,10 @@ export default function ChatPane({
           setActive={setTab}
           icon={<MessageCircleMore className="h-3.5 w-3.5" />}
         >
-          Comments
+          코멘트
         </ChatTab>
         <div className="ml-auto flex items-center gap-1 pb-1 text-[10px]">
-          <span className="text-muted-foreground">Backend</span>
+          <span className="text-muted-foreground">백엔드</span>
           <BackendToggle
             current={session.backend_id}
             disabled={switchBackend.isPending || sessionRunning}
@@ -117,6 +134,7 @@ export default function ChatPane({
             onSend={onSend}
             disabled={composerDisabled}
             canInterrupt={canInterrupt}
+            turnElapsedMs={turnElapsedMs}
             interruptPending={interruptPending}
             onInterrupt={onInterrupt}
             initialText={composerInitialText}
@@ -124,13 +142,15 @@ export default function ChatPane({
           />
         </>
       ) : (
-        <div className="flex-1 grid place-items-center p-6 text-center text-xs leading-relaxed text-foreground/80">
-          <p>
-            코멘트는 캔버스에서 남겨요. 위쪽 도구 막대에서 Comment 모드를 켠 뒤
-            화면의 원하는 위치를 클릭하면 그 자리에 코멘트가 붙고, 캔버스 옆
-            Comments 패널에 모입니다.
-          </p>
-        </div>
+        <CommentPanel
+          comments={comments}
+          activeRelPath={activeRelPath}
+          activeSlideIdx={activeSlideIdx}
+          focusedId={focusedCommentId}
+          onFocus={onFocusComment}
+          onUpdateBody={onUpdateCommentBody}
+          onToggleResolved={onToggleCommentResolved}
+        />
       )}
     </aside>
   );
@@ -157,12 +177,13 @@ function BackendToggle({
             onSwitch(opt);
           }}
           disabled={disabled}
+          aria-pressed={opt === current}
           title={
             disabled && opt !== current
-              ? "Cannot switch while a turn is running"
+              ? "턴 실행 중에는 바꿀 수 없어요"
               : opt === current
-                ? `Active: ${opt}`
-                : `Switch to ${opt} on next turn`
+                ? `사용 중: ${backendLabel(opt)}`
+                : `다음 턴부터 ${backendLabel(opt)} 사용`
           }
           className={cn(
             "max-[900px]:min-h-11 max-[900px]:min-w-11 px-1.5 py-0.5 font-mono uppercase transition-colors",
@@ -199,6 +220,7 @@ function ChatTab({
   return (
     <button
       onClick={() => setActive(id)}
+      aria-pressed={active === id}
       className={cn(
         "flex max-[900px]:min-h-11 items-center gap-1.5 px-2.5 py-2 text-xs font-medium border-b-2 -mb-px transition-colors",
         active === id

--- a/packages/frontend/src/components/chat/Composer.tsx
+++ b/packages/frontend/src/components/chat/Composer.tsx
@@ -40,6 +40,7 @@ export default function Composer({
   onSend,
   disabled = false,
   canInterrupt = false,
+  turnElapsedMs = null,
   interruptPending = false,
   onInterrupt,
   initialText = "",
@@ -60,6 +61,8 @@ export default function Composer({
    * disabled — idle composers never show Stop.
    */
   canInterrupt?: boolean;
+  /** 현재 턴 경과(ms). 중단 버튼 라벨에 mm:ss로 표시한다. */
+  turnElapsedMs?: number | null;
   interruptPending?: boolean;
   onInterrupt?: () => void;
   /**
@@ -225,7 +228,11 @@ export default function Composer({
             title="진행 중인 작업을 중단합니다"
           >
             <StopCircle className="h-3.5 w-3.5" />
-            {interruptPending ? "중단하는 중..." : "중단"}
+            {interruptPending
+              ? "중단하는 중..."
+              : turnElapsedMs == null
+                ? "중단"
+                : `중단 · ${formatElapsed(turnElapsedMs)}`}
           </Button>
         ) : (
           <Button
@@ -244,4 +251,11 @@ export default function Composer({
       </div>
     </div>
   );
+}
+
+function formatElapsed(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
 }

--- a/packages/frontend/src/components/chat/MessageStream.tsx
+++ b/packages/frontend/src/components/chat/MessageStream.tsx
@@ -118,10 +118,10 @@ export default function MessageStream({
           type="button"
           onClick={jumpToBottom}
           className="absolute bottom-3 right-4 z-10 inline-flex items-center gap-1 rounded-full border border-border bg-background/95 px-2.5 py-1 text-[11px] font-medium text-foreground shadow-sm backdrop-blur hover:bg-background"
-          title="Jump to latest"
+          title="최신으로 이동"
         >
           <ArrowDown className="h-3 w-3" />
-          New messages
+          새 메시지
         </button>
       )}
     </div>

--- a/packages/frontend/src/components/chat/PermissionDialog.tsx
+++ b/packages/frontend/src/components/chat/PermissionDialog.tsx
@@ -43,10 +43,10 @@ export default function PermissionDialog({
           <div className="mb-3 grid h-10 w-10 place-items-center rounded-md bg-amber-500/10 text-amber-600">
             <ShieldAlert className="h-5 w-5" />
           </div>
-          <DialogTitle>Allow this tool call?</DialogTitle>
+          <DialogTitle>이 도구 실행을 허용할까요?</DialogTitle>
           <DialogDescription>
-            The CLI requested permission to run a tool. Review the call and
-            decide whether to proceed. Denying aborts the turn.
+            CLI가 도구를 실행할 권한을 요청했어요. 내용을 확인하고 계속할지
+            정해 주세요. 거부하면 이번 턴이 중단돼요.
           </DialogDescription>
         </DialogHeader>
 
@@ -54,13 +54,13 @@ export default function PermissionDialog({
           <div className="rounded-md border border-border bg-muted/40 text-xs">
             <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
               <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-                Tool
+                도구
               </span>
               <span className="truncate font-mono">{request.tool}</span>
             </div>
             <div className="border-b border-border px-3 py-2">
               <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-                Input
+                입력
               </div>
               <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap break-words font-mono text-[11px]">
                 {formatInput(request.input)}
@@ -68,7 +68,7 @@ export default function PermissionDialog({
             </div>
             <div className="flex items-center justify-between gap-2 px-3 py-2">
               <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-                Call
+                호출 ID
               </span>
               <span className="truncate font-mono text-muted-foreground">
                 {request.toolCallId}
@@ -83,14 +83,14 @@ export default function PermissionDialog({
             onClick={() => onDecide("deny")}
             disabled={pending}
           >
-            Deny &amp; abort
+            거부하고 중단
           </Button>
           <Button
             variant="default"
             onClick={() => onDecide("allow")}
             disabled={pending}
           >
-            {pending ? "Submitting…" : "Allow"}
+            {pending ? "보내는 중…" : "허용"}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -99,7 +99,7 @@ export default function PermissionDialog({
 }
 
 function formatInput(input: unknown): string {
-  if (input == null) return "(no input)";
+  if (input == null) return "(입력 없음)";
   if (typeof input === "string") return input;
   try {
     return JSON.stringify(input, null, 2);

--- a/packages/frontend/src/components/chat/blocks/ErrorCard.tsx
+++ b/packages/frontend/src/components/chat/blocks/ErrorCard.tsx
@@ -13,17 +13,17 @@ export default function ErrorCard({
       <div className="flex items-start gap-2">
         <AlertTriangle className="h-4 w-4 text-destructive shrink-0 mt-0.5" />
         <div className="min-w-0 flex-1">
-          <div className="font-medium text-destructive">Error</div>
+          <div className="font-medium text-destructive">오류</div>
           <div className="text-destructive/80 mt-0.5 break-words">
             {message}
           </div>
           {recoverable && (
             <div className="mt-2 flex gap-2">
               <Button size="sm" variant="outline" className="h-7 gap-1">
-                <RefreshCw className="h-3 w-3" /> Retry
+                <RefreshCw className="h-3 w-3" /> 다시 시도
               </Button>
               <Button size="sm" variant="ghost" className="h-7">
-                Report
+                신고
               </Button>
             </div>
           )}

--- a/packages/frontend/src/components/chat/blocks/UsageFooter.tsx
+++ b/packages/frontend/src/components/chat/blocks/UsageFooter.tsx
@@ -5,15 +5,22 @@ export default function UsageFooter({
 }: {
   usage: SessionInfo["usage"];
 }) {
-  const fmt = (n: number) => n.toLocaleString();
+  const exact = (n: number) => n.toLocaleString();
+  const compact = (n: number) =>
+    n >= 1_000_000
+      ? `${(n / 1_000_000).toFixed(1)}M`
+      : n >= 10_000
+        ? `${Math.round(n / 1_000)}k`
+        : exact(n);
   return (
     <div
       data-qa="usage-footer"
+      title={`입력 ${exact(usage.input)} · 출력 ${exact(usage.output)} · 캐시 ${exact(usage.cached)} 토큰`}
       className="sticky bottom-0 -mx-3 -mb-4 border-t border-border bg-background/95 backdrop-blur px-3 py-1.5 flex items-center gap-3 text-[10px] text-muted-foreground font-mono"
     >
-      <span>in {fmt(usage.input)}</span>
-      <span>out {fmt(usage.output)}</span>
-      <span>cached {fmt(usage.cached)}</span>
+      <span>입력 {compact(usage.input)}</span>
+      <span>출력 {compact(usage.output)}</span>
+      <span>캐시 {compact(usage.cached)}</span>
     </div>
   );
 }

--- a/packages/frontend/src/components/chat/blocks/UserMessage.tsx
+++ b/packages/frontend/src/components/chat/blocks/UserMessage.tsx
@@ -21,7 +21,7 @@ export default function UserMessage({
         {text}
         {attachmentCount && attachmentCount > 0 ? (
           <div className="mt-1 text-[10px] text-muted-foreground">
-            📎 {attachmentCount} attachment{attachmentCount === 1 ? "" : "s"}
+            📎 첨부 파일 {attachmentCount}개
           </div>
         ) : null}
       </div>
@@ -31,12 +31,12 @@ export default function UserMessage({
           onClick={() => {
             if (!turnId || !onRevert || reverting) return;
             const ok = window.confirm(
-              "Revert to the state before this turn? Files changed since then will be lost.",
+              "이 턴 이전 상태로 되돌릴까요? 이후 변경된 파일은 사라져요.",
             );
             if (ok) onRevert(turnId);
           }}
           disabled={reverting}
-          title="Revert to the state before this turn"
+          title="이 턴 이전 상태로 되돌리기"
           className={cn(
             "absolute -left-6 top-1/2 inline-flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-full border border-border bg-background text-muted-foreground opacity-0 transition-opacity",
             "group-hover:opacity-100 hover:text-foreground",
@@ -44,7 +44,7 @@ export default function UserMessage({
           )}
         >
           <RotateCcw className="h-3 w-3" />
-          <span className="sr-only">Revert this turn</span>
+          <span className="sr-only">이 턴 되돌리기</span>
         </button>
       )}
     </div>

--- a/packages/frontend/src/components/errors/BackendCrashToast.tsx
+++ b/packages/frontend/src/components/errors/BackendCrashToast.tsx
@@ -36,7 +36,7 @@ export default function ToastContainer() {
             <button
               onClick={() => dismiss(t.id)}
               className="text-muted-foreground hover:text-foreground"
-              aria-label="Dismiss"
+              aria-label="닫기"
             >
               <X className="h-3.5 w-3.5" />
             </button>

--- a/packages/frontend/src/components/errors/CliMissingModal.tsx
+++ b/packages/frontend/src/components/errors/CliMissingModal.tsx
@@ -26,9 +26,9 @@ export default function CliMissingModal({
           <div className="h-10 w-10 rounded-md bg-destructive/10 text-destructive grid place-items-center mb-3">
             <AlertTriangle className="h-5 w-5" />
           </div>
-          <DialogTitle>No LLM CLI found</DialogTitle>
+          <DialogTitle>LLM CLI를 찾을 수 없어요</DialogTitle>
           <DialogDescription>
-            BurnGuard Design needs Claude Code or Codex CLI installed to create projects.
+            BurnGuard Design에서 프로젝트를 만들려면 Claude Code 또는 Codex CLI를 설치해야 해요.
           </DialogDescription>
         </DialogHeader>
 
@@ -42,7 +42,7 @@ export default function CliMissingModal({
                     {b.id.replace("-", " ")}
                   </span>
                   <span className="text-xs text-muted-foreground">
-                    {b.found ? `installed (${b.version ?? "ok"})` : "not found"}
+                    {b.found ? `설치됨 (${b.version ?? "정상"})` : "찾을 수 없음"}
                   </span>
                 </div>
                 {!b.found && url && (
@@ -52,7 +52,7 @@ export default function CliMissingModal({
                     rel="noreferrer"
                     className="text-xs text-accent inline-flex items-center gap-1 mt-1"
                   >
-                    <ExternalLink className="h-3 w-3" /> Install guide
+                    <ExternalLink className="h-3 w-3" /> 설치 안내
                   </a>
                 )}
               </li>
@@ -61,7 +61,7 @@ export default function CliMissingModal({
         </ul>
 
         <DialogFooter className="pt-2 border-t border-border">
-          <Button onClick={() => onOpenChange(false)}>OK</Button>
+          <Button onClick={() => onOpenChange(false)}>확인</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/packages/frontend/src/components/export/ExportMenu.tsx
+++ b/packages/frontend/src/components/export/ExportMenu.tsx
@@ -79,11 +79,11 @@ export default function ExportMenu({ projectId, projectType, projectOptionsJson,
       void queryClient.invalidateQueries({
         queryKey: ["project", projectId, "exports"],
       });
-      pushToast({ title: "Export queued", tone: "info" });
+      pushToast({ title: "내보내기를 예약했어요", tone: "info" });
     },
     onError: (err) => {
       pushToast({
-        title: "Export failed to start",
+        title: "내보내기를 시작하지 못했어요",
         body: err instanceof Error ? err.message : String(err),
         tone: "error",
       });
@@ -116,12 +116,12 @@ export default function ExportMenu({ projectId, projectType, projectOptionsJson,
         const looksLikeChromium = job.error_message?.toLowerCase().includes("chromium");
         const auditFailed = isDesignAuditExportFailure(job);
         pushToast({
-          title: `Export failed (${formatLabel(job.format)})`,
+          title: `내보내기에 실패했어요 (${formatLabel(job.format)})`,
           body: auditFailed
             ? "내보내기 전 품질 점검에서 고쳐야 할 문제가 발견됐어요."
             : looksLikeChromium
-              ? 'Chromium is not installed. Open Settings → "Chromium for exports" → Install, then re-run the export.'
-              : (job.error_message ?? "Unknown error."),
+              ? 'Chromium이 설치되어 있지 않아요. 설정 → "내보내기용 Chromium" → 설치를 실행한 뒤 다시 내보내 주세요.'
+              : (job.error_message ?? "알 수 없는 오류예요."),
           tone: "error",
         });
       }
@@ -135,13 +135,13 @@ export default function ExportMenu({ projectId, projectType, projectOptionsJson,
           variant="outline"
           size="sm"
           className="gap-1.5 focus:ring-2 focus:ring-ring focus:ring-offset-1 max-[900px]:min-h-11 max-[900px]:min-w-11 max-[900px]:justify-center max-[900px]:gap-0 max-[900px]:px-0 max-[900px]:text-[0px]"
-          aria-label="Export"
+          aria-label="내보내기"
         >
-          <Download className="h-3.5 w-3.5" /> Export
+          <Download className="h-3.5 w-3.5" /> 내보내기
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent data-export-menu-content align="end" className="z-[100] w-72">
-        <DropdownMenuLabel>Export as</DropdownMenuLabel>
+        <DropdownMenuLabel>내보내기 형식</DropdownMenuLabel>
         <DropdownMenuSeparator />
         {qualityGate !== null && <div className="mx-2 mb-2 rounded-md border border-destructive/30 bg-destructive/10 p-2">
           <p className="text-pretty break-keep text-xs text-foreground">고쳐야 할 문제 {qualityGate.mustFixCount}개가 있어 내보내기를 {"시작할\u00A0수\u00A0없어요."}</p>
@@ -179,7 +179,7 @@ export default function ExportMenu({ projectId, projectType, projectOptionsJson,
               <span className="flex-1">{option.label}</span>
               {option.disabledReason === "deck_only" && (
                 <span className="text-[10px] text-muted-foreground">
-                  deck only
+                  덱 전용
                 </span>
               )}
             </DropdownMenuItem>

--- a/packages/frontend/src/components/export/ExportStatusList.tsx
+++ b/packages/frontend/src/components/export/ExportStatusList.tsx
@@ -32,7 +32,7 @@ export default function ExportStatusList({
   return (
     <div className="px-2 py-1.5">
       <div className="mb-1 px-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-        Recent
+        최근 내보내기
       </div>
       <ul className="space-y-1">
         {jobs.slice(0, 5).map((j) => {
@@ -81,10 +81,10 @@ export default function ExportStatusList({
                   onClick={() => onRetry?.(j.format)}
                   disabled={retryDisabled}
                   className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-accent/10 hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
-                  title="Retry this export"
+                  title="이 내보내기 다시 시도"
                 >
                   <RotateCcw className="h-3 w-3" />
-                  Retry
+                  다시 시도
                 </button>
               )}
               {!canDownload && !canRetry && (

--- a/packages/frontend/src/components/export/export-options.ts
+++ b/packages/frontend/src/components/export/export-options.ts
@@ -40,13 +40,13 @@ export function buildExportRetryRequest(
 }
 
 const STANDARD_OPTIONS = [
-  { key: "html_zip", format: "html_zip", label: "HTML zip" },
-  { key: "pdf-a4", format: "pdf", options: { pdf_paper: "a4" }, label: "PDF · A4 landscape" },
-  { key: "pdf-letter", format: "pdf", options: { pdf_paper: "letter" }, label: "PDF · Letter landscape" },
-  { key: "pdf-widescreen", format: "pdf", options: { pdf_paper: "widescreen-16x9" }, label: "PDF · 16:9 widescreen" },
-  { key: "pptx-16x9", format: "pptx", options: { pptx_size: "16x9" }, label: "PowerPoint · 16:9" },
-  { key: "pptx-4x3", format: "pptx", options: { pptx_size: "4x3" }, label: "PowerPoint · 4:3" },
-  { key: "handoff", format: "handoff", label: "Developer handoff (.zip)" },
+  { key: "html_zip", format: "html_zip", label: "HTML ZIP 파일" },
+  { key: "pdf-a4", format: "pdf", options: { pdf_paper: "a4" }, label: "PDF · A4 가로" },
+  { key: "pdf-letter", format: "pdf", options: { pdf_paper: "letter" }, label: "PDF · 레터 가로" },
+  { key: "pdf-widescreen", format: "pdf", options: { pdf_paper: "widescreen-16x9" }, label: "PDF · 16:9 와이드스크린" },
+  { key: "pptx-16x9", format: "pptx", options: { pptx_size: "16x9" }, label: "파워포인트 · 16:9" },
+  { key: "pptx-4x3", format: "pptx", options: { pptx_size: "4x3" }, label: "파워포인트 · 4:3" },
+  { key: "handoff", format: "handoff", label: "개발자 전달용 (.zip)" },
 ] as const satisfies readonly ExportMenuOption[];
 
 export function buildExportMenuModel(

--- a/packages/frontend/src/components/files/FilePreview.tsx
+++ b/packages/frontend/src/components/files/FilePreview.tsx
@@ -4,7 +4,7 @@ export default function FilePreview({ file }: { file: FileInfo | null }) {
   if (!file) {
     return (
       <div className="flex-1 grid place-items-center text-sm text-muted-foreground p-8">
-        Select a file to preview.
+        미리 볼 파일을 선택하세요.
       </div>
     );
   }
@@ -40,7 +40,7 @@ export default function FilePreview({ file }: { file: FileInfo | null }) {
 function PlaceholderImage({ name }: { name: string }) {
   return (
     <div className="aspect-video grid place-items-center bg-muted border border-border rounded-md text-muted-foreground text-sm">
-      {name} — image preview arrives in Sprint 4
+      {name} — 이미지 미리보기는 Sprint 4에서 제공돼요
     </div>
   );
 }

--- a/packages/frontend/src/components/files/FileTree.tsx
+++ b/packages/frontend/src/components/files/FileTree.tsx
@@ -19,13 +19,13 @@ const CATEGORY_ORDER: FileInfo["category"][] = [
 ];
 
 const CATEGORY_LABEL: Record<FileInfo["category"], string> = {
-  folder: "Folders",
-  stylesheet: "Stylesheets",
-  script: "Scripts",
-  html: "Html",
-  asset: "Assets",
-  document: "Documents",
-  other: "Other",
+  folder: "폴더",
+  stylesheet: "스타일시트",
+  script: "스크립트",
+  html: "HTML",
+  asset: "에셋",
+  document: "문서",
+  other: "기타",
 };
 
 function iconFor(category: FileInfo["category"]) {

--- a/packages/frontend/src/components/layout/Sidebar.tsx
+++ b/packages/frontend/src/components/layout/Sidebar.tsx
@@ -83,7 +83,7 @@ export default function Sidebar() {
                 variant="outline"
                 className="h-4 rounded-sm py-0 text-[10px]"
               >
-                Local
+                로컬
               </Badge>
               <span className="text-[11px] text-foreground/70">
                 v{settings.app_version}

--- a/packages/frontend/src/components/layout/TopBar.tsx
+++ b/packages/frontend/src/components/layout/TopBar.tsx
@@ -10,7 +10,7 @@ export default function TopBar() {
         className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
       >
         <ChevronLeft className="h-4 w-4" />
-        Home
+        홈
       </Link>
       <div className="mx-3 text-muted-foreground text-sm">·</div>
       <div className="text-sm text-foreground font-mono">{pathname}</div>

--- a/packages/frontend/src/components/modes/CommentPanel.tsx
+++ b/packages/frontend/src/components/modes/CommentPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Comment } from "@bg/shared";
 import { cn } from "@/lib/utils";
 
@@ -32,14 +32,14 @@ export default function CommentPanel({
     : [];
 
   return (
-    <div className="flex min-h-0 flex-col">
+    <div className="flex min-h-0 flex-1 flex-col">
       <div className="border-b border-border px-3 py-2">
         <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-          Comments
+          코멘트
         </div>
-        <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-          Click on the canvas to drop a pin. Each pin is anchored to a
-          percentage position on the active file.
+        <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground [word-break:keep-all]">
+          캔버스를 클릭하면 그 자리에 핀이 생겨요. 핀은 활성 파일의 백분율
+          위치에 고정돼요.
         </p>
       </div>
 
@@ -48,9 +48,9 @@ export default function CommentPanel({
           <p className="px-1 pt-2 text-xs text-muted-foreground">
             {activeRelPath
               ? activeSlideIdx != null
-                ? "No open comments on this slide yet."
-                : "No open comments on this file yet."
-              : "Open a file in the canvas to comment."}
+                ? "이 슬라이드에는 아직 열린 코멘트가 없어요."
+                : "이 파일에는 아직 열린 코멘트가 없어요."
+              : "코멘트를 남기려면 캔버스에서 파일을 여세요."}
           </p>
         )}
 
@@ -90,13 +90,14 @@ function CommentItem({
   onToggleResolved: () => void;
 }) {
   const [draft, setDraft] = useState(comment.body);
+  const editingRef = useRef(false);
   const resolved = comment.resolved_at !== null;
 
-  // Sync local draft whenever the server-side body changes and the user isn't
-  // actively editing (cheap heuristic: only when not focused).
   useEffect(() => {
-    if (!focused) setDraft(comment.body);
-  }, [comment.body, focused]);
+    setDraft((current) =>
+      nextCommentDraft(current, comment.body, editingRef.current),
+    );
+  }, [comment.body]);
 
   const commitIfDirty = () => {
     if (draft !== comment.body) onUpdateBody(draft);
@@ -128,7 +129,7 @@ function CommentItem({
           {comment.node_selector || "body"}
         </span>
         <span className="text-[10px] text-muted-foreground">
-          {resolved ? "resolved" : "open"}
+          {resolved ? "해결됨" : "열림"}
         </span>
       </button>
 
@@ -136,8 +137,14 @@ function CommentItem({
         <textarea
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
-          onBlur={commitIfDirty}
-          placeholder="Add a note..."
+          onFocus={() => {
+            editingRef.current = true;
+          }}
+          onBlur={() => {
+            commitIfDirty();
+            editingRef.current = false;
+          }}
+          placeholder="메모를 남겨 보세요..."
           rows={2}
           className="w-full resize-none rounded border border-border bg-background p-1.5 text-xs"
         />
@@ -150,10 +157,18 @@ function CommentItem({
             onClick={onToggleResolved}
             className="text-[10px] text-muted-foreground hover:text-foreground"
           >
-            {resolved ? "Reopen" : "Resolve"}
+            {resolved ? "다시 열기" : "해결하기"}
           </button>
         </div>
       </div>
     </div>
   );
+}
+
+export function nextCommentDraft(
+  current: string,
+  serverBody: string,
+  editing: boolean,
+): string {
+  return editing ? current : serverBody;
 }

--- a/packages/frontend/src/components/modes/DrawPanel.tsx
+++ b/packages/frontend/src/components/modes/DrawPanel.tsx
@@ -3,9 +3,9 @@ import { cn } from "@/lib/utils";
 import type { DrawTool } from "@/components/canvas/DrawLayer";
 
 const TOOLS: Array<{ id: DrawTool; label: string; icon: typeof Pencil }> = [
-  { id: "pen", label: "Pen", icon: Pencil },
-  { id: "rect", label: "Rect", icon: Square },
-  { id: "arrow", label: "Arrow", icon: ArrowUpRight },
+  { id: "pen", label: "펜", icon: Pencil },
+  { id: "rect", label: "사각형", icon: Square },
+  { id: "arrow", label: "화살표", icon: ArrowUpRight },
 ];
 
 const COLORS = ["#EF4444", "#F59E0B", "#10B981", "#3B82F6", "#111827"];
@@ -38,17 +38,17 @@ export default function DrawPanel({
     <div className="flex min-h-0 flex-col overflow-y-auto">
       <div className="border-b border-border px-3 py-2">
         <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-          Draw
+          그리기
         </div>
         <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-          Sketch annotations over the canvas. Saved per file; excluded
-          from the html_zip export.
+          캔버스 위에 메모를 스케치해요. 파일마다 저장되고 html_zip
+          내보내기에는 포함되지 않아요.
         </p>
       </div>
 
       <section className="px-3 py-2 border-b border-border">
         <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground mb-1.5">
-          Tool
+          도구
         </div>
         <div className="grid grid-cols-3 gap-1">
           {TOOLS.map((t) => (
@@ -72,7 +72,7 @@ export default function DrawPanel({
 
       <section className="px-3 py-2 border-b border-border">
         <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground mb-1.5">
-          Color
+          색상
         </div>
         <div className="flex flex-wrap gap-1.5">
           {COLORS.map((c) => (
@@ -93,7 +93,7 @@ export default function DrawPanel({
 
       <section className="px-3 py-2 border-b border-border">
         <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground mb-1.5">
-          Stroke
+          선 굵기
         </div>
         <div className="flex gap-1.5">
           {WIDTHS.map((w) => (
@@ -123,26 +123,26 @@ export default function DrawPanel({
           onClick={onUndo}
           disabled={!hasShapes}
           className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] text-muted-foreground hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed"
-          title="Undo (Ctrl+Z)"
+          title="실행 취소 (Ctrl+Z)"
         >
-          <Undo2 className="h-3 w-3" /> Undo
+          <Undo2 className="h-3 w-3" /> 실행 취소
         </button>
         <button
           type="button"
           onClick={onRedo}
           className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] text-muted-foreground hover:text-foreground"
-          title="Redo (Ctrl+Shift+Z)"
+          title="다시 실행 (Ctrl+Shift+Z)"
         >
-          <Redo2 className="h-3 w-3" /> Redo
+          <Redo2 className="h-3 w-3" /> 다시 실행
         </button>
         <button
           type="button"
           onClick={onClear}
           disabled={!hasShapes}
           className="ml-auto inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] text-destructive hover:bg-destructive/10 disabled:opacity-40 disabled:cursor-not-allowed"
-          title="Clear all shapes on this file"
+          title="이 파일의 그리기를 모두 지워요"
         >
-          <Trash2 className="h-3 w-3" /> Clear
+          <Trash2 className="h-3 w-3" /> 모두 지우기
         </button>
       </div>
     </div>

--- a/packages/frontend/src/components/modes/EditPanel.tsx
+++ b/packages/frontend/src/components/modes/EditPanel.tsx
@@ -44,12 +44,13 @@ export default function EditPanel({
     return (
       <div className="p-4">
         <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-2">
-          Edit
+          편집
         </div>
         <p className="text-xs text-muted-foreground leading-relaxed">
-          Hover over the canvas to highlight editable elements, then click one
-          to inspect and edit it. Only elements with{" "}
-          <code className="font-mono">data-bg-node-id</code> are editable.
+          캔버스에 마우스를 올리면 편집할 수 있는 요소가 강조되고, 클릭하면
+          내용을 보고 고칠 수 있어요.{" "}
+          <code className="font-mono">data-bg-node-id</code>가 있는 요소만
+          편집할 수 있어요.
         </p>
       </div>
     );
@@ -91,14 +92,14 @@ export default function EditPanel({
       <div className="border-b border-border px-3 py-2">
         <div className="flex items-center justify-between">
           <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-            Edit
+            편집
           </span>
           <button
             type="button"
             onClick={onClear}
             className="text-[10px] text-muted-foreground hover:text-foreground"
           >
-            Clear
+            선택 해제
           </button>
         </div>
         <div className="mt-1 font-mono text-xs">&lt;{target.tag}&gt;</div>
@@ -109,7 +110,7 @@ export default function EditPanel({
 
       <section className="px-3 py-2">
         <label className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-          Text content
+          텍스트 내용
         </label>
         <textarea
           value={text}
@@ -122,19 +123,19 @@ export default function EditPanel({
       <section className="px-3 py-2 border-t border-border">
         <div className="flex items-center justify-between">
           <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-            Attributes
+            속성
           </span>
           <button
             type="button"
             onClick={() => setAttrRows((prev) => [...prev, { key: "", value: "" }])}
             className="text-[10px] text-muted-foreground hover:text-foreground"
           >
-            + Add
+            + 추가
           </button>
         </div>
         <div className="mt-1 flex flex-col gap-1">
           {attrRows.length === 0 && (
-            <p className="text-[10px] text-muted-foreground">No attributes.</p>
+            <p className="text-[10px] text-muted-foreground">속성이 없어요.</p>
           )}
           {attrRows.map((row, idx) => (
             <div key={idx} className="flex gap-1">
@@ -145,7 +146,7 @@ export default function EditPanel({
                   next[idx] = { ...next[idx], key: e.target.value };
                   setAttrRows(next);
                 }}
-                placeholder="name"
+                placeholder="이름"
                 className="min-w-0 flex-1 rounded border border-border bg-background p-1 text-[11px] font-mono"
               />
               <input
@@ -155,14 +156,14 @@ export default function EditPanel({
                   next[idx] = { ...next[idx], value: e.target.value };
                   setAttrRows(next);
                 }}
-                placeholder="value"
+                placeholder="값"
                 className="min-w-0 flex-1 rounded border border-border bg-background p-1 text-[11px] font-mono"
               />
               <button
                 type="button"
                 onClick={() => setAttrRows(attrRows.filter((_, i) => i !== idx))}
                 className="px-1 text-muted-foreground hover:text-foreground"
-                aria-label="Remove attribute"
+                aria-label="속성 삭제"
               >
                 ×
               </button>
@@ -181,7 +182,7 @@ export default function EditPanel({
             "hover:bg-orange-600 disabled:cursor-not-allowed disabled:opacity-60",
           )}
         >
-          {saving ? "Saving..." : "Save"}
+          {saving ? "저장하는 중..." : "저장"}
         </button>
       </div>
     </div>

--- a/packages/frontend/src/components/modes/SelectorReadOnlyPanel.tsx
+++ b/packages/frontend/src/components/modes/SelectorReadOnlyPanel.tsx
@@ -16,13 +16,13 @@ export default function SelectorReadOnlyPanel({
     return (
       <div className="p-4">
         <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-2">
-          Select
+          선택
         </div>
         <p className="text-xs text-muted-foreground leading-relaxed">
-          Click an element in the canvas to inspect its computed styles.
+          캔버스에서 요소를 클릭하면 계산된 스타일을 볼 수 있어요.
         </p>
         <p className="mt-3 text-[10px] text-muted-foreground leading-relaxed">
-          Select an authored element to carry its context into inline Tweaks.
+          코드에 있는 요소를 고르면 그 맥락을 그대로 스타일 모드로 넘길 수 있어요.
         </p>
       </div>
     );
@@ -30,7 +30,7 @@ export default function SelectorReadOnlyPanel({
 
   const groups: Array<{ title: string; keys: string[] }> = [
     {
-      title: "Typography",
+      title: "타이포그래피",
       keys: [
         "font-family",
         "font-size",
@@ -40,9 +40,9 @@ export default function SelectorReadOnlyPanel({
         "letter-spacing",
       ],
     },
-    { title: "Size", keys: ["width", "height"] },
+    { title: "크기", keys: ["width", "height"] },
     {
-      title: "Box",
+      title: "박스",
       keys: ["padding", "margin", "border", "border-radius", "background"],
     },
   ];
@@ -51,7 +51,7 @@ export default function SelectorReadOnlyPanel({
     <div className="p-3 overflow-y-auto">
       <div className="px-1 pb-2 border-b border-border mb-3">
         <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-          Selector
+          선택자
         </div>
         <div className="text-xs font-mono mt-0.5 truncate">
           {selection.nodeId}
@@ -80,8 +80,8 @@ export default function SelectorReadOnlyPanel({
       ))}
 
       <p className="text-[10px] text-muted-foreground px-1 mt-3 leading-relaxed">
-        Computed values come from the live canvas. Inline changes are saved as
-        reversible file patches.
+        계산된 값은 지금 캔버스에서 그대로 읽어 와요. 인라인 변경은 되돌릴 수
+        있는 파일 패치로 저장돼요.
       </p>
       {selection.bgId && (
         <button
@@ -89,7 +89,7 @@ export default function SelectorReadOnlyPanel({
           onClick={onPromoteToTweaks}
           className="mx-1 mt-3 w-[calc(100%-0.5rem)] rounded-md bg-accent px-3 py-2 text-xs font-medium text-accent-foreground transition-colors hover:bg-accent/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
-          Open in Tweaks
+          스타일 모드에서 열기
         </button>
       )}
     </div>

--- a/packages/frontend/src/components/modes/TweaksPanel.tsx
+++ b/packages/frontend/src/components/modes/TweaksPanel.tsx
@@ -95,12 +95,12 @@ export default function TweaksPanel({
     return (
       <div className="p-4">
         <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-2">
-          Tweaks
+          스타일
         </div>
         <p className="text-xs text-muted-foreground leading-relaxed">
-          Hover the canvas to highlight an element, then click to inspect
-          and edit its CSS. Changes save as inline style overrides on the
-          picked element. Cmd/Ctrl+Z undoes the last change.
+          캔버스에 마우스를 올리면 요소가 강조되고, 클릭하면 CSS를 살펴보고
+          고칠 수 있어요. 바꾼 값은 선택한 요소의 인라인 스타일로 저장돼요.
+          Cmd/Ctrl+Z로 마지막 변경을 되돌릴 수 있어요.
         </p>
       </div>
     );
@@ -111,24 +111,24 @@ export default function TweaksPanel({
       <div className="border-b border-border px-3 py-2">
         <div className="flex items-center justify-between">
           <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-            Tweaks
+            스타일
           </span>
           <div className="flex items-center gap-2">
             <button
               type="button"
               onClick={onResetAll}
               className="text-[10px] text-muted-foreground hover:text-foreground"
-              title="Remove every inline override on this node"
+              title="이 요소의 인라인 덮어쓰기를 모두 지워요"
               disabled={saving || Object.keys(target.inline).length === 0}
             >
-              Reset
+              초기화
             </button>
             <button
               type="button"
               onClick={onClear}
               className="text-[10px] text-muted-foreground hover:text-foreground"
             >
-              Clear
+              선택 해제
             </button>
           </div>
         </div>
@@ -139,10 +139,10 @@ export default function TweaksPanel({
       </div>
       {review && (
         <section
-          aria-label="Last inline patch"
+          aria-label="마지막 인라인 패치"
           className="border-b border-border bg-muted/30 px-3 py-2"
         >
-          <SectionHeader>Last patch</SectionHeader>
+          <SectionHeader>마지막 변경</SectionHeader>
           <pre className="mt-1.5 overflow-x-auto rounded border border-border bg-background px-2 py-1.5 font-mono text-[10px] leading-relaxed">
             <span className="text-muted-foreground">
               - {review.property}: {review.from}
@@ -153,13 +153,13 @@ export default function TweaksPanel({
             </span>
           </pre>
           <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-            Saved as a reversible inline style override.
+            되돌릴 수 있는 인라인 스타일 덮어쓰기로 저장했어요.
           </p>
         </section>
       )}
 
       <section className="border-b border-border px-3 py-2">
-        <SectionHeader>Typography</SectionHeader>
+        <SectionHeader>타이포그래피</SectionHeader>
         <div className="mt-1.5 flex flex-col gap-2">
           <SizeRow target={target} styleKey="font-size" saving={saving} onApply={onApply} />
           <FontWeightRow target={target} saving={saving} onApply={onApply} />
@@ -170,7 +170,7 @@ export default function TweaksPanel({
       </section>
 
       <section className="border-b border-border px-3 py-2">
-        <SectionHeader>Box</SectionHeader>
+        <SectionHeader>박스</SectionHeader>
         <div className="mt-1.5 flex flex-col gap-2">
           <ColorRow target={target} styleKey="background-color" saving={saving} onApply={onApply} />
           <SidesRow target={target} styleKey="padding" saving={saving} onApply={onApply} />
@@ -180,9 +180,9 @@ export default function TweaksPanel({
       </section>
 
       <p className="px-3 py-2 text-[10px] leading-relaxed text-muted-foreground">
-        Sizes commit as <code className="font-mono">px</code>. Clear a size
-        field to drop that override; click a palette swatch or enter a hex
-        to set a colour.
+        크기는 <code className="font-mono">px</code> 단위로 저장돼요. 크기 칸을
+        비우면 그 덮어쓰기가 사라지고, 팔레트 색을 누르거나 hex 값을 입력하면
+        색이 지정돼요.
       </p>
     </div>
   );
@@ -290,7 +290,7 @@ function FontWeightRow({
 
   return (
     <label className="flex items-center gap-2 text-[11px]">
-      <RowLabel>font-weight</RowLabel>
+      <RowLabel>글꼴 굵기</RowLabel>
       <select
         value={inline}
         onChange={(e) => {
@@ -301,7 +301,7 @@ function FontWeightRow({
         className={inputCls("min-w-0 flex-1")}
       >
         <option value="">
-          {computed ? `inherit (${computed})` : "inherit"}
+          {computed ? `상속 (${computed})` : "상속"}
         </option>
         {FONT_WEIGHTS.map((w) => (
           <option key={w.value} value={w.value}>
@@ -449,9 +449,9 @@ function ColorRow({
                 "rounded border border-border bg-background px-1.5 py-0.5 text-[10px] text-muted-foreground hover:text-foreground",
                 !inline && "opacity-50 cursor-not-allowed",
               )}
-              title="Remove this inline override"
+              title="이 인라인 덮어쓰기를 지워요"
             >
-              Clear
+              지우기
             </button>
           </div>
         </div>
@@ -513,10 +513,10 @@ function SidesRow({
     <div className="flex items-center gap-2 text-[11px]">
       <RowLabel>{styleKey}</RowLabel>
       <div className="flex min-w-0 flex-1 items-center gap-1">
-        <SideInput title="top" value={sides.top} onCommit={commitSide("top")} disabled={saving} />
-        <SideInput title="right" value={sides.right} onCommit={commitSide("right")} disabled={saving} />
-        <SideInput title="bottom" value={sides.bottom} onCommit={commitSide("bottom")} disabled={saving} />
-        <SideInput title="left" value={sides.left} onCommit={commitSide("left")} disabled={saving} />
+        <SideInput title="위" value={sides.top} onCommit={commitSide("top")} disabled={saving} />
+        <SideInput title="오른쪽" value={sides.right} onCommit={commitSide("right")} disabled={saving} />
+        <SideInput title="아래" value={sides.bottom} onCommit={commitSide("bottom")} disabled={saving} />
+        <SideInput title="왼쪽" value={sides.left} onCommit={commitSide("left")} disabled={saving} />
       </div>
       <span className="w-6 shrink-0 text-[10px] text-muted-foreground">px</span>
     </div>

--- a/packages/frontend/src/components/present/PresentOverlay.tsx
+++ b/packages/frontend/src/components/present/PresentOverlay.tsx
@@ -72,11 +72,11 @@ export default function PresentOverlay({
       ref={rootRef}
       className="fixed inset-0 z-[9999] bg-black"
       role="dialog"
-      aria-label="Presentation"
+      aria-label="프레젠테이션"
     >
       <iframe
         key={src}
-        title="Presentation"
+        title="프레젠테이션"
         src={withPresentFlag(src)}
         sandbox="allow-scripts"
         className="absolute inset-0 h-full w-full border-0 bg-black"
@@ -85,9 +85,9 @@ export default function PresentOverlay({
         type="button"
         onClick={onClose}
         className="absolute right-3 top-3 inline-flex items-center gap-1 rounded-full bg-white/10 px-2.5 py-1.5 text-[11px] font-medium text-white backdrop-blur transition-colors hover:bg-white/20"
-        title="Exit presentation (Esc)"
+        title="프레젠테이션 종료 (Esc)"
       >
-        <X className="h-3 w-3" /> Exit
+        <X className="h-3 w-3" /> 종료
       </button>
       <div className="pointer-events-none absolute left-3 top-3 rounded-full bg-white/10 px-2.5 py-1 font-mono text-[11px] text-white backdrop-blur">
         {formatElapsed(elapsedMs)}

--- a/packages/frontend/src/components/project/ArtifactTabs.tsx
+++ b/packages/frontend/src/components/project/ArtifactTabs.tsx
@@ -77,6 +77,7 @@ export default function ArtifactTabs({
             <button
               type="button"
               onClick={() => onSelect(tab.id)}
+              title={tab.relPath ?? tab.title}
               className={cn(
                 "flex h-full items-center gap-2 border-b-2 px-3 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
                 isActive

--- a/packages/frontend/src/components/project/ProjectTopBar.tsx
+++ b/packages/frontend/src/components/project/ProjectTopBar.tsx
@@ -27,7 +27,7 @@ export default function ProjectTopBar({
         <Link
           to="/"
           className="text-muted-foreground hover:text-foreground"
-          title="Home"
+          title="홈"
         >
           <Home className="h-4 w-4" />
         </Link>
@@ -50,11 +50,11 @@ export default function ProjectTopBar({
           disabled={!canPresent || !onPresent}
           title={
             canPresent
-              ? "Start presentation"
-              : "Open a deck file in the canvas to present"
+              ? "발표 시작"
+              : "발표하려면 캔버스에서 덱 파일을 여세요"
           }
         >
-          <Play className="h-3.5 w-3.5" /> Present
+          <Play className="h-3.5 w-3.5" /> 발표
         </Button>
         <ExportMenu projectId={project.id} projectType={project.type} projectOptionsJson={project.options_json} qualityGate={qualityGate} onOpenQuality={onOpenQuality} />
       </div>

--- a/packages/frontend/src/components/settings/BackendSelector.tsx
+++ b/packages/frontend/src/components/settings/BackendSelector.tsx
@@ -14,7 +14,7 @@ export default function BackendSelector({
   return (
     <div className="space-y-2">
       <label className="text-xs font-medium text-muted-foreground">
-        Default backend
+        기본 백엔드
       </label>
       <div className="space-y-2">
         {detection.backends.map((b) => {

--- a/packages/frontend/src/components/settings/SettingsModal.tsx
+++ b/packages/frontend/src/components/settings/SettingsModal.tsx
@@ -27,6 +27,17 @@ import {
 } from "@/api/settings";
 import { useUIStore } from "@/state/uiStore";
 
+const CHAT_CONTEXT_MODE_LABELS = {
+  compact: "간단",
+  full: "전체",
+} as const;
+
+const THEME_LABELS = {
+  light: "밝게",
+  dark: "어둡게",
+  auto: "시스템 설정",
+} as const;
+
 export default function SettingsModal() {
   const open = useUIStore((s) => s.settingsOpen);
   const setOpen = useUIStore((s) => s.setSettingsOpen);
@@ -98,7 +109,7 @@ export default function SettingsModal() {
       setPw(next);
     } catch (err) {
       pushToast({
-        title: "Could not start Playwright install",
+        title: "Playwright 설치를 시작하지 못했어요",
         body: err instanceof Error ? err.message : String(err),
         tone: "error",
       });
@@ -140,7 +151,7 @@ export default function SettingsModal() {
       setPy(next);
     } catch (err) {
       pushToast({
-        title: "Could not start pypdf install",
+        title: "pypdf 설치를 시작하지 못했어요",
         body: err instanceof Error ? err.message : String(err),
         tone: "error",
       });
@@ -161,11 +172,11 @@ export default function SettingsModal() {
         user: settings.user,
       });
       queryClient.setQueryData(["settings"], next);
-      pushToast({ title: "Settings saved", tone: "success" });
+      pushToast({ title: "설정을 저장했어요", tone: "success" });
       setOpen(false);
     } catch (err) {
       pushToast({
-        title: "Could not save settings",
+        title: "설정을 저장하지 못했어요",
         body: err instanceof Error ? err.message : String(err),
         tone: "error",
       });
@@ -182,12 +193,12 @@ export default function SettingsModal() {
       queryClient.setQueryData(["settings"], next);
       setFigmaTokenInput("");
       pushToast({
-        title: value === null ? "Figma token cleared" : "Figma token saved",
+        title: value === null ? "Figma 토큰을 지웠어요" : "Figma 토큰을 저장했어요",
         tone: "success",
       });
     } catch (err) {
       pushToast({
-        title: "Could not save Figma token",
+        title: "Figma 토큰을 저장하지 못했어요",
         body: err instanceof Error ? err.message : String(err),
         tone: "error",
       });
@@ -200,15 +211,15 @@ export default function SettingsModal() {
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>Settings</DialogTitle>
+          <DialogTitle>설정</DialogTitle>
           <DialogDescription>
-            Local preferences — saved to <code className="font-mono text-[11px]">~/.burnguard/config.json</code>
+            이 컴퓨터에만 저장되는 설정이에요 — <code className="font-mono text-[11px]">~/.burnguard/config.json</code>
           </DialogDescription>
         </DialogHeader>
 
         {!settings || !detection ? (
           <div className="py-8 text-center text-sm text-muted-foreground">
-            Loading…
+            불러오는 중…
           </div>
         ) : (
           <div className="space-y-5 py-2">
@@ -217,7 +228,7 @@ export default function SettingsModal() {
                 htmlFor="display-name"
                 className="text-xs font-medium text-muted-foreground"
               >
-                Display name
+                표시 이름
               </label>
               <Input
                 id="display-name"
@@ -241,7 +252,7 @@ export default function SettingsModal() {
 
             <div className="space-y-1.5">
               <label className="text-xs font-medium text-muted-foreground">
-                Chromium for exports
+                내보내기용 Chromium
               </label>
               <div className="rounded-md border border-border bg-muted/30 p-3">
                 <div className="flex items-center gap-2">
@@ -254,7 +265,7 @@ export default function SettingsModal() {
                       variant="ghost"
                       size="icon"
                       className="h-6 w-6"
-                      title="Refresh"
+                      title="새로 고침"
                       onClick={async () => {
                         try {
                           setPw(await getPlaywrightInstallStatus());
@@ -276,10 +287,10 @@ export default function SettingsModal() {
                     >
                       <Download className="h-3 w-3" />
                       {pw?.state === "installing"
-                        ? "Installing…"
+                        ? "설치하는 중…"
                         : pw?.state === "success"
-                          ? "Reinstall"
-                          : "Install Chromium"}
+                          ? "다시 설치"
+                          : "Chromium 설치"}
                     </Button>
                   </div>
                 </div>
@@ -294,18 +305,18 @@ export default function SettingsModal() {
                   </p>
                 )}
                 <p className="mt-2 text-[10px] leading-relaxed text-muted-foreground">
-                  PDF and PPTX export need a Chromium build. This runs{" "}
+                  PDF·PPTX 내보내기에는 Chromium이 필요해요. 서버에서{" "}
                   <code className="font-mono">
                     npx playwright install chromium
                   </code>{" "}
-                  on the server. ~170MB download, first run only.
+                  를 실행해요. 약 170MB이고 처음 한 번만 받아요.
                 </p>
               </div>
             </div>
 
             <div className="space-y-1.5">
               <label className="text-xs font-medium text-muted-foreground">
-                Python for uploads
+                업로드용 Python
               </label>
               <div className="rounded-md border border-border bg-muted/30 p-3">
                 <div className="flex items-center gap-2">
@@ -316,7 +327,7 @@ export default function SettingsModal() {
                       variant="ghost"
                       size="icon"
                       className="h-6 w-6"
-                      title="Refresh"
+                      title="새로 고침"
                       onClick={async () => {
                         try {
                           setPy(await getPythonSettings());
@@ -339,16 +350,16 @@ export default function SettingsModal() {
                       }
                       title={
                         py?.health.python.found === false
-                          ? "Install Python 3.10+ first"
+                          ? "먼저 Python 3.10 이상을 설치해 주세요"
                           : undefined
                       }
                     >
                       <Download className="h-3 w-3" />
                       {py?.install.state === "installing"
-                        ? "Installing…"
+                        ? "설치하는 중…"
                         : py?.health.pypdf.found
-                          ? "Reinstall pypdf"
-                          : "Install pypdf"}
+                          ? "pypdf 다시 설치"
+                          : "pypdf 설치"}
                     </Button>
                   </div>
                 </div>
@@ -363,12 +374,12 @@ export default function SettingsModal() {
                   </p>
                 )}
                 <p className="mt-2 text-[10px] leading-relaxed text-muted-foreground">
-                  PDF / PPTX design-system uploads shell out to Python with{" "}
-                  <code className="font-mono">pypdf</code>. Install runs{" "}
+                  PDF·PPTX 디자인 시스템 업로드는 Python의{" "}
+                  <code className="font-mono">pypdf</code>를 사용해요. 설치는{" "}
                   <code className="font-mono">
                     python -m pip install --user pypdf
                   </code>{" "}
-                  — small download, first run only.
+                  를 실행해요. 용량이 작고 처음 한 번만 받아요.
                 </p>
               </div>
             </div>
@@ -378,7 +389,7 @@ export default function SettingsModal() {
                 htmlFor="abort-threshold"
                 className="text-xs font-medium text-muted-foreground"
               >
-                Interrupt button delay (seconds)
+                중단 버튼이 나타나기까지 (초)
               </label>
               <Input
                 id="abort-threshold"
@@ -399,15 +410,15 @@ export default function SettingsModal() {
                 }}
               />
               <p className="text-[11px] text-muted-foreground">
-                Stop button appears once a chat turn has been running this
-                long. Default 300s (5 min) — lower it if local CLIs stall
-                often, raise it to stay out of the way on cold starts.
+                채팅 턴이 이 시간만큼 이어지면 중단 버튼이 나타나요. 기본값은
+                300초(5분)예요. 로컬 CLI가 자주 멈춘다면 줄이고, 초기 실행이
+                느린 편이라면 늘려 주세요.
               </p>
             </div>
 
             <div className="space-y-1.5">
               <label className="text-xs font-medium text-muted-foreground">
-                Chat context
+                채팅 컨텍스트
               </label>
               <div className="flex gap-2">
                 {(["compact", "full"] as const).map((mode) => (
@@ -421,26 +432,26 @@ export default function SettingsModal() {
                       setSettings({ ...settings, chat_context_mode: mode })
                     }
                   >
-                    {mode}
+                    {CHAT_CONTEXT_MODE_LABELS[mode]}
                   </Button>
                 ))}
               </div>
               <p className="text-[11px] text-muted-foreground">
-                Compact keeps stable project and design-system context as file
-                references so long slide-deck chats stay lighter. Full inlines
-                those excerpts every turn.
+                간단 모드는 프로젝트와 디자인 시스템 맥락을 파일 참조로만 넘겨서
+                긴 슬라이드 덱 대화를 가볍게 유지해요. 전체 모드는 매 턴 그 내용을
+                본문에 그대로 담아요.
               </p>
             </div>
 
             <div className="space-y-1.5">
               <label className="text-xs font-medium text-muted-foreground">
-                Figma access
+                Figma 연동
               </label>
               {settings.figma_token_set ? (
                 <div className="flex items-center justify-between rounded border border-border px-3 py-2 text-xs">
                   <span className="flex items-center gap-2">
                     <span className="inline-block h-1.5 w-1.5 rounded-full bg-accent" />
-                    Connected — Figma personal access token is set.
+                    연결됨 — Figma 개인 액세스 토큰이 설정돼 있어요.
                   </span>
                   <Button
                     variant="outline"
@@ -448,7 +459,7 @@ export default function SettingsModal() {
                     disabled={figmaTokenSaving}
                     onClick={() => saveFigmaToken(null)}
                   >
-                    Disconnect
+                    연결 해제
                   </Button>
                 </div>
               ) : (
@@ -468,22 +479,21 @@ export default function SettingsModal() {
                     }
                     onClick={() => saveFigmaToken(figmaTokenInput.trim())}
                   >
-                    {figmaTokenSaving ? "Saving…" : "Save"}
+                    {figmaTokenSaving ? "저장하는 중…" : "저장"}
                   </Button>
                 </div>
               )}
               <p className="text-[11px] text-muted-foreground">
-                Used by the Systems → Import flow to extract published color
-                and text styles from a Figma file. Generate a token at
-                Figma → Settings → Personal access tokens. The value is stored
-                only in your local <code className="font-mono">~/.burnguard/config.json</code>{" "}
-                and is never echoed back through this UI.
+                Figma 파일에서 공개된 색·텍스트 스타일을 가져올 때 사용해요.
+                토큰은 Figma → Settings → Personal access tokens에서 만들 수
+                있어요. 값은 이 컴퓨터의 <code className="font-mono">~/.burnguard/config.json</code>{" "}
+                에만 저장되고 화면에 다시 표시되지 않아요.
               </p>
             </div>
 
             <div className="space-y-1.5">
               <label className="text-xs font-medium text-muted-foreground">
-                Theme
+                테마
               </label>
               <div className="flex gap-2">
                 {(["light", "dark", "auto"] as const).map((t) => (
@@ -493,12 +503,12 @@ export default function SettingsModal() {
                     size="sm"
                     onClick={() => setSettings({ ...settings, theme: t })}
                   >
-                    {t}
+                    {THEME_LABELS[t]}
                   </Button>
                 ))}
               </div>
               <p className="text-[11px] text-muted-foreground">
-                Dark theme arrives in Phase 2.
+                다크 테마는 2단계에서 제공될 예정이에요.
               </p>
             </div>
           </div>
@@ -506,10 +516,10 @@ export default function SettingsModal() {
 
         <DialogFooter className="pt-2 border-t border-border">
           <Button variant="ghost" onClick={() => setOpen(false)}>
-            Cancel
+            취소
           </Button>
           <Button variant="cta" onClick={save} disabled={saving || !settings}>
-            {saving ? "Saving…" : "Save"}
+            {saving ? "저장하는 중…" : "저장"}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -534,16 +544,16 @@ function PlaywrightStateDot({
 }
 
 function pwLabel(status: PlaywrightInstallStatus | null): string {
-  if (!status) return "Loading…";
+  if (!status) return "불러오는 중…";
   switch (status.state) {
     case "installing":
-      return "Installing Chromium…";
+      return "Chromium을 설치하는 중이에요…";
     case "success":
-      return "Chromium install completed.";
+      return "Chromium 설치를 마쳤어요.";
     case "error":
-      return "Last install failed.";
+      return "지난 설치가 실패했어요.";
     default:
-      return "Not installed (or status unknown).";
+      return "설치되어 있지 않아요(또는 상태를 알 수 없어요).";
   }
 }
 
@@ -569,15 +579,15 @@ function PyStateDot({ py }: { py: PythonSettings | null }) {
 }
 
 function pyLabel(py: PythonSettings | null): string {
-  if (!py) return "Loading…";
-  if (py.install.state === "installing") return "Installing pypdf…";
+  if (!py) return "불러오는 중…";
+  if (py.install.state === "installing") return "pypdf를 설치하는 중이에요…";
   if (!py.health.python.found) {
-    return "Python runtime not found — install Python 3.10+.";
+    return "Python을 찾지 못했어요 — Python 3.10 이상을 설치해 주세요.";
   }
   if (py.health.pypdf.found) {
     const ver = py.health.pypdf.version ? ` ${py.health.pypdf.version}` : "";
-    return `Ready — pypdf${ver} (${py.health.python.version ?? "Python"}).`;
+    return `사용할 수 있어요 — pypdf${ver} (${py.health.python.version ?? "Python"}).`;
   }
-  if (py.install.state === "error") return "Last pypdf install failed.";
-  return "pypdf not installed yet.";
+  if (py.install.state === "error") return "지난 pypdf 설치가 실패했어요.";
+  return "pypdf가 아직 설치되지 않았어요.";
 }

--- a/packages/frontend/src/components/systems/PreviewIframe.tsx
+++ b/packages/frontend/src/components/systems/PreviewIframe.tsx
@@ -53,7 +53,7 @@ export default function PreviewIframe({
         <div>
           <div className="truncate max-w-[180px]">{path}</div>
           <div className="mt-1 text-[9px] text-muted-foreground/70">
-            preview unavailable
+            미리보기를 사용할 수 없어요
           </div>
         </div>
       </div>
@@ -63,7 +63,7 @@ export default function PreviewIframe({
   if (!content) {
     return (
       <div className="aspect-video rounded-md bg-muted grid place-items-center text-[10px] font-mono text-muted-foreground">
-        loading…
+        불러오는 중…
       </div>
     );
   }

--- a/packages/frontend/src/components/systems/SystemHeader.tsx
+++ b/packages/frontend/src/components/systems/SystemHeader.tsx
@@ -2,12 +2,18 @@ import type { DesignSystemSummary } from "@bg/shared";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
+const STATUS_LABELS = {
+  draft: "초안",
+  review: "검토",
+  published: "게시됨",
+} as const;
+
 export default function SystemHeader({ system }: { system: DesignSystemSummary }) {
   return (
     <header className="border-b border-border bg-background px-8 py-4 flex items-center gap-3 shrink-0">
       <div className="flex-1 min-w-0">
         <div className="text-xs text-muted-foreground uppercase tracking-wider">
-          Design system
+          디자인 시스템
         </div>
         <h1 className="text-lg font-semibold truncate">{system.name}</h1>
       </div>
@@ -15,12 +21,12 @@ export default function SystemHeader({ system }: { system: DesignSystemSummary }
         variant={system.status === "published" ? "accent" : "outline"}
         className="uppercase tracking-wider"
       >
-        {system.status}
+        {STATUS_LABELS[system.status]}
       </Badge>
-      {system.is_template && <Badge variant="outline">Template</Badge>}
+      {system.is_template && <Badge variant="outline">템플릿</Badge>}
       {system.status === "review" && (
         <Button variant="cta" size="sm">
-          Publish
+          게시
         </Button>
       )}
     </header>

--- a/packages/frontend/src/components/systems/SystemPreviewGrid.tsx
+++ b/packages/frontend/src/components/systems/SystemPreviewGrid.tsx
@@ -9,44 +9,44 @@ interface PreviewSection {
 
 const SECTIONS: PreviewSection[] = [
   {
-    group: "Brand",
+    group: "브랜드",
     items: [
-      { id: "brand-logos", title: "Brand Logos", desc: "Six official lockups" },
-      { id: "brand-icons", title: "Brand Icons", desc: "Lucide 1.5px stroke" },
+      { id: "brand-logos", title: "브랜드 로고", desc: "공식 로고 조합 6개" },
+      { id: "brand-icons", title: "브랜드 아이콘", desc: "Lucide 1.5px 스트로크" },
     ],
   },
   {
-    group: "Colors",
+    group: "색상",
     items: [
-      { id: "colors-brand", title: "Brand Colors" },
-      { id: "colors-neutrals", title: "Neutrals" },
-      { id: "colors-ramps", title: "Full Ramps" },
-      { id: "colors-semantic", title: "Semantic" },
-      { id: "colors-charts", title: "Chart Palette" },
+      { id: "colors-brand", title: "브랜드 색상" },
+      { id: "colors-neutrals", title: "중립 색상" },
+      { id: "colors-ramps", title: "전체 색상 단계" },
+      { id: "colors-semantic", title: "의미 색상" },
+      { id: "colors-charts", title: "차트 팔레트" },
     ],
   },
   {
-    group: "Typography",
+    group: "타이포그래피",
     items: [
-      { id: "type-display", title: "Display" },
-      { id: "type-headings", title: "Headings" },
-      { id: "type-body", title: "Body" },
+      { id: "type-display", title: "디스플레이" },
+      { id: "type-headings", title: "제목" },
+      { id: "type-body", title: "본문" },
     ],
   },
   {
-    group: "Foundations",
+    group: "기초",
     items: [
-      { id: "spacing", title: "Spacing" },
-      { id: "radii-shadows", title: "Radii & Shadows" },
+      { id: "spacing", title: "간격" },
+      { id: "radii-shadows", title: "모서리 반경과 그림자" },
     ],
   },
   {
-    group: "Components",
+    group: "컴포넌트",
     items: [
-      { id: "components-buttons", title: "Buttons" },
-      { id: "components-cards", title: "Cards" },
-      { id: "components-forms", title: "Forms" },
-      { id: "components-badges-table", title: "Badges & Table" },
+      { id: "components-buttons", title: "버튼" },
+      { id: "components-cards", title: "카드" },
+      { id: "components-forms", title: "폼" },
+      { id: "components-badges-table", title: "배지와 표" },
     ],
   },
 ];
@@ -95,7 +95,7 @@ export default function SystemPreviewGrid({
                       </div>
                     )}
                   </div>
-                  {grp.group === "Colors" && onEditColors ? (
+                  {grp.group === "색상" && onEditColors ? (
                     <Button
                       variant="ghost"
                       size="sm"
@@ -103,7 +103,7 @@ export default function SystemPreviewGrid({
                       onClick={onEditColors}
                     >
                       <Pencil className="h-3 w-3" />
-                      Edit
+                      편집
                     </Button>
                   ) : null}
                 </div>
@@ -113,7 +113,7 @@ export default function SystemPreviewGrid({
         </section>
       ))}
       <p className="text-[11px] text-muted-foreground">
-        Preview content streams from{" "}
+        미리보기 콘텐츠는 다음 경로에서 제공돼요:{" "}
         <code className="font-mono">
           GET /api/design-systems/:id/files/preview/:name
         </code>

--- a/packages/frontend/src/components/ui/dialog.tsx
+++ b/packages/frontend/src/components/ui/dialog.tsx
@@ -41,7 +41,7 @@ const DialogContent = React.forwardRef<
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">닫기</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>

--- a/packages/frontend/src/lib/canvas-source.ts
+++ b/packages/frontend/src/lib/canvas-source.ts
@@ -1,0 +1,27 @@
+export type CanvasSourceInput = {
+  readonly projectId: string | null;
+  readonly activeRelPath: string | null;
+  readonly indexedRelPaths: readonly string[] | null;
+  readonly entrypointUrl: string | null;
+};
+
+export function resolveCanvasSource({
+  projectId,
+  activeRelPath,
+  indexedRelPaths,
+  entrypointUrl,
+}: CanvasSourceInput): string | null {
+  if (projectId !== null && activeRelPath !== null) {
+    if (indexedRelPaths?.length === 0) return null;
+    return `/api/projects/${projectId}/fs/${encodePath(activeRelPath)}`;
+  }
+  if (!entrypointUrl || /\/fs\/?$/u.test(entrypointUrl)) return null;
+  return entrypointUrl;
+}
+
+function encodePath(relPath: string): string {
+  return relPath
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}

--- a/packages/frontend/src/views/DesignFilesView.tsx
+++ b/packages/frontend/src/views/DesignFilesView.tsx
@@ -21,11 +21,11 @@ export default function DesignFilesView({
   const [active, setActive] = useState<FileInfo | null>(null);
 
   return (
-    <div className="flex-1 flex min-h-0">
-      <div className="w-[280px] shrink-0 border-r border-border overflow-y-auto bg-background">
+    <div className="flex-1 flex min-h-0 flex-col sm:flex-row">
+      <div className="h-1/2 w-full shrink-0 overflow-y-auto border-b border-border bg-background sm:h-auto sm:w-[280px] sm:border-b-0 sm:border-r">
         <div className="px-3 pt-3 pb-2 flex items-center justify-between">
           <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-            Project files
+            프로젝트 파일
           </div>
         </div>
         <FileTree

--- a/packages/frontend/src/views/DesignSystemView.tsx
+++ b/packages/frontend/src/views/DesignSystemView.tsx
@@ -17,6 +17,29 @@ import { useUIStore } from "@/state/uiStore";
 
 type FontRole = "display" | "sans" | "serif" | "mono";
 
+const STATUS_LABELS = {
+  draft: "초안",
+  review: "검토",
+  published: "게시됨",
+} as const;
+
+const FONT_ROLE_LABELS = {
+  display: "디스플레이",
+  sans: "산세리프",
+  serif: "세리프",
+  mono: "고정폭",
+} as const;
+
+const CATALOG_DETAIL_LABELS: Record<string, string> = {
+  Status: "상태",
+  Template: "템플릿",
+  Source: "출처",
+  "Source URI": "출처 URI",
+  Directory: "디렉터리",
+  "Tokens CSS": "토큰 CSS",
+  Archived: "보관됨",
+};
+
 export default function DesignSystemView({
   systemIdOverride,
 }: {
@@ -53,7 +76,7 @@ export default function DesignSystemView({
       if (!id) throw new Error("missing id");
       if (!system) throw new Error("missing system");
       const trimmedName = draftName.trim();
-      if (!trimmedName) throw new Error("Name cannot be empty.");
+      if (!trimmedName) throw new Error("이름을 비워 둘 수 없어요.");
       return await updateDesignSystemWithConflictReload(id, {
         expected_revision: system.metadata_revision,
         name: trimmedName,
@@ -69,20 +92,20 @@ export default function DesignSystemView({
         setDraftDescription(result.current.description ?? "");
         setDraftStatus(result.current.status);
         pushToast({
-          title: "Design system changed elsewhere",
-          body: "Current metadata was reloaded. Review and save again.",
+          title: "다른 곳에서 디자인 시스템이 변경됐어요",
+          body: "현재 메타데이터를 다시 불러왔어요. 검토한 뒤 다시 저장해 주세요.",
           tone: "error",
         });
         return;
       }
       setSystem(result.system);
       setEditing(false);
-      pushToast({ title: "Design system updated", tone: "success" });
+      pushToast({ title: "디자인 시스템을 업데이트했어요", tone: "success" });
       await queryClient.invalidateQueries({ queryKey: ["design-systems"] });
     },
     onError: (err) => {
       pushToast({
-        title: "Could not update design system",
+        title: "디자인 시스템을 업데이트하지 못했어요",
         body: err instanceof Error ? err.message : String(err),
         tone: "error",
       });
@@ -104,11 +127,11 @@ export default function DesignSystemView({
       setDraftColorName("");
       setDraftColorValue("#000000");
       setPreviewRefreshKey((key) => key + 1);
-      pushToast({ title: "Color token saved", tone: "success" });
+      pushToast({ title: "색상 토큰을 저장했어요", tone: "success" });
     },
     onError: (err) => {
       pushToast({
-        title: "Could not save color",
+        title: "색상을 저장하지 못했어요",
         body: err instanceof Error ? err.message : String(err),
         tone: "error",
       });
@@ -118,7 +141,7 @@ export default function DesignSystemView({
   const fontMutation = useMutation({
     mutationFn: async () => {
       if (!id) throw new Error("missing id");
-      if (!fontFile) throw new Error("Choose a font file first.");
+      if (!fontFile) throw new Error("먼저 글꼴 파일을 선택해 주세요.");
       return await uploadDesignSystemFont(id, fontFile, {
         family: fontFamily,
         role: fontRole,
@@ -132,14 +155,14 @@ export default function DesignSystemView({
       }
       setPreviewRefreshKey((key) => key + 1);
       pushToast({
-        title: "Font uploaded",
-        body: `${font.family} saved to ${font.rel_path}`,
+        title: "글꼴을 업로드했어요",
+        body: `${font.family}을(를) ${font.rel_path}에 저장했어요`,
         tone: "success",
       });
     },
     onError: (err) => {
       pushToast({
-        title: "Could not upload font",
+        title: "글꼴을 업로드하지 못했어요",
         body: err instanceof Error ? err.message : String(err),
         tone: "error",
       });
@@ -196,7 +219,7 @@ export default function DesignSystemView({
     return (
       <div className="grid flex-1 place-items-center">
         <div className="text-sm text-muted-foreground">
-          Loading design system...
+          디자인 시스템을 불러오는 중...
         </div>
       </div>
     );
@@ -208,7 +231,7 @@ export default function DesignSystemView({
         <div className="mx-auto max-w-4xl rounded-2xl border border-border bg-card p-8 shadow-sm">
           <div className="flex items-start justify-between gap-4">
             <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
-              Design system
+              디자인 시스템
             </div>
             {!editing ? (
               <Button
@@ -223,7 +246,7 @@ export default function DesignSystemView({
                 }}
               >
                 <Pencil className="h-3.5 w-3.5" />
-                Edit details
+                세부 정보 편집
               </Button>
             ) : null}
           </div>
@@ -235,7 +258,7 @@ export default function DesignSystemView({
               </h1>
               <p className="mt-3 max-w-2xl text-sm leading-7 text-muted-foreground">
                 {system.description ??
-                  "Bundled local design system. Files are available to sessions as project context."}
+                  "기본 제공 로컬 디자인 시스템이에요. 파일은 프로젝트 컨텍스트로 세션에 제공돼요."}
               </p>
             </>
           ) : (
@@ -245,7 +268,7 @@ export default function DesignSystemView({
                   htmlFor="ds-name"
                   className="text-xs font-medium text-muted-foreground"
                 >
-                  Name
+                  이름
                 </label>
                 <Input
                   id="ds-name"
@@ -259,7 +282,7 @@ export default function DesignSystemView({
                   htmlFor="ds-description"
                   className="text-xs font-medium text-muted-foreground"
                 >
-                  Description
+                  설명
                 </label>
                 <textarea
                   id="ds-description"
@@ -275,7 +298,7 @@ export default function DesignSystemView({
                   htmlFor="ds-status"
                   className="text-xs font-medium text-muted-foreground"
                 >
-                  Status
+                  상태
                 </label>
                 <select
                   id="ds-status"
@@ -288,9 +311,9 @@ export default function DesignSystemView({
                   disabled={updateMutation.isPending}
                   className="flex h-9 w-full max-w-[200px] rounded-md border border-input bg-background px-3 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:opacity-50"
                 >
-                  <option value="draft">Draft</option>
-                  <option value="review">Review</option>
-                  <option value="published">Published</option>
+                  <option value="draft">{STATUS_LABELS.draft}</option>
+                  <option value="review">{STATUS_LABELS.review}</option>
+                  <option value="published">{STATUS_LABELS.published}</option>
                 </select>
               </div>
               <div className="flex items-center gap-2 pt-1">
@@ -301,14 +324,14 @@ export default function DesignSystemView({
                     updateMutation.isPending || !draftName.trim()
                   }
                 >
-                  {updateMutation.isPending ? "Saving…" : "Save changes"}
+                  {updateMutation.isPending ? "저장하는 중…" : "변경 사항 저장"}
                 </Button>
                 <Button
                   variant="ghost"
                   onClick={() => setEditing(false)}
                   disabled={updateMutation.isPending}
                 >
-                  Cancel
+                  취소
                 </Button>
               </div>
             </div>
@@ -319,7 +342,7 @@ export default function DesignSystemView({
           ) : null}
 
           <dl className="mt-8 grid gap-4 text-sm md:grid-cols-2">
-            {catalogDetailRows(system).map((row) => <InfoRow key={row.label} label={row.label} value={row.value} />)}
+            {catalogDetailRows(system).map((row) => <InfoRow key={row.label} label={CATALOG_DETAIL_LABELS[row.label] ?? row.label} value={row.label === "Status" ? STATUS_LABELS[system.status] : row.label === "Template" ? system.is_template ? "예" : "아니요" : row.value} />)}
           </dl>
 
           <div className="mt-8 grid gap-4 lg:grid-cols-[0.9fr_1.1fr]">
@@ -417,16 +440,16 @@ function FontUploadCard({
       <div className="flex items-start justify-between gap-3">
         <div>
           <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
-            Fonts
+            글꼴
           </div>
-          <h2 className="mt-1 text-base font-semibold">Upload font</h2>
+          <h2 className="mt-1 text-base font-semibold">글꼴 업로드</h2>
         </div>
         <Upload className="mt-1 h-4 w-4 text-muted-foreground" />
       </div>
       <div className="mt-4 space-y-3">
         <div className="space-y-1.5">
           <label className="text-xs font-medium text-muted-foreground">
-            Font file
+            글꼴 파일
           </label>
           <Input
             ref={inputRef}
@@ -443,18 +466,18 @@ function FontUploadCard({
         </div>
         <div className="space-y-1.5">
           <label className="text-xs font-medium text-muted-foreground">
-            Font family
+            글꼴 패밀리
           </label>
           <Input
             value={family}
-            placeholder="Leave blank to infer from filename"
+            placeholder="비워 두면 파일 이름에서 추정해요"
             onChange={(e) => onFamilyChange(e.target.value)}
             disabled={saving}
           />
         </div>
         <div className="space-y-1.5">
           <label className="text-xs font-medium text-muted-foreground">
-            Assign to token
+            토큰에 할당
           </label>
           <select
             value={role}
@@ -462,10 +485,10 @@ function FontUploadCard({
             disabled={saving}
             className="flex h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:opacity-50"
           >
-            <option value="sans">Sans</option>
-            <option value="display">Display</option>
-            <option value="serif">Serif</option>
-            <option value="mono">Mono</option>
+            <option value="sans">{FONT_ROLE_LABELS.sans}</option>
+            <option value="display">{FONT_ROLE_LABELS.display}</option>
+            <option value="serif">{FONT_ROLE_LABELS.serif}</option>
+            <option value="mono">{FONT_ROLE_LABELS.mono}</option>
           </select>
         </div>
         <Button
@@ -474,7 +497,7 @@ function FontUploadCard({
           onClick={onUpload}
           disabled={saving || !file}
         >
-          {saving ? "Uploading..." : "Upload font"}
+          {saving ? "업로드하는 중..." : "글꼴 업로드"}
         </Button>
       </div>
     </section>
@@ -517,28 +540,28 @@ function ColorTokenEditor({
       <div className="flex items-start justify-between gap-3">
         <div>
           <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
-            Colors
+            색상
           </div>
-          <h2 className="mt-1 text-base font-semibold">Color tokens</h2>
+          <h2 className="mt-1 text-base font-semibold">색상 토큰</h2>
           <p className="mt-1 text-xs text-muted-foreground">
-            {tokenFilePath ? "Backed by colors_and_type.css" : "No token file found"}
+            {tokenFilePath ? "colors_and_type.css에서 관리돼요" : "토큰 파일을 찾을 수 없어요"}
           </p>
         </div>
         <Button variant="outline" size="sm" onClick={onAdd}>
           <Plus className="h-3.5 w-3.5" />
-          Add color
+          색상 추가
         </Button>
       </div>
 
       {hasDraft ? (
         <div className="mt-4 rounded-xl border border-border bg-card p-4">
           <div className="mb-3 text-xs font-medium">
-            {editingToken ? `Edit --${editingToken.name}` : "Add color token"}
+            {editingToken ? `--${editingToken.name} 편집` : "색상 토큰 추가"}
           </div>
           <div className="grid gap-3 md:grid-cols-[1fr_0.8fr]">
             <div className="space-y-1.5">
               <label className="text-xs font-medium text-muted-foreground">
-                Token name
+                토큰 이름
               </label>
               <Input
                 value={name}
@@ -549,7 +572,7 @@ function ColorTokenEditor({
             </div>
             <div className="space-y-1.5">
               <label className="text-xs font-medium text-muted-foreground">
-                Color value
+                색상 값
               </label>
               <div className="flex gap-2">
                 <input
@@ -575,10 +598,10 @@ function ColorTokenEditor({
               onClick={onSave}
               disabled={saving || !name.trim() || !value.trim()}
             >
-              {saving ? "Saving..." : "Save color"}
+              {saving ? "저장하는 중..." : "색상 저장"}
             </Button>
             <Button variant="ghost" size="sm" onClick={onCancel} disabled={saving}>
-              Cancel
+              취소
             </Button>
           </div>
         </div>
@@ -587,7 +610,7 @@ function ColorTokenEditor({
       <div className="mt-4 max-h-[360px] space-y-2 overflow-y-auto pr-1">
         {tokens.length === 0 ? (
           <div className="rounded-xl border border-dashed border-border px-4 py-6 text-center text-sm text-muted-foreground">
-            No color tokens detected yet.
+            아직 감지된 색상 토큰이 없어요.
           </div>
         ) : (
           tokens.map((token) => (
@@ -612,7 +635,7 @@ function ColorTokenEditor({
                 onClick={() => onEdit(token)}
               >
                 <Pencil className="h-3 w-3" />
-                Edit
+                편집
               </Button>
             </div>
           ))
@@ -643,49 +666,48 @@ function DraftValidationCard({
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <Badge variant="outline" className="border-amber-300 bg-white text-amber-800">
-              Issue
+              확인 필요
             </Badge>
             <span className="text-xs font-medium uppercase tracking-[0.16em] text-amber-800">
-              Draft validation
+              초안 검증
             </span>
           </div>
           <h2 className="mt-2 text-base font-semibold text-foreground">
-            Do these components and typography patterns actually match the source?
+            이 컴포넌트와 타이포그래피 패턴이 실제 원본과 일치하나요?
           </h2>
           <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
-            This draft was scaffolded automatically. The main review question is
-            whether the extracted component patterns, typography samples, and
-            preview sections are actually faithful to the source material for{" "}
-            {system.name}. If not, the next step should be to dig through the
-            source CSS and HTML again and rebuild the draft with better matches.
+            이 초안은 자동으로 만들었어요. 검토할 핵심은 추출된 컴포넌트 패턴, 타이포그래피
+            샘플, 미리보기 섹션이 {system.name}의 원본 자료를 충실히 반영하는지예요.
+            그렇지 않다면 원본 CSS와 HTML을 다시 살펴보고, 더 잘 맞도록 초안을
+            다시 만들어야 해요.
           </p>
 
           <div className="mt-4 grid gap-3 md:grid-cols-2">
             <IssueBox
-              label="Check components"
-              body="Are the buttons, cards, forms, badges, tables, and other previewed components actually representative of the source design system?"
+              label="컴포넌트 확인"
+              body="버튼, 카드, 폼, 배지, 표와 그 밖의 미리보기 컴포넌트가 원본 디자인 시스템을 제대로 대표하나요?"
             />
             <IssueBox
-              label="Check typography"
-              body="Do the display, heading, and body samples reflect the real source type choices, scale, weight, and tone rather than guessed defaults?"
+              label="타이포그래피 확인"
+              body="디스플레이, 제목, 본문 샘플이 추정한 기본값이 아니라 실제 원본의 글꼴 선택, 크기, 굵기, 분위기를 반영하나요?"
             />
           </div>
 
           <div className="mt-3 rounded-xl border border-amber-200 bg-white/80 px-4 py-3">
             <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-amber-800">
-              If the answer is no
+              아니라면
             </div>
             <p className="mt-2 text-sm leading-6 text-foreground">
-              Re-run extraction with a stronger pass over the source CSS, HTML,
-              and captured UI files so the draft reflects the real system more
-              accurately before review or publish.
+              검토 또는 게시하기 전에 원본 CSS, HTML, 캡처한 UI 파일을 더 면밀히
+              분석하여 추출을 다시 실행하고, 초안이 실제 시스템을 더 정확히
+              반영하도록 해 주세요.
             </p>
           </div>
 
           {notes.length > 0 ? (
             <div className="mt-3 rounded-xl border border-amber-200 bg-white/80 px-4 py-3">
               <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-amber-800">
-                Extraction notes
+                추출 메모
               </div>
               <ul className="mt-2 space-y-1 text-sm leading-6 text-foreground">
                 {notes.map((note, idx) => (

--- a/packages/frontend/src/views/ProjectView.tsx
+++ b/packages/frontend/src/views/ProjectView.tsx
@@ -39,7 +39,6 @@ import {
   listProjectComments,
   updateProjectComment,
 } from "@/api/comments";
-import { getSettings } from "@/api/home";
 import {
   cancelDesignDirections,
   generateDesignDirections,
@@ -103,6 +102,7 @@ import {
   isDesignAuditCurrent,
   preferDesignAuditResult,
 } from "@/lib/design-audit-state";
+import { resolveCanvasSource } from "@/lib/canvas-source";
 
 export default function ProjectView() {
   const { id } = useParams();
@@ -219,10 +219,6 @@ export default function ProjectView() {
     queryFn: () => listProjectComments(id!),
     enabled: Boolean(id),
   });
-  const settingsQuery = useQuery({
-    queryKey: ["settings"],
-    queryFn: getSettings,
-  });
   const directionQueryKey = useMemo(
     () => ["project", id, "design-directions"] as const,
     [id],
@@ -333,7 +329,7 @@ export default function ProjectView() {
     },
     onError: (error) => {
       pushToast({
-        title: "Refresh failed",
+        title: "캔버스를 새로 고치지 못했어요",
         body: error instanceof Error ? error.message : String(error),
         tone: "error",
       });
@@ -357,7 +353,7 @@ export default function ProjectView() {
     },
     onError: (error) => {
       pushToast({
-        title: "Could not create comment",
+        title: "코멘트를 만들지 못했어요",
         body: error instanceof Error ? error.message : String(error),
         tone: "error",
       });
@@ -383,7 +379,7 @@ export default function ProjectView() {
     },
     onError: (error) => {
       pushToast({
-        title: "Could not update comment",
+        title: "코멘트를 수정하지 못했어요",
         body: error instanceof Error ? error.message : String(error),
         tone: "error",
       });
@@ -405,7 +401,7 @@ export default function ProjectView() {
     },
     onError: (error) => {
       pushToast({
-        title: "Could not submit decision",
+        title: "권한 결정을 보내지 못했어요",
         body: error instanceof Error ? error.message : String(error),
         tone: "error",
       });
@@ -444,7 +440,7 @@ export default function ProjectView() {
     },
     onError: (error) => {
       pushToast({
-        title: "Could not apply tweak",
+        title: "스타일을 적용하지 못했어요",
         body: error instanceof Error ? error.message : String(error),
         tone: "error",
       });
@@ -484,7 +480,7 @@ export default function ProjectView() {
     },
     onError: (error) => {
       pushToast({
-        title: "Could not save edit",
+        title: "편집을 저장하지 못했어요",
         body: error instanceof Error ? error.message : String(error),
         tone: "error",
       });
@@ -496,7 +492,7 @@ export default function ProjectView() {
     if (!(error instanceof ApiError) || error.status !== 404) {
       return;
     }
-    pushToast({ title: "Project not found", tone: "error" });
+    pushToast({ title: "프로젝트를 찾을 수 없어요", tone: "error" });
     navigate("/", { replace: true });
   }, [navigate, projectQuery.error, pushToast]);
 
@@ -546,11 +542,11 @@ export default function ProjectView() {
         invalidateDesignAudit(),
       ]);
       setRefreshTick((value) => value + 1);
-      pushToast({ title: "Turn reverted", tone: "info" });
+      pushToast({ title: "이전 턴으로 되돌렸어요", tone: "info" });
     },
     onError: (error) => {
       pushToast({
-        title: "Could not revert turn",
+        title: "턴을 되돌리지 못했어요",
         body: error instanceof Error ? error.message : String(error),
         tone: "error",
       });
@@ -567,7 +563,7 @@ export default function ProjectView() {
     }) => putProjectDraws(id!, relPath, svg),
     onError: (err) => {
       pushToast({
-        title: "Could not save draw",
+        title: "그리기를 저장하지 못했어요",
         body: err instanceof Error ? err.message : String(err),
         tone: "error",
       });
@@ -603,6 +599,23 @@ export default function ProjectView() {
       cancelled = true;
     };
   }, [id, activeTabId, openFileTabs]);
+
+  // Escape는 현재 캔버스 모드를 끈다. 입력 필드 타이핑 중에는 무시해
+  // 인스펙터/컴포저의 자체 Escape 동작을 방해하지 않는다.
+  useEffect(() => {
+    if (mode === null) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      const t = e.target as HTMLElement | null;
+      if (t) {
+        const tag = t.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || t.isContentEditable) return;
+      }
+      setMode(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [mode]);
 
   // Global Cmd/Ctrl+Z / Cmd/Ctrl+Shift+Z for Draw mode — routes to
   // DrawLayer's internal undo/redo stack via ref. Draw shapes don't need
@@ -801,12 +814,12 @@ export default function ProjectView() {
     const handle = window.setInterval(() => setNowTs(Date.now()), 1000);
     return () => window.clearInterval(handle);
   }, [chatComposerDisabled]);
-  const abortThresholdMs =
-    settingsQuery.data?.chat_abort_threshold_ms ?? 300_000;
+  // 통제권 우선: 실행 중이면 5초 유예 뒤 항상 중단 가능. 턴 시작 시점에
+  // 체크포인트를 뜨고 되돌리기가 있으므로 중단은 복구 가능한 동작이다.
+  const turnElapsedMs =
+    turnStartedAt == null ? null : Math.max(0, nowTs - turnStartedAt);
   const canInterrupt =
-    chatComposerDisabled &&
-    turnStartedAt != null &&
-    nowTs - turnStartedAt >= abortThresholdMs;
+    chatComposerDisabled && turnElapsedMs != null && turnElapsedMs >= 5_000;
 
   const interruptMutation = useMutation({
     mutationFn: () => {
@@ -815,7 +828,7 @@ export default function ProjectView() {
     },
     onError: (err) => {
       pushToast({
-        title: "Could not interrupt turn",
+        title: "작업을 중단하지 못했어요",
         body: err instanceof Error ? err.message : String(err),
         tone: "error",
       });
@@ -873,15 +886,22 @@ export default function ProjectView() {
     const activeFile = tabs.find(
       (tab) => tab.id === activeTabId && tab.kind === "file" && tab.relPath,
     );
-    if (activeFile?.relPath && project) {
-      return `/api/projects/${project.id}/fs/${encodeRelPath(activeFile.relPath)}`;
-    }
-    // Only accept an entrypoint URL that actually has a file segment.
-    // A bare `/api/projects/X/fs/` triggers the `relPath: ""` 404 loop.
-    const fallback = artifacts?.entrypoint_url ?? null;
-    if (!fallback || /\/fs\/?$/.test(fallback)) return null;
-    return fallback;
-  }, [activeTabId, artifacts?.entrypoint_url, project, tabs]);
+    return resolveCanvasSource({
+      projectId: project?.id ?? null,
+      activeRelPath: activeFile?.relPath ?? null,
+      indexedRelPaths: filesQuery.isSuccess
+        ? files.map((file) => file.rel_path)
+        : null,
+      entrypointUrl: artifacts?.entrypoint_url ?? null,
+    });
+  }, [
+    activeTabId,
+    artifacts?.entrypoint_url,
+    files,
+    filesQuery.isSuccess,
+    project?.id,
+    tabs,
+  ]);
 
   // File-level single-step undo (audit fix #7). Tracks per-file undo
   // availability and exposes it through the canvas top bar. Server
@@ -932,7 +952,7 @@ export default function ProjectView() {
     },
     onError: (err) => {
       pushToast({
-        title: "Could not undo",
+        title: "실행 취소하지 못했어요",
         body: err instanceof Error ? err.message : String(err),
         tone: "error",
       });
@@ -959,7 +979,7 @@ export default function ProjectView() {
   if (isLoading) {
     return (
       <div className="grid flex-1 place-items-center">
-        <div className="text-sm text-muted-foreground">Loading project...</div>
+        <div className="text-sm text-muted-foreground">프로젝트를 불러오는 중...</div>
       </div>
     );
   }
@@ -967,7 +987,7 @@ export default function ProjectView() {
   if (!project || !session || !artifacts) {
     return (
       <div className="grid flex-1 place-items-center">
-        <div className="text-sm text-destructive">Project unavailable</div>
+        <div className="text-sm text-destructive">프로젝트를 열 수 없어요</div>
       </div>
     );
   }
@@ -1010,8 +1030,20 @@ export default function ProjectView() {
           events={events}
           session={session}
           projectFiles={files}
+          comments={comments}
+          activeRelPath={activeRelPath}
+          activeSlideIdx={activeSlideIdx}
+          focusedCommentId={focusedCommentId}
+          onFocusComment={setFocusedCommentId}
+          onUpdateCommentBody={(commentId, body) =>
+            updateCommentMutation.mutate({ commentId, patch: { body } })
+          }
+          onToggleCommentResolved={(commentId, resolved) =>
+            updateCommentMutation.mutate({ commentId, patch: { resolved } })
+          }
           composerDisabled={composerDisabled}
           canInterrupt={canInterrupt}
+          turnElapsedMs={turnElapsedMs}
           interruptPending={interruptMutation.isPending}
           onInterrupt={() => interruptMutation.mutate()}
           composerInitialText={composerPrefill}
@@ -1046,8 +1078,8 @@ export default function ProjectView() {
                 pushToast({
                   title:
                     error instanceof ApiError && error.status === 409
-                      ? "Turn already running"
-                      : "Could not send message",
+                      ? "이미 실행 중인 턴이 있어요"
+                      : "메시지를 보내지 못했어요",
                   body: visualSourceSendErrorCopy(error),
                   tone: "error",
                 });
@@ -1339,7 +1371,7 @@ function buildTabs(
   return [
     {
       id: "design-system",
-      title: project?.design_system_name ?? "Design System",
+      title: project?.design_system_name ?? "디자인 시스템",
       kind: "design_system",
       closeable: false,
     },
@@ -1351,7 +1383,7 @@ function buildTabs(
     },
     {
       id: "design-files",
-      title: "Design Files",
+      title: "디자인 파일",
       kind: "design_files",
       closeable: false,
     },
@@ -1429,7 +1461,7 @@ function openFileAsTab(
       ...current,
       {
         id: relPath,
-        title: relPath,
+        title: relPath.split("/").pop() ?? relPath,
         kind: "file",
         relPath,
         closeable: true,

--- a/packages/frontend/tests/canvas-source.test.ts
+++ b/packages/frontend/tests/canvas-source.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { resolveCanvasSource } from "../src/lib/canvas-source";
+
+describe("resolveCanvasSource", () => {
+  test("Given a stale active entrypoint and zero indexed files When resolved Then the empty canvas does not fetch the missing file", () => {
+    const source = resolveCanvasSource({
+      projectId: "project-1",
+      activeRelPath: "index.html",
+      indexedRelPaths: [],
+      entrypointUrl: "/api/projects/project-1/fs/index.html",
+    });
+
+    expect(source).toBeNull();
+  });
+
+  test("Given an indexed nested active file When resolved Then its encoded project URL is returned", () => {
+    const source = resolveCanvasSource({
+      projectId: "project-1",
+      activeRelPath: "sections/hero panel.html",
+      indexedRelPaths: ["sections/hero panel.html"],
+      entrypointUrl: null,
+    });
+
+    expect(source).toBe(
+      "/api/projects/project-1/fs/sections/hero%20panel.html",
+    );
+  });
+
+  test("Given a non-empty stale index and a newly generated active file When resolved Then the new file remains renderable", () => {
+    const source = resolveCanvasSource({
+      projectId: "project-1",
+      activeRelPath: "generated/new deck.html",
+      indexedRelPaths: ["index.html"],
+      entrypointUrl: "/api/projects/project-1/fs/index.html",
+    });
+
+    expect(source).toBe(
+      "/api/projects/project-1/fs/generated/new%20deck.html",
+    );
+  });
+
+  test("Given an unavailable file index and an active file When resolved Then the existing canvas remains renderable", () => {
+    const source = resolveCanvasSource({
+      projectId: "project-1",
+      activeRelPath: "index.html",
+      indexedRelPaths: null,
+      entrypointUrl: "/api/projects/project-1/fs/index.html",
+    });
+
+    expect(source).toBe("/api/projects/project-1/fs/index.html");
+  });
+
+  test("Given no active file When a valid artifact entrypoint exists Then the fallback remains available", () => {
+    expect(
+      resolveCanvasSource({
+        projectId: "project-1",
+        activeRelPath: null,
+        indexedRelPaths: ["index.html"],
+        entrypointUrl: "/api/projects/project-1/fs/index.html",
+      }),
+    ).toBe("/api/projects/project-1/fs/index.html");
+  });
+});

--- a/packages/frontend/tests/comment-draft.test.ts
+++ b/packages/frontend/tests/comment-draft.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { nextCommentDraft } from "../src/components/modes/CommentPanel";
+
+describe("nextCommentDraft", () => {
+  test("Given another panel saved newer text When this textarea is idle Then it synchronizes", () => {
+    expect(nextCommentDraft("stale body", "new body", false)).toBe("new body");
+  });
+
+  test("Given another panel saved newer text When this textarea is actively editing Then its draft is preserved", () => {
+    expect(nextCommentDraft("local edit", "new body", true)).toBe("local edit");
+  });
+});

--- a/packages/frontend/tests/error-card.test.ts
+++ b/packages/frontend/tests/error-card.test.ts
@@ -11,7 +11,5 @@ test("Given a sanitized parent-path turn failure When modeled for UI Then no hos
   }));
   expect(html).not.toContain(raw);
   expect(html).not.toContain("/private/");
-  expect(html).toContain("프로젝트 파일에 안전하게 접근할 수 없어요");
-  expect(html).toContain("Retry");
-  expect(html).toContain("Report");
+  expect(html.match(/<button/g)?.length).toBe(2);
 });

--- a/scripts/qa/port.ts
+++ b/scripts/qa/port.ts
@@ -1,4 +1,3 @@
-import { createServer } from "node:net";
 import { QaInputError } from "./errors";
 
 export function parseQaPort(raw: string): number {
@@ -13,20 +12,24 @@ export function parseQaPort(raw: string): number {
 }
 
 export async function isPortFree(port: number): Promise<boolean> {
-  return await new Promise<boolean>((resolve, reject) => {
-    const server = createServer();
-    server.once("error", (error: NodeJS.ErrnoException) => {
-      if (error.code === "EADDRINUSE") resolve(false);
-      else reject(error);
+  try {
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port,
+      fetch: () => new Response(null, { status: 204 }),
     });
-    server.once("listening", () => {
-      server.close((error) => {
-        if (error) reject(error);
-        else resolve(true);
-      });
-    });
-    server.listen(port, "127.0.0.1");
-  });
+    await server.stop(true);
+    return true;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "EADDRINUSE"
+    ) {
+      return false;
+    }
+    throw error;
+  }
 }
 
 async function portOwnerPids(port: number): Promise<readonly number[]> {

--- a/scripts/qa/runtime-smoke.ts
+++ b/scripts/qa/runtime-smoke.ts
@@ -1,27 +1,24 @@
 #!/usr/bin/env bun
 import { mkdtemp } from "node:fs/promises";
-import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { QaPreflightError, QaTimeoutError } from "./errors";
 import { OwnedResources, waitForExactReadiness } from "./runtime";
 
 async function allocatePort(): Promise<number> {
-  return await new Promise<number>((resolve, reject) => {
-    const server = createServer();
-    server.once("error", reject);
-    server.once("listening", () => {
-      const address = server.address();
-      if (address === null || typeof address === "string") {
-        reject(new QaPreflightError("port_allocation_failed", "OS did not allocate a TCP port"));
-        return;
-      }
-      server.close((error) => {
-        if (error) reject(error);
-        else resolve(address.port);
-      });
-    });
-    server.listen(0, "127.0.0.1");
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => new Response(null, { status: 204 }),
   });
+  const port = server.port;
+  await server.stop(true);
+  if (port === undefined) {
+    throw new QaPreflightError(
+      "port_allocation_failed",
+      "OS did not allocate a TCP port",
+    );
+  }
+  return port;
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
## Summary

- **G1 — Control:** show interrupt after five seconds, display elapsed `m:ss`, and preserve the last artifact after interruption.
- **G2 — Empty state:** replace the dark English placeholder with a light Korean empty state; suppress stale entrypoints only for confirmed empty projects and preserve the canvas while the file index is unavailable.
- **G3 — Localization:** localize the remaining product-owned user-facing project, canvas, comments, export, settings, and design-system copy.
- **G4 — Comments:** replace the dead chat placeholder with the real CommentPanel; keep duplicate panel drafts synchronized without clobbering the actively focused editor.
- **G5 — File tabs:** show basenames while preserving full paths in native titles.
- **G6 — Accessibility:** provide the responsive 3x2 mode grid, `aria-pressed` state, and Escape mode exit.
- **G7 — Usage:** show compact Korean token values with exact-value tooltips.

## Verification

- `bun run typecheck` — passed (`tsc --build`, exit 0).
- `bun run scripts/qa/runtime-smoke.ts --json` — readiness, ownership, cleanup, repeated cleanup, misleading-success rejection, and timeout rejection passed.
- Port compatibility driver — occupied/released behavior passed; independent QA covered 23/23 parsing, ownership, occupancy, and release checks.
- Focused G2/G4 regressions — 7 pass, 0 fail.
- `bun test packages/frontend` — **104 pass, 0 fail, 213 assertions across 17 files**. The process exits 1 only because the unchanged repository-wide `bunfig.toml` coverage threshold is 80%; no test failed.
- `git diff --check` — passed.

## Manual and visual evidence

- Full G1-G7 browser coverage at 1280x900, 900x800, and 375x812, including interrupt timing, comments, duplicate file tabs, accessibility state, localization, empty state, and compact usage.
- Latest-tree isolated real-Chromium delta run: 16/16 checks passed, seven valid screenshots, zero page errors, and zero horizontal overflow at 375px.
- The delta run verified indexed canvas, confirmed-empty placeholder, unavailable-index canvas preservation, two live CommentPanel surfaces, active draft protection, idle peer synchronization, blur commit, server persistence, and convergence.
- Review-work publication gate: goal, code quality, security, hands-on QA, and repository context all passed.

## QA compatibility rationale

Root `tsconfig.json` includes `scripts/qa`. Under Bun 1.3.14, Bun’s `node:net` `Server` type does not expose `once()`, so the exact main-branch port probes fail `tsc --build`. The two QA files use the smallest semantically equivalent loopback-only `Bun.serve` allocation; runtime ownership, readiness, error propagation, and cleanup behavior were exercised before publication. No broader QA enhancement is included.

## Deferred backlog

- Session token-budget guard and threshold warning UI.
- Settings cleanup for `chat_abort_threshold_ms` after G1 fixed the interrupt delay at five seconds.
- Mode keyboard shortcuts (1–6), after observing Escape usage.
- README screenshot-slot population.

`.omo` evidence, build outputs, tsbuildinfo, credentials, and unrelated files are excluded from this PR.