### PR TITLE
feat(updates): macOS automatic updates through the Velopack release channel

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -1,0 +1,44 @@
+name: macOS release package
+on:
+  workflow_dispatch:
+  push:
+    tags: ["v*"]
+permissions:
+  contents: write
+jobs:
+  package:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - run: bun install --frozen-lockfile
+      - name: Verify tagged version
+        run: |
+          version=$(bun -e 'console.log(JSON.parse(await Bun.file("package.json").text()).version)')
+          if [ "$GITHUB_REF_TYPE" = "tag" ] && [ "$GITHUB_REF_NAME" != "v$version" ]; then echo "Tag and app version differ" >&2; exit 1; fi
+      - run: bun run typecheck
+      - run: bun run lint
+      - run: bun test packages/backend/tests/mac-updates.test.ts packages/backend/tests/app-update-routes.test.ts --timeout 30000
+      # Signing/notarization stay off until BG_MAC_* secrets exist; unsigned packages are for verification only.
+      - run: bun run build:mac:release
+      - uses: actions/upload-artifact@v4
+        with:
+          name: BurnGuard-macOS
+          path: dist/releases/*
+      - name: Attach to the tag's draft release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The Windows workflow drafts the release for the same tag; whichever job finishes first creates it.
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" dist/releases/* --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" dist/releases/* --draft --verify-tag --title "BurnGuard $GITHUB_REF_NAME" --notes 'Windows and macOS installers, portable apps, and automatic update feeds. Publish this draft after checking the packages.'
+          fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,6 +36,8 @@ jobs:
           packages/backend/tests/python-health.test.ts
           packages/backend/tests/turn-error-sanitizer.test.ts
           packages/backend/tests/config-storage.test.ts
+          packages/backend/tests/mac-updates.test.ts
+          packages/backend/tests/app-update-routes.test.ts
           packages/frontend/tests/artifact-csp.test.ts
           packages/frontend/tests/client.test.ts
       # Advisories with no upstream fix are allowlisted by id; remove an id as

--- a/README.ko.md
+++ b/README.ko.md
@@ -112,7 +112,7 @@ bun run build
 
 `dist/windows/burnguard-design.exe`를 실행하면 빌드된 UI를 **http://127.0.0.1:14070**에서 제공합니다. 배포할 때는 **`dist/windows` 폴더 전체**를 옮기세요. `resources`에는 UI·마이그레이션·기본 디자인 자료·Playwright·Node와 라이선스가 함께 들어 있습니다. Chromium과 Python 상태는 별도로 확인해야 합니다.
 
-macOS 빌드 스크립트도 있지만 최신 UI 변경을 macOS에서 직접 검증하지는 않았습니다. [빌드·개발 문서](doc/CONTRIBUTING.md)를 참고하세요.
+macOS 빌드도 같은 Velopack 업데이트 채널을 사용합니다. `bun run build:mac:release`가 설치 패키지·포터블 앱·`releases.osx.json` 피드를 만들고, 패키지된 앱은 설정 → 업데이트에서 GitHub Releases의 새 버전을 확인해 적용합니다. [빌드·개발 문서](doc/CONTRIBUTING.md)와 [업데이트 문서](doc/13-windows-updates-and-original-samples.md#macos-packaging-and-updates)를 참고하세요.
 
 ## 작업 흐름
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ bun run build
 
 Run `dist/windows/burnguard-design.exe` to serve the built UI at **http://127.0.0.1:14070**. To distribute the app, copy the **entire `dist/windows` folder**. Its `resources` directory includes the UI, migrations, bundled design assets, Playwright, Node, and their licenses. Check Chromium and Python availability separately.
 
-macOS build scripts are also available, but the latest UI changes have not been directly verified on macOS. See the [build and development guide](doc/CONTRIBUTING.md).
+macOS builds use the same Velopack release channel: `bun run build:mac:release` produces the installer, portable app and `releases.osx.json` feed, and the packaged app checks GitHub Releases for updates from Settings → 업데이트. See the [build and development guide](doc/CONTRIBUTING.md) and [updates](doc/13-windows-updates-and-original-samples.md#macos-packaging-and-updates).
 
 ## Workflow
 

--- a/doc/01-architecture.md
+++ b/doc/01-architecture.md
@@ -266,10 +266,14 @@ Current enforcement (updated 2026-09-09 after the security assessment):
   instruction to treat imported text as data, not instructions
 - the Windows desktop shell cancels top-level WebView2 navigation to `/api/*`
   and `/runtime/*`; external links open in the default browser
-- Windows automatic updates (Velopack) read only the public GitHub Releases of
+- automatic updates (Velopack) read only the public GitHub Releases of
   `ashmoonori-afk/BurnGuard` over HTTPS, skip drafts and prereleases, verify
   each package against the SHA-256 feed before staging it, and never apply an
-  update while the owned backend is running
+  update while the backend is running. Windows drives this from the native
+  shell; macOS drives it from the backend (`services/mac-updates.ts`), which
+  hands the verified package to the bundled `UpdateMac` after its own graceful
+  shutdown. A `BG_UPDATE_FEED_URL` override is honoured only for loopback or
+  HTTPS feeds and exists for local rehearsals
 
 Accepted risks and trust assumptions:
 

--- a/doc/13-windows-updates-and-original-samples.md
+++ b/doc/13-windows-updates-and-original-samples.md
@@ -22,6 +22,21 @@ For each new version:
 
 No tag or public release is created by the local build script. Package signing is not configured. Configure a trusted Windows signing certificate in a private release environment before signed distribution; never commit certificate secrets. Changing the repository requires updating the native `GithubSource` URL before shipping the last release on the old feed.
 
+## macOS packaging and updates
+
+macOS packages use the same Velopack tool and the same GitHub release. Build on macOS with Bun 1.3.14 and the .NET 8 SDK:
+
+```bash
+bun install --frozen-lockfile
+bun run build:mac:release
+```
+
+`dist/releases/` then contains `BurnGuard-osx-Setup.pkg`, `BurnGuard-osx-Portable.zip`, the full `.nupkg`, the `releases.osx.json` feed, and SHA256 sums. The packed bundle is `BurnGuard.app` with `Contents/MacOS/UpdateMac` beside the engine; only that bundle can update itself. The plain `dist/mac/BurnGuard Design.app` and the DMG are development builds without an updater.
+
+The **macOS release package** workflow runs on the same `v*` tag as the Windows workflow and attaches its assets to the same draft release (whichever job finishes first creates the draft). Publish the draft with both `releases.win.json` and `releases.osx.json` attached. Signing and notarization run when `BG_MAC_SIGN_IDENTITY`, `BG_MAC_INSTALL_IDENTITY` and `BG_MAC_NOTARY_PROFILE` are configured; unsigned packages are for verification only and Gatekeeper will warn on first launch.
+
+On macOS the engine itself checks the feed shortly after launch and every six hours, downloads the newer full package into `~/.burnguard/cache/updates`, verifies its SHA-256 against the feed, and shows the result in Settings → 업데이트. **다시 시작해 적용** stops the engine and lets `UpdateMac` swap the bundle and relaunch it. `BG_UPDATE_FEED_URL` (loopback or HTTPS) points the check at a local feed for rehearsals.
+
 ## How updates behave
 
 - Once the workspace opens, check for a newer stable version; repeat every six hours or when **업데이트 확인** is pressed.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:windows:release": "bun run build && bun run scripts/build-windows-native.ts --skip-zip && bun run scripts/package-windows-release.ts",
     "build:mac": "bun run build:frontend && bun run scripts/build-mac.ts",
     "build:mac:dmg": "bun run build:frontend && bun run scripts/build-mac.ts -- --dmg",
+    "build:mac:release": "bun run build:frontend && bun run scripts/build-mac.ts && bun run scripts/package-mac-release.ts",
     "build": "bun run build:frontend && bun run build:backend",
     "typecheck": "tsc --build",
     "test": "bun test --timeout 30000",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -9,6 +9,7 @@ import { generateLaunchCapability } from "./security/request-authority";
 import { MAX_REQUEST_BODY_BYTES } from "./security/request-limits";
 import { createApp } from "./server";
 import { closeActiveExportBrowsers } from "./services/export-browser-registry";
+import { configureAppUpdater, startAppUpdateScheduler } from "./services/mac-updates";
 import { interruptAllUserTurns } from "./services/turns";
 
 if (process.argv.includes("--bg-chromium-probe")) {
@@ -79,6 +80,8 @@ const shutdown = async (): Promise<void> => {
   // would keep writing into it after the server is gone.
   server.stop(false); await interruptAllUserTurns(); await closeActiveExportBrowsers(); server.stop(true); profileOwner?.close(); process.exit(0);
 };
+// macOS self-update: the staged package is applied by the bundled updater once this process has shut down.
+startAppUpdateScheduler(configureAppUpdater({ shutdown }));
 process.on("SIGINT", () => { void shutdown(); });
 process.on("SIGTERM", () => { void shutdown(); });
 if (isDesktop) {

--- a/packages/backend/src/routes/settings.ts
+++ b/packages/backend/src/routes/settings.ts
@@ -3,9 +3,11 @@ import { getLocalFonts } from "../services/local-fonts";
 import type {
   ApiErrorBody,
   ApiSuccess,
+  AppUpdateStatus,
   PlaywrightInstallStatus,
   PythonSettings,
 } from "@bg/shared";
+import { getAppUpdater } from "../services/mac-updates";
 import {
   getPlaywrightInstallStatus,
   startPlaywrightInstall,
@@ -31,6 +33,25 @@ export const settingsRoutes = new Hono();
 settingsRoutes.get("/api/settings/local-fonts", async (c) => {
   try { return c.json(ok(await getLocalFonts())); }
   catch { return c.json(fail("local_fonts_unavailable", "Local font listing is unavailable"), 503); }
+});
+
+settingsRoutes.get("/api/settings/updates", (c) => {
+  return c.json(ok(getAppUpdater().status() satisfies AppUpdateStatus));
+});
+
+settingsRoutes.post("/api/settings/updates/check", async (c) => {
+  const updater = getAppUpdater();
+  if (!updater.status().supported) return c.json(fail("update_unsupported", "This installation cannot update itself"), 409);
+  await updater.check();
+  return c.json(ok(updater.status() satisfies AppUpdateStatus));
+});
+
+settingsRoutes.post("/api/settings/updates/apply", async (c) => {
+  const updater = getAppUpdater();
+  const result = await updater.apply();
+  if (result === "unsupported") return c.json(fail("update_unsupported", "This installation cannot update itself"), 409);
+  if (result === "not_ready") return c.json(fail("update_not_ready", "No update has been downloaded yet"), 409);
+  return c.json(ok({ accepted: true as const }), 202);
 });
 
 settingsRoutes.get("/api/settings/playwright", (c) => {

--- a/packages/backend/src/services/mac-updates.ts
+++ b/packages/backend/src/services/mac-updates.ts
@@ -1,0 +1,332 @@
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, rename, rm } from "node:fs/promises";
+import path from "node:path";
+import { APP_VERSION } from "@bg/shared/app";
+import type { AppUpdateStatus, AppUpdateUnsupportedReason } from "@bg/shared/updates";
+import { cacheDir as appCacheDir } from "../lib/app-paths";
+
+/**
+ * Velopack self-update for the macOS app. Windows updates live in the native
+ * shell (packages/desktop-windows); on macOS the Bun backend is the app, so it
+ * reads the same GitHub release feed (`releases.osx.json`), verifies the full
+ * package against the feed's SHA-256, and hands the staged file to the bundled
+ * `UpdateMac` binary, which swaps the bundle after this process exits.
+ */
+
+export const UPDATE_REPOSITORY = "ashmoonori-afk/BurnGuard";
+export const UPDATE_PACKAGE_ID = "BurnGuard";
+export const UPDATE_FEED_NAME = "releases.osx.json";
+const UPDATER_BINARY = "UpdateMac";
+const MAX_PACKAGE_BYTES = 1024 * 1024 * 1024;
+const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const FIRST_CHECK_DELAY_MS = 15_000;
+
+export type VelopackFeedAsset = {
+  readonly PackageId: string;
+  readonly Version: string;
+  readonly Type: "Full" | "Delta";
+  readonly FileName: string;
+  readonly SHA256: string;
+  readonly Size: number;
+};
+
+export interface AppUpdateSource {
+  /** The raw `releases.osx.json` document for the newest published release. */
+  fetchFeed(signal?: AbortSignal): Promise<unknown>;
+  /** The package bytes for a file name listed in that feed. */
+  openPackage(fileName: string, signal?: AbortSignal): Promise<Response>;
+}
+
+export class AppUpdateError extends Error {
+  readonly name = "AppUpdateError";
+  constructor(readonly code: "invalid_update_feed" | "update_check_failed" | "package_download_failed" | "package_too_large" | "package_digest_mismatch") {
+    super(code);
+  }
+}
+
+const SAFE_FILE_NAME = /^[A-Za-z0-9._-]+\.nupkg$/;
+const SHA256_HEX = /^[0-9a-fA-F]{64}$/;
+
+export function parseVelopackFeed(value: unknown): VelopackFeedAsset[] {
+  if (typeof value !== "object" || value === null || !("Assets" in value) || !Array.isArray(value.Assets)) throw new AppUpdateError("invalid_update_feed");
+  const assets: VelopackFeedAsset[] = [];
+  for (const entry of value.Assets) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const record = entry as Record<string, unknown>;
+    if (
+      typeof record.PackageId !== "string" || typeof record.Version !== "string" || parseVersion(record.Version) === null ||
+      (record.Type !== "Full" && record.Type !== "Delta") || typeof record.FileName !== "string" || !SAFE_FILE_NAME.test(record.FileName) ||
+      typeof record.SHA256 !== "string" || !SHA256_HEX.test(record.SHA256) || typeof record.Size !== "number" || !Number.isSafeInteger(record.Size) || record.Size <= 0
+    ) continue;
+    assets.push({ PackageId: record.PackageId, Version: record.Version, Type: record.Type, FileName: record.FileName, SHA256: record.SHA256.toUpperCase(), Size: record.Size });
+  }
+  return assets;
+}
+
+type ParsedVersion = { readonly numbers: readonly number[]; readonly prerelease: string | null };
+
+function parseVersion(version: string): ParsedVersion | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(version.trim());
+  if (match === null) return null;
+  return { numbers: [Number(match[1]), Number(match[2]), Number(match[3])], prerelease: match[4] ?? null };
+}
+
+/** Negative when `left` is older than `right`, zero when equal, positive when newer. Unparseable versions sort lowest. */
+export function compareVersions(left: string, right: string): number {
+  const a = parseVersion(left);
+  const b = parseVersion(right);
+  if (a === null || b === null) return a === null && b === null ? 0 : a === null ? -1 : 1;
+  for (let index = 0; index < 3; index += 1) {
+    const difference = (a.numbers[index] ?? 0) - (b.numbers[index] ?? 0);
+    if (difference !== 0) return difference;
+  }
+  if (a.prerelease === b.prerelease) return 0;
+  if (a.prerelease === null) return 1;
+  if (b.prerelease === null) return -1;
+  return a.prerelease < b.prerelease ? -1 : 1;
+}
+
+/** The newest full package for this app that is newer than `currentVersion`, or null. */
+export function selectUpdate(assets: readonly VelopackFeedAsset[], currentVersion: string, packageId = UPDATE_PACKAGE_ID): VelopackFeedAsset | null {
+  let best: VelopackFeedAsset | null = null;
+  for (const asset of assets) {
+    if (asset.PackageId !== packageId || asset.Type !== "Full") continue;
+    if (compareVersions(asset.Version, currentVersion) <= 0) continue;
+    if (best === null || compareVersions(asset.Version, best.Version) > 0) best = asset;
+  }
+  return best;
+}
+
+export type UpdateSupport = { readonly supported: boolean; readonly reason: AppUpdateUnsupportedReason | null };
+
+export function updaterBinaryPath(execPath: string): string {
+  return path.join(path.dirname(execPath), UPDATER_BINARY);
+}
+
+/** Only a Velopack-packaged macOS bundle (UpdateMac beside the executable) can update itself. */
+export function detectUpdateSupport(input: { readonly platform: NodeJS.Platform; readonly execPath: string; readonly desktopShell: boolean }): UpdateSupport {
+  if (input.desktopShell) return { supported: false, reason: "windows_shell" };
+  if (input.platform !== "darwin") return { supported: false, reason: "platform" };
+  return existsSync(updaterBinaryPath(input.execPath)) ? { supported: true, reason: null } : { supported: false, reason: "not_installed" };
+}
+
+export type AppUpdaterDependencies = {
+  readonly currentVersion: string;
+  readonly cacheDir: string;
+  readonly source: AppUpdateSource;
+  readonly support: UpdateSupport;
+  readonly updaterPath: string;
+  /** Starts the detached updater process; must not throw for a well-formed command. */
+  readonly spawn: (cmd: readonly string[]) => void;
+  /** The application's graceful shutdown; the updater swaps the bundle once this pid exits. */
+  readonly shutdown: () => Promise<void>;
+  /** Defers the shutdown so the HTTP response that accepted the apply can leave the socket first. */
+  readonly scheduleShutdown?: (run: () => void) => void;
+};
+
+export type AppUpdater = {
+  status(): AppUpdateStatus;
+  /** Checks the feed and stages a newer package. Concurrent calls share one run. */
+  check(): Promise<void>;
+  apply(): Promise<"unsupported" | "not_ready" | "applying">;
+};
+
+export function createAppUpdater(deps: AppUpdaterDependencies): AppUpdater {
+  let state: AppUpdateStatus = {
+    supported: deps.support.supported,
+    unsupported_reason: deps.support.reason,
+    state: deps.support.supported ? "idle" : "unsupported",
+    current_version: deps.currentVersion,
+    available_version: null,
+    progress: null,
+    checked_at: null,
+    error: null,
+  };
+  let staged: { readonly asset: VelopackFeedAsset; readonly file: string } | null = null;
+  let running: Promise<void> | null = null;
+  const patch = (next: Partial<AppUpdateStatus>): void => { state = { ...state, ...next }; };
+
+  async function run(): Promise<void> {
+    patch({ state: "checking", error: null, progress: null });
+    let asset: VelopackFeedAsset | null;
+    try {
+      asset = selectUpdate(parseVelopackFeed(await deps.source.fetchFeed()), deps.currentVersion);
+    } catch (error) {
+      patch({ state: "error", checked_at: Date.now(), error: error instanceof AppUpdateError ? error.code : "update_check_failed" });
+      return;
+    }
+    if (asset === null) {
+      staged = null;
+      patch({ state: "idle", available_version: null, checked_at: Date.now() });
+      return;
+    }
+    if (staged !== null && staged.asset.FileName === asset.FileName && staged.asset.SHA256 === asset.SHA256 && existsSync(staged.file)) {
+      patch({ state: "ready", available_version: asset.Version, checked_at: Date.now() });
+      return;
+    }
+    patch({ state: "downloading", available_version: asset.Version, progress: 0 });
+    try {
+      const file = await downloadPackage(deps, asset, (progress) => patch({ progress }));
+      staged = { asset, file };
+      patch({ state: "ready", progress: null, checked_at: Date.now() });
+    } catch (error) {
+      staged = null;
+      patch({ state: "error", progress: null, checked_at: Date.now(), error: error instanceof AppUpdateError ? error.code : "package_download_failed" });
+    }
+  }
+
+  return {
+    status: () => state,
+    check() {
+      if (!deps.support.supported) return Promise.resolve();
+      running ??= run().finally(() => { running = null; });
+      return running;
+    },
+    async apply() {
+      if (!deps.support.supported) return "unsupported";
+      if (staged === null || state.state !== "ready") return "not_ready";
+      deps.spawn([deps.updaterPath, "apply", "--package", staged.file, "--waitPid", String(process.pid)]);
+      (deps.scheduleShutdown ?? ((run) => { setTimeout(run, 250); }))(() => { void deps.shutdown(); });
+      return "applying";
+    },
+  };
+}
+
+async function downloadPackage(deps: AppUpdaterDependencies, asset: VelopackFeedAsset, onProgress: (percent: number) => void): Promise<string> {
+  if (asset.Size > MAX_PACKAGE_BYTES) throw new AppUpdateError("package_too_large");
+  const directory = path.join(deps.cacheDir, "updates");
+  await mkdir(directory, { recursive: true });
+  const target = path.join(directory, asset.FileName);
+  const partial = `${target}.partial`;
+  let response: Response;
+  try { response = await deps.source.openPackage(asset.FileName); }
+  catch { throw new AppUpdateError("package_download_failed"); }
+  if (!response.ok || response.body === null) throw new AppUpdateError("package_download_failed");
+  const hash = createHash("sha256");
+  const writer = Bun.file(partial).writer();
+  let received = 0;
+  let open = true;
+  const close = async (): Promise<void> => { if (!open) return; open = false; try { await writer.end(); } catch { /* the sink is already closed */ } };
+  try {
+    const reader = response.body.getReader();
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        received += value.byteLength;
+        if (received > asset.Size) throw new AppUpdateError("package_too_large");
+        hash.update(value);
+        writer.write(value);
+        onProgress(Math.floor((received / asset.Size) * 100));
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    await close();
+    if (received !== asset.Size || hash.digest("hex").toUpperCase() !== asset.SHA256) throw new AppUpdateError("package_digest_mismatch");
+    await rename(partial, target);
+    return target;
+  } catch (error) {
+    await close();
+    await rm(partial, { force: true });
+    throw error;
+  }
+}
+
+type GithubRelease = { readonly draft: boolean; readonly prerelease: boolean; readonly assets: readonly { readonly name: string; readonly browser_download_url: string }[] };
+
+function isGithubRelease(value: unknown): value is GithubRelease {
+  return typeof value === "object" && value !== null && "assets" in value && Array.isArray(value.assets) && "draft" in value && "prerelease" in value;
+}
+
+/** The same selection rule as Velopack's GithubSource: the newest published, non-prerelease release that carries the feed. */
+export function githubReleaseSource(repository: string, fetchImpl: typeof fetch = fetch): AppUpdateSource {
+  const headers = { accept: "application/vnd.github+json", "user-agent": `BurnGuard/${APP_VERSION} updater` };
+  let release: GithubRelease | null = null;
+  const locate = async (signal?: AbortSignal): Promise<GithubRelease> => {
+    const response = await fetchImpl(`https://api.github.com/repos/${repository}/releases?per_page=30`, { headers, signal });
+    if (!response.ok) throw new AppUpdateError("update_check_failed");
+    const releases: unknown = await response.json();
+    if (!Array.isArray(releases)) throw new AppUpdateError("update_check_failed");
+    const found = releases.find((entry): entry is GithubRelease => isGithubRelease(entry) && !entry.draft && !entry.prerelease && entry.assets.some((asset) => asset.name === UPDATE_FEED_NAME));
+    if (found === undefined) throw new AppUpdateError("invalid_update_feed");
+    release = found;
+    return found;
+  };
+  return {
+    async fetchFeed(signal) {
+      const current = await locate(signal);
+      const feed = current.assets.find((asset) => asset.name === UPDATE_FEED_NAME);
+      if (feed === undefined) throw new AppUpdateError("invalid_update_feed");
+      const response = await fetchImpl(feed.browser_download_url, { headers: { accept: "application/octet-stream", "user-agent": headers["user-agent"] }, signal });
+      if (!response.ok) throw new AppUpdateError("update_check_failed");
+      return response.json();
+    },
+    async openPackage(fileName, signal) {
+      const current = release ?? await locate(signal);
+      const asset = current.assets.find((entry) => entry.name === fileName);
+      if (asset === undefined) throw new AppUpdateError("package_download_failed");
+      return fetchImpl(asset.browser_download_url, { headers: { accept: "application/octet-stream", "user-agent": headers["user-agent"] }, signal });
+    },
+  };
+}
+
+/** A plain directory listing served over HTTP(S); used for local rehearsals of the update flow. */
+export function webFeedSource(baseUrl: URL, fetchImpl: typeof fetch = fetch): AppUpdateSource {
+  const resolve = (name: string): URL => new URL(name, baseUrl.href.endsWith("/") ? baseUrl : `${baseUrl.href}/`);
+  return {
+    async fetchFeed(signal) {
+      const response = await fetchImpl(resolve(UPDATE_FEED_NAME), { signal });
+      if (!response.ok) throw new AppUpdateError("update_check_failed");
+      return response.json();
+    },
+    openPackage(fileName, signal) { return fetchImpl(resolve(fileName), { signal }); },
+  };
+}
+
+/** `BG_UPDATE_FEED_URL` must be loopback or HTTPS; anything else keeps the GitHub feed. */
+export function resolveUpdateSource(env: NodeJS.ProcessEnv = process.env): AppUpdateSource {
+  const override = env.BG_UPDATE_FEED_URL;
+  if (override !== undefined && override !== "") {
+    try {
+      const url = new URL(override);
+      const loopback = url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "[::1]";
+      if (url.protocol === "https:" || (url.protocol === "http:" && loopback)) return webFeedSource(url);
+    } catch { /* fall through to the GitHub feed */ }
+  }
+  return githubReleaseSource(UPDATE_REPOSITORY);
+}
+
+let instance: AppUpdater | null = null;
+let timer: ReturnType<typeof setInterval> | null = null;
+
+/** Wires the process-wide updater; `index.ts` calls this once with the real shutdown. */
+export function configureAppUpdater(overrides: Partial<AppUpdaterDependencies> & { readonly shutdown: () => Promise<void> }): AppUpdater {
+  const execPath = process.execPath;
+  const support = overrides.support ?? detectUpdateSupport({ platform: process.platform, execPath, desktopShell: process.env.BG_DESKTOP === "1" });
+  instance = createAppUpdater({
+    currentVersion: overrides.currentVersion ?? APP_VERSION,
+    cacheDir: overrides.cacheDir ?? appCacheDir,
+    source: overrides.source ?? resolveUpdateSource(),
+    support,
+    updaterPath: overrides.updaterPath ?? updaterBinaryPath(execPath),
+    spawn: overrides.spawn ?? ((cmd) => { Bun.spawn([...cmd], { stdin: "ignore", stdout: "ignore", stderr: "ignore" }).unref(); }),
+    shutdown: overrides.shutdown,
+    ...(overrides.scheduleShutdown === undefined ? {} : { scheduleShutdown: overrides.scheduleShutdown }),
+  });
+  return instance;
+}
+
+export function getAppUpdater(): AppUpdater {
+  return instance ?? configureAppUpdater({ shutdown: async () => {} });
+}
+
+/** Background checks mirror the Windows shell: once shortly after launch, then every six hours. */
+export function startAppUpdateScheduler(updater: AppUpdater): void {
+  if (!updater.status().supported || timer !== null) return;
+  const first = setTimeout(() => { void updater.check(); }, FIRST_CHECK_DELAY_MS);
+  first.unref();
+  timer = setInterval(() => { void updater.check(); }, CHECK_INTERVAL_MS);
+  timer.unref();
+}

