### PR TITLE
fix: open the native app from the Windows launcher

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -96,7 +96,9 @@ bun install --frozen-lockfile
 bun run scripts/dev-launcher.ts
 ```
 
-실행기는 backend 준비 후 frontend를 시작하고 브라우저를 엽니다. 이후에는 저장소의 `Start-BurnGuard.bat`으로도 시작할 수 있습니다.
+이 개발용 실행기는 backend 준비 후 frontend를 시작하고 브라우저를 엽니다.
+
+Windows에서는 `Start-BurnGuard.bat`를 더블클릭하면 네이티브 앱이 열립니다. 첫 실행은 Bun과 .NET 8 SDK로 앱을 빌드하며, 이후에는 기존 빌드를 바로 엽니다. 소스를 업데이트한 뒤에는 `Start-BurnGuard.bat --rebuild`로 다시 빌드해 여세요. 네이티브 앱을 열기 전에는 브라우저 모드 서버를 종료해 주세요.
 
 - 앱: **http://127.0.0.1:5173**
 - Backend 상태: **http://127.0.0.1:14070/api/health**

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ bun install --frozen-lockfile
 bun run scripts/dev-launcher.ts
 ```
 
-The launcher waits for the backend to be ready, starts the frontend, and opens a browser. You can also start it with `Start-BurnGuard.bat` in the repository.
+This development launcher waits for the backend to be ready, starts the frontend, and opens a browser.
+
+On Windows, double-click `Start-BurnGuard.bat` to open the native app. It builds the app on first launch (Bun and the .NET 8 SDK are required), then opens the existing build immediately on later launches. After updating source code, run `Start-BurnGuard.bat --rebuild` to build and open the updated app. Close the browser-mode servers before opening the native app.
 
 - App: **http://127.0.0.1:5173**
 - Backend health: **http://127.0.0.1:14070/api/health**

--- a/Start-BurnGuard.bat
+++ b/Start-BurnGuard.bat
@@ -2,16 +2,20 @@
 setlocal EnableExtensions
 
 rem One-click launcher for BurnGuard Design (Windows).
-rem Double-click this file to start the backend + frontend dev servers.
-rem
-rem Real work lives in scripts\dev-launcher.ts so the boot sequence (backend
-rem health check, frontend wait, browser open, clean shutdown) is identical
-rem on Windows and macOS.
+rem Open the existing native Windows build immediately, or build it on first use.
+rem After source changes, run with --rebuild to update the app before opening it.
 
 cd /d "%~dp0"
 
 title BurnGuard Design
 
+if not "%~2"=="" goto usage
+if "%~1"=="--build" goto build
+if "%~1"=="--rebuild" goto build
+if not "%~1"=="" goto usage
+if exist "dist\windows-native\BurnGuard.exe" goto launch
+
+:build
 where bun >nul 2>nul
 if errorlevel 1 (
     echo.
@@ -22,24 +26,48 @@ if errorlevel 1 (
     exit /b 1
 )
 
-if not exist "node_modules" (
-    echo [BurnGuard] First-time setup: running bun install --frozen-lockfile...
-    call bun install --frozen-lockfile
-    if errorlevel 1 (
-        echo.
-        echo [BurnGuard] bun install --frozen-lockfile failed. See log above.
-        echo.
-        pause
-        exit /b 1
-    )
+where dotnet >nul 2>nul
+if errorlevel 1 (
+    echo.
+    echo [BurnGuard] The .NET 8 SDK is required to build the native app.
+    echo            Install it from https://dotnet.microsoft.com/download/dotnet/8.0
+    echo.
+    pause
+    exit /b 1
 )
 
-echo [BurnGuard] Booting dev stack (backend then frontend)...
-echo            Close this window to stop the servers.
-echo.
-call bun run scripts/dev-launcher.ts
+echo [BurnGuard] Checking dependencies with bun install --frozen-lockfile...
+call bun install --frozen-lockfile
+if errorlevel 1 goto build_failed
 
+echo [BurnGuard] Building the current source for the native Windows app...
 echo.
-echo [BurnGuard] Dev stack stopped.
-pause
+call bun run build
+if errorlevel 1 goto build_failed
+call bun run scripts/build-windows-native.ts --skip-zip
+if errorlevel 1 goto build_failed
+
+:launch
+echo [BurnGuard] Opening the native app...
+start "" /D "%~dp0dist\windows-native" "%~dp0dist\windows-native\BurnGuard.exe"
+if errorlevel 1 goto launch_failed
 endlocal
+exit /b 0
+
+:build_failed
+echo.
+echo [BurnGuard] Native build failed. See the error above and try again.
+echo            An older build will not be opened.
+pause
+exit /b 1
+
+:launch_failed
+echo.
+echo [BurnGuard] The native app could not be opened. See the error above.
+pause
+exit /b 1
+
+:usage
+echo Usage: Start-BurnGuard.bat [--build ^| --rebuild]
+echo        No option opens the existing native build; source changes need --rebuild.
+exit /b 1

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     },
   },
   server: {
+    host: "127.0.0.1",
     port: 5173,
     strictPort: true,
     headers: {


### PR DESCRIPTION
Double-clicking `Start-BurnGuard.bat` now opens the Windows native app. An existing build opens immediately; the first launch or `--rebuild` installs locked dependencies and builds the current source before opening it. Failed builds never fall back to an older executable. The English and Korean READMEs explain the cached launch and explicit rebuild behavior.

Vite now binds to `127.0.0.1`, matching the development launcher's readiness URL and the backend's allowed development authority. This fixes initial connection failures on Windows hosts where Vite otherwise binds to `localhost`/IPv6. Request authority and proxy restrictions stay enforced.

Validation:
- Lint passed, and the Windows batch launcher retains CRLF line endings.
- Frontend and backend builds passed; the native Release build passed with zero warnings and errors.
- The development app loaded its real project list; health, frontend response, and authenticated bootstrap passed at the loopback address.
- The native smoke passed occupied-port refusal, then hit its 120-second deadline. Its automatic cleanup closed the diagnostic window; the older successful smoke receipt is not evidence for this run. A fresh full native-smoke pass is not claimed.
- The actual `Start-BurnGuard.bat` default path launched the current native build with the existing user profile. The visible BurnGuard window is responding; its owned packaged backend passed health, frontend serving, and authority bootstrap. Served HTML exactly matches both the packaged and freshly built frontend. It is left running without diagnostic/automatic-close options.
- Both GitHub Security checks passed.