--- a/packages/backend/tests/app-update-routes.test.ts
+++ b/packages/backend/tests/app-update-routes.test.ts
@@ -1,0 +1,58 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { settingsRoutes } from "../src/routes/settings";
+import { configureAppUpdater, type AppUpdateSource } from "../src/services/mac-updates";
+
+const bytes = new TextEncoder().encode("pkg");
+const sha = createHash("sha256").update(bytes).digest("hex").toUpperCase();
+const feed = { Assets: [{ PackageId: "BurnGuard", Version: "9.9.9", Type: "Full", FileName: "BurnGuard-9.9.9-osx-full.nupkg", SHA256: sha, Size: bytes.byteLength }] };
+const tempDirs: string[] = [];
+
+afterAll(async () => { for (const dir of tempDirs.splice(0)) await rm(dir, { recursive: true, force: true }); });
+
+describe("application update routes", () => {
+  test("Given a supported host When status, check and apply are requested Then the contract states flow idle -> ready -> applying and shutdown runs once", async () => {
+    const cacheDir = await mkdtemp(path.join(tmpdir(), "bg-update-routes-"));
+    tempDirs.push(cacheDir);
+    const spawned: string[][] = [];
+    let shutdowns = 0;
+    const source: AppUpdateSource = { async fetchFeed() { return feed; }, async openPackage() { return new Response(bytes); } };
+    configureAppUpdater({ currentVersion: "0.5.1", cacheDir, source, support: { supported: true, reason: null }, updaterPath: "/bundle/UpdateMac", spawn: (cmd) => { spawned.push([...cmd]); }, shutdown: async () => { shutdowns += 1; }, scheduleShutdown: (run) => run() });
+
+    const initial = await settingsRoutes.request("http://local/api/settings/updates");
+    expect(initial.status).toBe(200);
+    expect((await initial.json()).data).toMatchObject({ supported: true, state: "idle", current_version: "0.5.1", available_version: null });
+
+    const early = await settingsRoutes.request("http://local/api/settings/updates/apply", { method: "POST" });
+    expect(early.status).toBe(409);
+    expect((await early.json()).error.code).toBe("update_not_ready");
+
+    const checked = await settingsRoutes.request("http://local/api/settings/updates/check", { method: "POST" });
+    expect(checked.status).toBe(200);
+    expect((await checked.json()).data).toMatchObject({ state: "ready", available_version: "9.9.9" });
+
+    const applied = await settingsRoutes.request("http://local/api/settings/updates/apply", { method: "POST" });
+    expect(applied.status).toBe(202);
+    expect((await applied.json()).data).toEqual({ accepted: true });
+    expect(spawned).toEqual([["/bundle/UpdateMac", "apply", "--package", path.join(cacheDir, "updates", "BurnGuard-9.9.9-osx-full.nupkg"), "--waitPid", String(process.pid)]]);
+    expect(shutdowns).toBe(1);
+  });
+
+  test("Given an unsupported host When check or apply is requested Then the routes refuse without touching the feed", async () => {
+    let fetches = 0;
+    const source: AppUpdateSource = { async fetchFeed() { fetches += 1; return feed; }, async openPackage() { return new Response(bytes); } };
+    configureAppUpdater({ currentVersion: "0.5.1", cacheDir: tmpdir(), source, support: { supported: false, reason: "windows_shell" }, updaterPath: "/unused", spawn: () => {}, shutdown: async () => {} });
+    const status = await settingsRoutes.request("http://local/api/settings/updates");
+    expect((await status.json()).data).toMatchObject({ supported: false, unsupported_reason: "windows_shell", state: "unsupported" });
+    const checked = await settingsRoutes.request("http://local/api/settings/updates/check", { method: "POST" });
+    expect(checked.status).toBe(409);
+    expect((await checked.json()).error.code).toBe("update_unsupported");
+    const applied = await settingsRoutes.request("http://local/api/settings/updates/apply", { method: "POST" });
+    expect(applied.status).toBe(409);
+    expect((await applied.json()).error.code).toBe("update_unsupported");
+    expect(fetches).toBe(0);
+  });
+});

--- a/packages/backend/tests/mac-updates.test.ts
+++ b/packages/backend/tests/mac-updates.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  compareVersions,
+  createAppUpdater,
+  detectUpdateSupport,
+  parseVelopackFeed,
+  selectUpdate,
+  type AppUpdateSource,
+  type VelopackFeedAsset,
+} from "../src/services/mac-updates";
+
+const asset = (overrides: Partial<VelopackFeedAsset> = {}): VelopackFeedAsset => ({
+  PackageId: "BurnGuard", Version: "0.5.2", Type: "Full", FileName: "BurnGuard-0.5.2-osx-full.nupkg", SHA256: "AB".repeat(32), Size: 3, ...overrides,
+});
+
+function fakeSource(assets: readonly VelopackFeedAsset[], bytes: Record<string, Uint8Array>): AppUpdateSource & { readonly fetches: string[] } {
+  const fetches: string[] = [];
+  return {
+    fetches,
+    async fetchFeed() { fetches.push("feed"); return { Assets: assets }; },
+    async openPackage(fileName) {
+      fetches.push(fileName);
+      const body = bytes[fileName];
+      if (body === undefined) throw new Error(`missing package ${fileName}`);
+      return new Response(body, { headers: { "content-length": String(body.byteLength) } });
+    },
+  };
+}
+
+describe("velopack feed selection", () => {
+  test("Given a releases.osx.json feed When parsed Then only well-formed assets survive", () => {
+    const parsed = parseVelopackFeed({ Assets: [asset(), { PackageId: "BurnGuard", Version: "x", Type: "Full", FileName: "bad.nupkg", SHA256: "00", Size: 1 }, { Type: "Delta" }] });
+    expect(parsed.map((entry) => entry.FileName)).toEqual(["BurnGuard-0.5.2-osx-full.nupkg"]);
+    expect(() => parseVelopackFeed({})).toThrow("invalid_update_feed");
+    expect(() => parseVelopackFeed("Assets")).toThrow("invalid_update_feed");
+  });
+
+  test("Given semantic versions When compared Then numeric order wins and prereleases sort below their release", () => {
+    expect(compareVersions("0.5.2", "0.5.1")).toBeGreaterThan(0);
+    expect(compareVersions("0.10.0", "0.9.9")).toBeGreaterThan(0);
+    expect(compareVersions("1.0.0", "1.0.0")).toBe(0);
+    expect(compareVersions("1.0.0-beta.1", "1.0.0")).toBeLessThan(0);
+  });
+
+  test("Given current 0.5.1 When the feed carries newer, equal, older, delta and foreign packages Then the newest full package above current is selected", () => {
+    const assets = [
+      asset({ Version: "0.5.1", FileName: "same.nupkg" }),
+      asset({ Version: "0.4.9", FileName: "older.nupkg" }),
+      asset({ Version: "0.6.0", Type: "Delta", FileName: "delta.nupkg" }),
+      asset({ Version: "0.7.0", PackageId: "OtherApp", FileName: "other.nupkg" }),
+      asset({ Version: "0.5.2", FileName: "next.nupkg" }),
+      asset({ Version: "0.5.3", FileName: "newest.nupkg" }),
+    ];
+    expect(selectUpdate(assets, "0.5.1")?.FileName).toBe("newest.nupkg");
+    expect(selectUpdate([asset({ Version: "0.5.1" })], "0.5.1")).toBeNull();
+    expect(selectUpdate([asset({ Version: "0.4.0" })], "0.5.1")).toBeNull();
+  });
+});
+
+describe("update support detection", () => {
+  test("Given the packed bundle layout When the updater binary sits beside the executable Then macOS updates are supported, otherwise not", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "bg-mac-updates-"));
+    try {
+      const macos = path.join(root, "BurnGuard.app", "Contents", "MacOS");
+      await Bun.write(path.join(macos, "burnguard-design"), "bin");
+      expect(detectUpdateSupport({ platform: "darwin", execPath: path.join(macos, "burnguard-design"), desktopShell: false })).toEqual({ supported: false, reason: "not_installed" });
+      await writeFile(path.join(macos, "UpdateMac"), "#!/bin/sh\n", "utf8");
+      await chmod(path.join(macos, "UpdateMac"), 0o755);
+      expect(detectUpdateSupport({ platform: "darwin", execPath: path.join(macos, "burnguard-design"), desktopShell: false })).toEqual({ supported: true, reason: null });
+      expect(detectUpdateSupport({ platform: "win32", execPath: path.join(macos, "burnguard-design"), desktopShell: true })).toEqual({ supported: false, reason: "windows_shell" });
+      expect(detectUpdateSupport({ platform: "linux", execPath: path.join(macos, "burnguard-design"), desktopShell: false })).toEqual({ supported: false, reason: "platform" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("app updater flow", () => {
+  test("Given a newer full package When checked Then it is downloaded, verified and staged; equal versions stay idle; corrupt bytes fail closed", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "bg-updater-"));
+    try {
+      const good = new TextEncoder().encode("pkg");
+      const sha = createHash("sha256").update(good).digest("hex").toUpperCase();
+      const upToDate = createAppUpdater({ currentVersion: "0.5.2", cacheDir: root, source: fakeSource([asset({ SHA256: sha })], { "BurnGuard-0.5.2-osx-full.nupkg": good }), support: { supported: true, reason: null }, updaterPath: "/unused", spawn: () => { throw new Error("must not spawn"); }, shutdown: async () => {} });
+      await upToDate.check();
+      expect(upToDate.status()).toMatchObject({ state: "idle", available_version: null, error: null });
+
+      const updater = createAppUpdater({ currentVersion: "0.5.1", cacheDir: root, source: fakeSource([asset({ SHA256: sha })], { "BurnGuard-0.5.2-osx-full.nupkg": good }), support: { supported: true, reason: null }, updaterPath: "/unused", spawn: () => { throw new Error("must not spawn"); }, shutdown: async () => {} });
+      await updater.check();
+      expect(updater.status()).toMatchObject({ state: "ready", available_version: "0.5.2", current_version: "0.5.1", error: null });
+      expect(await readFile(path.join(root, "updates", "BurnGuard-0.5.2-osx-full.nupkg"))).toEqual(Buffer.from(good));
+
+      const corrupt = createAppUpdater({ currentVersion: "0.5.1", cacheDir: root, source: fakeSource([asset({ SHA256: sha })], { "BurnGuard-0.5.2-osx-full.nupkg": new TextEncoder().encode("bad") }), support: { supported: true, reason: null }, updaterPath: "/unused", spawn: () => { throw new Error("must not spawn"); }, shutdown: async () => {} });
+      await corrupt.check();
+      expect(corrupt.status()).toMatchObject({ state: "error", error: "package_digest_mismatch" });
+      expect(await Bun.file(path.join(root, "updates", "BurnGuard-0.5.2-osx-full.nupkg.partial")).exists()).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("Given a staged package When applied Then the bundled updater is started with the package and this pid, then shutdown runs", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "bg-updater-apply-"));
+    try {
+      const good = new TextEncoder().encode("pkg");
+      const sha = createHash("sha256").update(good).digest("hex").toUpperCase();
+      const spawned: string[][] = [];
+      let shutdowns = 0;
+      const updater = createAppUpdater({ currentVersion: "0.5.1", cacheDir: root, source: fakeSource([asset({ SHA256: sha })], { "BurnGuard-0.5.2-osx-full.nupkg": good }), support: { supported: true, reason: null }, updaterPath: "/Applications/BurnGuard.app/Contents/MacOS/UpdateMac", spawn: (cmd) => { spawned.push(cmd); }, shutdown: async () => { shutdowns += 1; }, scheduleShutdown: (run) => run() });
+      expect(await updater.apply()).toBe("not_ready");
+      await updater.check();
+      expect(await updater.apply()).toBe("applying");
+      expect(spawned).toEqual([["/Applications/BurnGuard.app/Contents/MacOS/UpdateMac", "apply", "--package", path.join(root, "updates", "BurnGuard-0.5.2-osx-full.nupkg"), "--waitPid", String(process.pid)]]);
+      expect(shutdowns).toBe(1);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("Given an offline feed When checked Then the error is typed and a later check recovers", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "bg-updater-offline-"));
+    try {
+      let online = false;
+      const good = new TextEncoder().encode("pkg");
+      const sha = createHash("sha256").update(good).digest("hex").toUpperCase();
+      const source: AppUpdateSource = { async fetchFeed() { if (!online) throw new Error("ECONNREFUSED"); return { Assets: [asset({ SHA256: sha })] }; }, async openPackage() { return new Response(good); } };
+      const updater = createAppUpdater({ currentVersion: "0.5.1", cacheDir: root, source, support: { supported: true, reason: null }, updaterPath: "/unused", spawn: () => {}, shutdown: async () => {} });
+      await updater.check();
+      expect(updater.status()).toMatchObject({ state: "error", error: "update_check_failed" });
+      online = true;
+      await updater.check();
+      expect(updater.status().state).toBe("ready");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("Given an unsupported host When checked or applied Then nothing is fetched", async () => {
+    const source = fakeSource([asset()], {});
+    const updater = createAppUpdater({ currentVersion: "0.5.1", cacheDir: tmpdir(), source, support: { supported: false, reason: "platform" }, updaterPath: "/unused", spawn: () => {}, shutdown: async () => {} });
+    await updater.check();
+    expect(await updater.apply()).toBe("unsupported");
+    expect(updater.status()).toMatchObject({ supported: false, unsupported_reason: "platform", state: "unsupported" });
+    expect(source.fetches).toEqual([]);
+  });
+});

--- a/packages/frontend/src/api/settings.ts
+++ b/packages/frontend/src/api/settings.ts
@@ -1,5 +1,49 @@
-import type { PlaywrightInstallStatus, PythonSettings } from "@bg/shared";
+import type { AppUpdateStatus, PlaywrightInstallStatus, PythonSettings } from "@bg/shared";
 import { apiFetch } from "./client";
+
+export async function getAppUpdateStatus(): Promise<AppUpdateStatus> {
+  return apiFetch<AppUpdateStatus>("/api/settings/updates");
+}
+
+export async function checkAppUpdate(): Promise<AppUpdateStatus> {
+  return apiFetch<AppUpdateStatus>("/api/settings/updates/check", { method: "POST" });
+}
+
+export async function applyAppUpdate(): Promise<{ accepted: true }> {
+  return apiFetch<{ accepted: true }>("/api/settings/updates/apply", { method: "POST" });
+}
+
+export function waitForAppRestart(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const controller = new AbortController();
+    let inFlight = false;
+    const finish = (error?: Error) => {
+      clearInterval(interval);
+      clearTimeout(deadline);
+      controller.abort();
+      if (error) reject(error);
+      else resolve();
+    };
+    const deadline = setTimeout(() => finish(new Error("업데이트가 적용되는 동안 연결이 끊겼어요. BurnGuard를 다시 열어 주세요.")), 120_000);
+    const interval = setInterval(async () => {
+      if (inFlight) return;
+      inFlight = true;
+      try {
+        // Relaunch replaces API authority; health is public and must bypass apiFetch.
+        const response = await fetch("/api/health", {
+          cache: "no-store",
+          credentials: "omit",
+          signal: AbortSignal.any([controller.signal, AbortSignal.timeout(2000)]),
+        });
+        if (response.ok) finish();
+      } catch {
+        // Connection failures are expected during replacement; the deadline reports failure.
+      } finally {
+        inFlight = false;
+      }
+    }, 2000);
+  });
+}
 
 export async function getPlaywrightInstallStatus(): Promise<PlaywrightInstallStatus> {
   return apiFetch<PlaywrightInstallStatus>("/api/settings/playwright");

--- a/packages/frontend/src/components/settings/SettingsModal.tsx
+++ b/packages/frontend/src/components/settings/SettingsModal.tsx
@@ -21,6 +21,10 @@ import GenerationControls from "./GenerationControls";
 import { defaultGenerationOptions } from "@bg/shared";
 import { detectBackends, getSettings, patchSettings } from "@/api/home";
 import {
+  applyAppUpdate,
+  checkAppUpdate,
+  getAppUpdateStatus,
+  waitForAppRestart,
   getPlaywrightInstallStatus,
   getPythonSettings,
   startPlaywrightInstall,
@@ -28,6 +32,7 @@ import {
 } from "@/api/settings";
 import { useUIStore } from "@/state/uiStore";
 import { apiErrorCopy } from "@/lib/error-copy";
+import { appUpdateView } from "@/lib/app-update-state";
 
 const CHAT_CONTEXT_MODE_LABELS = {
   compact: "간단",
@@ -53,6 +58,16 @@ function SettingsDialog({ onClose }: { onClose: () => void }) {
   const settingsQuery = useQuery({
     queryKey: ["settings", "dialog"], queryFn: getSettings, gcTime: 0,
   });
+  const [updateChecking, setUpdateChecking] = useState(false);
+  const [updateApplying, setUpdateApplying] = useState(false);
+  const [updateError, setUpdateError] = useState<string | null>(null);
+  const updateQuery = useQuery({
+    queryKey: ["settings", "updates"], queryFn: getAppUpdateStatus,
+    enabled: !updateApplying,
+    refetchOnMount: "always", refetchOnWindowFocus: false, refetchOnReconnect: false,
+    refetchInterval: (query) => !updateApplying && (updateChecking || (query.state.data && appUpdateView(query.state.data).busy)) ? 1500 : false,
+  });
+  const updateView = updateQuery.data ? appUpdateView(updateQuery.data) : null;
   const detectionQuery = useQuery({ queryKey: ["backends", "detect"], queryFn: detectBackends });
   const pwQuery = useQuery({
     queryKey: ["settings", "playwright"], queryFn: getPlaywrightInstallStatus,
@@ -92,6 +107,38 @@ function SettingsDialog({ onClose }: { onClose: () => void }) {
     // Initialize once; background status/token updates must not replace edits.
     if (!settings && settingsQuery.data && !settingsQuery.isFetching) setSettings(settingsQuery.data);
   }, [settings, settingsQuery.data, settingsQuery.isFetching]);
+
+  async function handleCheckUpdate() {
+    setUpdateChecking(true);
+    setUpdateError(null);
+    try {
+      const next = await checkAppUpdate();
+      queryClient.setQueryData(["settings", "updates"], next);
+    } catch {
+      setUpdateError("업데이트를 확인하지 못했습니다 · 인터넷 연결 또는 배포 상태를 확인해 주세요");
+    } finally {
+      setUpdateChecking(false);
+    }
+  }
+
+  async function handleApplyUpdate() {
+    setUpdateApplying(true);
+    setUpdateError(null);
+    try {
+      await applyAppUpdate();
+    } catch {
+      setUpdateError("업데이트 재시작을 예약하지 못했습니다. BurnGuard를 다시 실행해 주세요.");
+      setUpdateApplying(false);
+      return;
+    }
+    try {
+      await waitForAppRestart();
+      window.location.reload();
+    } catch {
+      setUpdateError("업데이트가 적용되는 동안 연결이 끊겼어요. BurnGuard를 다시 열어 주세요.");
+      setUpdateApplying(false);
+    }
+  }
 
   async function handleInstallPlaywright() {
     setPwStarting(true);
@@ -174,7 +221,7 @@ function SettingsDialog({ onClose }: { onClose: () => void }) {
   }
 
   return (
-    <Dialog open onOpenChange={(nextOpen) => { if (!nextOpen && !saving && !figmaTokenSaving && !commandcodeSaving) onClose(); }}>
+    <Dialog open onOpenChange={(nextOpen) => { if (!nextOpen && !saving && !figmaTokenSaving && !commandcodeSaving && !updateApplying) onClose(); }}>
       <DialogContent className="flex h-[min(780px,calc(100dvh-2rem))] w-[calc(100vw-2rem)] max-w-4xl flex-col gap-0 overflow-hidden p-0" onCloseAutoFocus={(event) => { if (returnFocusTarget?.isConnected) { event.preventDefault(); returnFocusTarget.focus(); } }}>
         <DialogHeader className="shrink-0 border-b border-border px-5 py-5 pr-12 sm:px-7">
           <DialogTitle className="text-xl">설정</DialogTitle>
@@ -195,7 +242,7 @@ function SettingsDialog({ onClose }: { onClose: () => void }) {
             불러오는 중…
           </div>
         ) : (
-          <fieldset disabled={saving} className="min-w-0 space-y-5">
+          <fieldset disabled={saving || updateApplying} className="min-w-0 space-y-5">
             <legend className="sr-only">일반 설정과 연동</legend>
             <section id="settings-user" aria-labelledby="settings-user-title" className="scroll-mt-6 space-y-5 rounded-2xl border border-border bg-card p-5">
               <div className="space-y-1"><h2 id="settings-user-title" className="text-base font-semibold">사용자</h2><p className="text-sm leading-6 text-muted-foreground">프로젝트에서 사용할 이름을 정해요.</p></div>
@@ -429,6 +476,28 @@ function SettingsDialog({ onClose }: { onClose: () => void }) {
               </div>
             </div>
 
+            {updateView?.visible !== false ? (
+              <section className="space-y-1.5" aria-labelledby="settings-updates-title">
+                <h3 id="settings-updates-title" className="text-xs font-medium text-muted-foreground">업데이트</h3>
+                <div className="rounded-md border border-border bg-muted/30 p-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span aria-hidden="true" className={`inline-block h-2 w-2 shrink-0 rounded-full ${updateApplying || updateChecking || updateView?.busy ? "bg-amber-500 animate-pulse" : updateError || updateQuery.isError || updateQuery.data?.state === "error" ? "bg-red-500" : updateView?.canApply || (updateQuery.data?.state === "idle" && updateQuery.data.checked_at !== null) ? "bg-emerald-500" : "bg-muted-foreground/40"}`} />
+                    <span className="min-w-0 flex-1 text-xs" role="status">
+                      {updateApplying ? "업데이트를 적용하고 다시 시작하는 중…" : updateQuery.isError ? "업데이트를 확인하지 못했습니다 · 인터넷 연결 또는 배포 상태를 확인해 주세요" : updateView?.label ?? "불러오는 중…"}
+                    </span>
+                    <div className="ml-auto flex w-full flex-wrap items-center justify-end gap-1.5 sm:w-auto">
+                      <Button type="button" variant="outline" size="sm" className="gap-1.5" onClick={handleCheckUpdate} disabled={!updateView?.canCheck || updateChecking || updateApplying}>
+                        <RefreshCw className="h-3 w-3" aria-hidden="true" />업데이트 확인
+                      </Button>
+                      {updateView?.canApply ? <Button type="button" variant="outline" size="sm" onClick={handleApplyUpdate} disabled={updateChecking || updateApplying}>다시 시작해 적용</Button> : null}
+                    </div>
+                  </div>
+                  {updateError ? <p role="alert" className="mt-2 text-xs leading-relaxed text-destructive">{updateError}</p> : null}
+                  {updateQuery.isError && !updateApplying ? <SettingsLoadError title="업데이트 상태 조회 실패" error={updateQuery.error} retry={() => void updateQuery.refetch()} pending={updateQuery.isFetching} /> : null}
+                </div>
+              </section>
+            ) : null}
+
             </section>
             <section id="settings-connections" aria-labelledby="settings-connections-title" className="scroll-mt-6 space-y-5 rounded-2xl border border-border bg-card p-5">
               <div className="space-y-1"><h2 id="settings-connections-title" className="text-base font-semibold">외부 연결</h2><p className="text-sm leading-6 text-muted-foreground">Figma의 색상과 텍스트 스타일을 가져와요.</p></div>
@@ -489,10 +558,10 @@ function SettingsDialog({ onClose }: { onClose: () => void }) {
         </div>
         <DialogFooter className="shrink-0 flex-row items-center justify-end gap-2 border-t border-border bg-card px-5 py-4 sm:px-7">
           <p className="mr-auto hidden text-xs text-muted-foreground sm:block">일반 설정은 저장 후 적용돼요.</p>
-          <Button variant="ghost" onClick={onClose} disabled={saving || figmaTokenSaving}>
+          <Button variant="ghost" onClick={onClose} disabled={saving || figmaTokenSaving || updateApplying}>
             취소
           </Button>
-          <Button variant="cta" onClick={save} disabled={saving || figmaTokenSaving || !settings}>
+          <Button variant="cta" onClick={save} disabled={saving || figmaTokenSaving || updateApplying || !settings}>
             {saving ? "저장하는 중…" : "저장"}
           </Button>
         </DialogFooter>

--- a/packages/frontend/src/lib/app-update-state.ts
+++ b/packages/frontend/src/lib/app-update-state.ts
@@ -1,0 +1,37 @@
+import type { AppUpdateStatus } from "@bg/shared";
+
+export function appUpdateView(status: AppUpdateStatus) {
+  const busy = status.state === "checking" || status.state === "downloading";
+  let label: string;
+  if (!status.supported) {
+    label = "자동 업데이트는 설치 패키지에서 사용할 수 있습니다";
+  } else {
+    switch (status.state) {
+      case "idle":
+        label = status.checked_at !== null ? `최신 버전입니다 (${status.current_version})` : "업데이트 대기 중";
+        break;
+      case "checking":
+        label = "업데이트 확인 중…";
+        break;
+      case "downloading":
+        label = `업데이트 다운로드 중… ${status.progress ?? 0}%`;
+        break;
+      case "ready":
+        label = `새 버전 ${status.available_version} 준비 완료 · 다시 시작하면 진행 중인 작업이 중단됩니다`;
+        break;
+      case "error":
+        label = "업데이트를 확인하지 못했습니다 · 인터넷 연결 또는 배포 상태를 확인해 주세요";
+        break;
+      case "unsupported":
+        label = "자동 업데이트는 설치 패키지에서 사용할 수 있습니다";
+        break;
+    }
+  }
+  return {
+    visible: status.unsupported_reason !== "windows_shell",
+    label,
+    canCheck: status.supported && status.state !== "unsupported" && !busy,
+    canApply: status.supported && status.state === "ready",
+    busy,
+  };
+}

--- a/packages/frontend/tests/app-update-state.test.ts
+++ b/packages/frontend/tests/app-update-state.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import type { AppUpdateStatus } from "@bg/shared";
+import { appUpdateView } from "../src/lib/app-update-state";
+
+const status: AppUpdateStatus = {
+  supported: true, unsupported_reason: null, state: "idle",
+  current_version: "1.0.0", available_version: null, progress: null,
+  checked_at: null, error: null,
+};
+
+describe("application update view", () => {
+  test("Given the Windows shell When mapping status Then the card is hidden and actions are disabled", () => {
+    const view = appUpdateView({ ...status, supported: false, unsupported_reason: "windows_shell", state: "unsupported" });
+    expect(view.visible).toBe(false);
+    expect(view.canCheck).toBe(false);
+    expect(view.canApply).toBe(false);
+  });
+
+  test.each(["platform", "not_installed"] as const)("Given unsupported reason %s When mapping status Then the card is visible with disabled actions", (unsupported_reason) => {
+    const view = appUpdateView({ ...status, supported: false, unsupported_reason, state: "unsupported" });
+    expect(view.visible).toBe(true);
+    expect(view.canCheck).toBe(false);
+    expect(view.canApply).toBe(false);
+    expect(view.busy).toBe(false);
+  });
+
+  test.each(["checking", "downloading"] as const)("Given state %s When mapping status Then checking is disabled and the card is busy", (state) => {
+    const view = appUpdateView({ ...status, state });
+    expect(view.canCheck).toBe(false);
+    expect(view.canApply).toBe(false);
+    expect(view.busy).toBe(true);
+  });
+
+  test.each(["unsupported", "idle", "checking", "downloading", "ready", "error"] as const)("Given state %s When mapping status Then applying is available only when ready", (state) => {
+    const view = appUpdateView({ ...status, state, supported: state !== "unsupported", available_version: "1.1.0" });
+    expect(view.canApply).toBe(state === "ready");
+    expect(view.busy).toBe(state === "checking" || state === "downloading");
+  });
+
+  test.each(["idle", "ready", "error"] as const)("Given supported state %s When mapping status Then checking is available", (state) => {
+    const view = appUpdateView({ ...status, state });
+    expect(view.visible).toBe(true);
+    expect(view.canCheck).toBe(true);
+    expect(view.busy).toBe(false);
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -25,7 +25,8 @@
     "./extraction-domain": "./src/extraction-domain.ts",
     "./events": "./src/events.ts",
     "./learning-contract": "./src/learning-contract.ts",
-    "./security": "./src/security.ts"
+    "./security": "./src/security.ts",
+    "./updates": "./src/updates.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -29,3 +29,4 @@ export * from "./local-fonts";
 export * from "./three-scene";
 export * from "./ux-review";
 export * from "./security";
+export * from "./updates";

--- a/packages/shared/src/updates.ts
+++ b/packages/shared/src/updates.ts
@@ -1,0 +1,22 @@
+/**
+ * Application self-update status exposed by the backend. On Windows the native
+ * shell owns the Velopack update flow; on macOS the backend drives the bundled
+ * Velopack updater itself and the web UI shows this status.
+ */
+export type AppUpdateState = "unsupported" | "idle" | "checking" | "downloading" | "ready" | "error";
+
+export type AppUpdateUnsupportedReason = "platform" | "not_installed" | "windows_shell";
+
+export interface AppUpdateStatus {
+  /** This process can check, download and apply a Velopack update itself. */
+  supported: boolean;
+  unsupported_reason: AppUpdateUnsupportedReason | null;
+  state: AppUpdateState;
+  current_version: string;
+  /** Newest published version found by the last check; staged when `state` is `ready`. */
+  available_version: string | null;
+  /** Download progress in percent while `state` is `downloading`. */
+  progress: number | null;
+  checked_at: number | null;
+  error: string | null;
+}

--- a/scripts/package-mac-release.ts
+++ b/scripts/package-mac-release.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env bun
+/**
+ * Build the macOS Velopack release assets (installer .pkg, portable .zip, full
+ * .nupkg, releases.osx.json feed) from the .app that `build-mac.ts` produced.
+ * Publication is a separate release step; this only writes dist/releases.
+ *
+ * Signing and notarization run only when credentials are present:
+ *   BG_MAC_SIGN_IDENTITY       Developer ID Application certificate subject
+ *   BG_MAC_INSTALL_IDENTITY    Developer ID Installer certificate subject
+ *   BG_MAC_NOTARY_PROFILE      notarytool keychain profile name
+ */
+import { $ } from "bun";
+import { readFile, realpath, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { APP_VERSION } from "../packages/shared/src/app";
+
+const root = path.resolve(import.meta.dir, "..");
+if (process.platform !== "darwin") throw new Error("macOS release packaging requires macOS.");
+if (!/^\d+\.\d+\.\d+$/.test(APP_VERSION)) throw new Error("Release version must be a stable semantic version.");
+for (const relative of ["package.json", "packages/backend/package.json", "packages/frontend/package.json", "packages/shared/package.json"]) {
+  if (JSON.parse(await readFile(path.join(root, relative), "utf8")).version !== APP_VERSION) throw new Error(`Version mismatch: ${relative}`);
+}
+const bundle = path.join(root, "dist/mac/BurnGuard Design.app");
+const marker = JSON.parse(await readFile(path.join(bundle, "Contents/MacOS/resources/burnguard-runtime.json"), "utf8"));
+if (marker.version !== APP_VERSION) throw new Error("Rebuild the macOS app before packaging a new release.");
+const distribution = await realpath(path.join(root, "dist"));
+const output = path.join(distribution, "releases");
+if (path.dirname(output) !== distribution || path.basename(output) !== "releases") throw new Error("Invalid release output directory");
+await rm(output, { recursive: true, force: true });
+
+const signing: string[] = [];
+if (process.env.BG_MAC_SIGN_IDENTITY) signing.push("--signAppIdentity", process.env.BG_MAC_SIGN_IDENTITY);
+if (process.env.BG_MAC_INSTALL_IDENTITY) signing.push("--signInstallIdentity", process.env.BG_MAC_INSTALL_IDENTITY);
+if (process.env.BG_MAC_NOTARY_PROFILE) signing.push("--notaryProfile", process.env.BG_MAC_NOTARY_PROFILE);
+if (signing.length === 0) console.warn("[release] unsigned package: set BG_MAC_SIGN_IDENTITY, BG_MAC_INSTALL_IDENTITY and BG_MAC_NOTARY_PROFILE for a distributable build");
+
+// `[osx]` is interpolated so the Bun shell never treats it as a glob.
+const platform = "[osx]";
+await $`dotnet tool restore`.cwd(root);
+// The pack id and feed channel pair with the Windows release so one GitHub release serves both feeds.
+await $`dotnet tool run vpk -- ${platform} pack --packId BurnGuard --packVersion ${APP_VERSION} --packDir ${bundle} --mainExe burnguard-design --packTitle BurnGuard --packAuthors BurnGuard --channel osx --icon ${path.join(root, "assets/icon.icns")} --outputDir ${output} ${signing}`.cwd(root);
+
+const files: string[] = [];
+for await (const name of new Bun.Glob("*").scan({ cwd: output, onlyFiles: true })) {
+  if (name === "SHA256SUMS.txt") continue;
+  const bytes = await readFile(path.join(output, name));
+  files.push(`${new Bun.CryptoHasher("sha256").update(bytes).digest("hex")}  ${name}`);
+}
+await writeFile(path.join(output, "SHA256SUMS.txt"), files.sort().join("\n") + "\n");
+console.log(`[release] ${APP_VERSION}: macOS installer, portable app, and update feed ready in dist/releases`);

--- a/scripts/qa/settings-redesign-fixtures.mjs
+++ b/scripts/qa/settings-redesign-fixtures.mjs
@@ -59,6 +59,7 @@ export async function runSettingsRedesignFixtures(page, base, scenario) {
     if (pathname === `/api/design-systems/${systemId}/tokens`) return ok(tokens);
     if (pathname === `/api/design-systems/${systemId}/previews`) return ok([]);
     if (pathname === "/api/backends/detect") return ok({ backends: [{ id: "claude-code", found: true, version: "fixture" }, { id: "codex", found: true, version: "fixture" }] });
+    if (pathname === "/api/settings/updates") return ok({ supported: false, unsupported_reason: "not_installed", state: "unsupported", current_version: "fixture", available_version: null, progress: null, checked_at: null, error: null });
     if (pathname === "/api/settings/playwright") return ok(installed);
     if (pathname === "/api/settings/python") return ok({ health: { python: { found: true, executable: ["fixture-python"], version: "Python fixture" }, pypdf: { found: true, version: "fixture", supported: true, required_version: "fixture" }, checked_at: at }, install: installed });
     return missing();


### PR DESCRIPTION
## Summary

macOS now has the same Velopack automatic-update channel as Windows.

- **Packaging** — `bun run build:mac:release` runs `vpk [osx] pack` on the existing `.app` and writes `dist/releases/` (`BurnGuard-osx-Setup.pkg`, `BurnGuard-osx-Portable.zip`, full `.nupkg`, `releases.osx.json`, `SHA256SUMS.txt`). Signing/notarization run when `BG_MAC_SIGN_IDENTITY` / `BG_MAC_INSTALL_IDENTITY` / `BG_MAC_NOTARY_PROFILE` exist.
- **Release workflow** — `macos-release.yml` runs on the same `v*` tag as the Windows workflow and attaches its assets to the same draft release (create-or-upload), so one release serves `releases.win.json` and `releases.osx.json`.
- **Client** — the Bun backend (`services/mac-updates.ts`) implements the GithubSource rules (newest published non-prerelease release carrying the feed), selects the newest full package above the running version, downloads with a size bound and verifies SHA-256 against the feed, then spawns the bundled `UpdateMac apply --package … --waitPid <pid>` and shuts down after the 202 has left the socket. Checks run shortly after launch and every six hours. `BG_UPDATE_FEED_URL` (loopback/HTTPS only) points rehearsals at a local feed.
- **API + UI** — `GET/POST /api/settings/updates{,/check,/apply}`; Settings → 업데이트 card with the same strings as the Windows shell, hidden under the native shell, with health polling + reload after restart-to-apply.
- Docs: architecture security model, doc/13 macOS section, READMEs.

## Verification

- RED→GREEN unit/route tests: `mac-updates.test.ts` (8), `app-update-routes.test.ts` (2), `app-update-state.test.ts` (frontend view mapping).
- Packaging on this Mac: `build:mac:release` produced all assets; the bundle contains `Contents/MacOS/UpdateMac`.
- **Real update rehearsal on this Mac**: packed 0.5.1 app launched from a temp dir with `BG_UPDATE_FEED_URL` at a loopback server hosting a scratch-built 0.5.2 → `check` staged the package (SHA-256 matched the feed) → `apply` returned 202, the old pid exited, `UpdateMac` swapped the bundle (`sq.version` 0.5.1→0.5.2) and the relaunched app answered `/api/health` with `0.5.2`. Scratch version bump reverted; nothing of it is committed.
- Settings card screenshots (desktop 1280 / mobile 390) captured against a live app server with a staged update.
- typecheck / lint / build:frontend green; full `bun test` 1097 pass / 9 skip / 25 fail where every failure is in the pre-existing macOS environment set (Chromium/`/private/var`/QA CLI); the two design-audit-render cases that appear under load pass alone.
- Not verified: signed/notarized packages and a public GitHub feed (no credentials / no published release yet); Gatekeeper will warn on unsigned builds.

Ultraworked with [omo](https://github.com/code-yeongyu/oh-my-openagent)
