### PR TITLE
fix(mac): ship the native canvas binding and PDF.js in the macOS package

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,6 +38,7 @@ jobs:
           packages/backend/tests/config-storage.test.ts
           packages/backend/tests/mac-updates.test.ts
           packages/backend/tests/app-update-routes.test.ts
+          packages/backend/tests/native-binding.test.ts
           packages/frontend/tests/artifact-csp.test.ts
           packages/frontend/tests/client.test.ts
       # Advisories with no upstream fix are allowlisted by id; remove an id as

--- a/doc/13-windows-updates-and-original-samples.md
+++ b/doc/13-windows-updates-and-original-samples.md
@@ -31,7 +31,7 @@ bun install --frozen-lockfile
 bun run build:mac:release
 ```
 
-`dist/releases/` then contains `BurnGuard-osx-Setup.pkg`, `BurnGuard-osx-Portable.zip`, the full `.nupkg`, the `releases.osx.json` feed, and SHA256 sums. The packed bundle is `BurnGuard.app` with `Contents/MacOS/UpdateMac` beside the engine; only that bundle can update itself. The plain `dist/mac/BurnGuard Design.app` and the DMG are development builds without an updater.
+`dist/releases/` then contains `BurnGuard-osx-Setup.pkg`, `BurnGuard-osx-Portable.zip`, the full `.nupkg`, the `releases.osx.json` feed, and SHA256 sums. The packed bundle is `BurnGuard.app` with `Contents/MacOS/UpdateMac` beside the engine; only that bundle can update itself. The bundle also carries the native canvas binding and PDF.js under `Contents/MacOS/node_modules`, which thumbnails, PNG export and PDF rasterization need. The plain `dist/mac/BurnGuard Design.app` and the DMG are development builds without an updater.
 
 The **macOS release package** workflow runs on the same `v*` tag as the Windows workflow and attaches its assets to the same draft release (whichever job finishes first creates the draft). Publish the draft with both `releases.win.json` and `releases.osx.json` attached. Signing and notarization run when `BG_MAC_SIGN_IDENTITY`, `BG_MAC_INSTALL_IDENTITY` and `BG_MAC_NOTARY_PROFILE` are configured; unsigned packages are for verification only and Gatekeeper will warn on first launch.
 

--- a/packages/backend/src/services/export-native-modules.ts
+++ b/packages/backend/src/services/export-native-modules.ts
@@ -3,15 +3,17 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { resolveRepoRoot } from "../lib/paths";
+import { nativeCanvasBinding } from "./native-binding";
 
 // Bun's compiled import.meta path is virtual; native bindings need the real package tree.
 const root = resolveRepoRoot();
 const runtimeRequire = createRequire(path.join(root, "packages/backend/package.json"));
 function loadCanvas(): typeof import("@napi-rs/canvas") {
   const previous = process.env.NAPI_RS_NATIVE_LIBRARY_PATH;
-  const packaged = process.platform === "win32" && existsSync(path.join(root, "burnguard-runtime.json"));
+  const binding = nativeCanvasBinding(process.platform, process.arch);
+  const packaged = binding !== null && existsSync(path.join(root, "burnguard-runtime.json"));
   // Compiled Bun cannot resolve the binding's relative .node import; NAPI-RS accepts an absolute path.
-  if (packaged) process.env.NAPI_RS_NATIVE_LIBRARY_PATH = path.resolve(root, "../node_modules/@napi-rs/canvas-win32-x64-msvc/skia.win32-x64-msvc.node");
+  if (packaged) process.env.NAPI_RS_NATIVE_LIBRARY_PATH = path.resolve(root, "../node_modules", binding.package, binding.file);
   try { return runtimeRequire(runtimeRequire.resolve("@napi-rs/canvas")); }
   finally { if (previous === undefined) delete process.env.NAPI_RS_NATIVE_LIBRARY_PATH; else process.env.NAPI_RS_NATIVE_LIBRARY_PATH = previous; }
 }

--- a/packages/backend/src/services/native-binding.ts
+++ b/packages/backend/src/services/native-binding.ts
@@ -1,0 +1,22 @@
+/**
+ * Native modules the packaged app needs as real files beside its resources:
+ * the compiled Bun binary cannot resolve NAPI-RS bindings or PDF.js's worker
+ * from its virtual module tree. Shared by the packaging script and the loader.
+ */
+export type NativeCanvasBinding = { readonly package: string; readonly file: string };
+
+const CANVAS_BINDINGS: Readonly<Record<string, string>> = {
+  "win32-x64": "win32-x64-msvc",
+  "darwin-arm64": "darwin-arm64",
+  "darwin-x64": "darwin-x64",
+};
+
+export function nativeCanvasBinding(platform: NodeJS.Platform, arch: NodeJS.Architecture): NativeCanvasBinding | null {
+  const suffix = CANVAS_BINDINGS[`${platform}-${arch}`];
+  return suffix === undefined ? null : { package: `@napi-rs/canvas-${suffix}`, file: `skia.${suffix}.node` };
+}
+
+export function nativeModulePackages(platform: NodeJS.Platform, arch: NodeJS.Architecture): readonly string[] {
+  const binding = nativeCanvasBinding(platform, arch);
+  return ["@napi-rs/canvas", ...(binding === null ? [] : [binding.package]), "pdfjs-dist"];
+}

--- a/packages/backend/tests/native-binding.test.ts
+++ b/packages/backend/tests/native-binding.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { nativeCanvasBinding, nativeModulePackages } from "../src/services/native-binding";
+
+describe("packaged native modules", () => {
+  test("Given each shipped platform When the canvas binding is resolved Then the package and .node file match NAPI-RS naming", () => {
+    expect(nativeCanvasBinding("win32", "x64")).toEqual({ package: "@napi-rs/canvas-win32-x64-msvc", file: "skia.win32-x64-msvc.node" });
+    expect(nativeCanvasBinding("darwin", "arm64")).toEqual({ package: "@napi-rs/canvas-darwin-arm64", file: "skia.darwin-arm64.node" });
+    expect(nativeCanvasBinding("darwin", "x64")).toEqual({ package: "@napi-rs/canvas-darwin-x64", file: "skia.darwin-x64.node" });
+    expect(nativeCanvasBinding("linux", "arm64")).toBeNull();
+  });
+
+  test("Given a target platform When runtime packages are listed Then canvas, its binding and pdf.js are all staged", () => {
+    expect(nativeModulePackages("darwin", "arm64")).toEqual(["@napi-rs/canvas", "@napi-rs/canvas-darwin-arm64", "pdfjs-dist"]);
+    expect(nativeModulePackages("win32", "x64")).toEqual(["@napi-rs/canvas", "@napi-rs/canvas-win32-x64-msvc", "pdfjs-dist"]);
+  });
+});

--- a/scripts/package-runtime.ts
+++ b/scripts/package-runtime.ts
@@ -1,6 +1,7 @@
 import { cp, copyFile, lstat, mkdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { APP_NAME, APP_VERSION } from "../packages/shared/src/app";
+import { nativeModulePackages } from "../packages/backend/src/services/native-binding";
 
 export function isRuntimeSource(relativePath: string): boolean {
   const normalized = relativePath.replaceAll("\\", "/");
@@ -38,13 +39,11 @@ export async function stageRuntimeAssets(repoRoot: string, outputDirectory: stri
   await cp(frontend, path.join(resources, "packages/frontend/dist"), { recursive: true });
   const playwright = path.dirname(Bun.resolveSync("playwright-core/package.json", path.join(repoRoot, "packages/backend")));
   await cp(playwright, path.join(resources, "node_modules/playwright-core"), { recursive: true, dereference: true });
-  if (includeWindowsNode) {
-    // Native canvas bindings and PDF.js's relative worker must remain real files.
-    const canvasRoot = path.dirname(Bun.resolveSync("@napi-rs/canvas/package.json", path.join(repoRoot, "packages/backend")));
-    for (const name of ["@napi-rs/canvas", "@napi-rs/canvas-win32-x64-msvc", "pdfjs-dist"]) {
-      const source = path.dirname(Bun.resolveSync(`${name}/package.json`, name === "@napi-rs/canvas-win32-x64-msvc" ? canvasRoot : path.join(repoRoot, "packages/backend")));
-      await cp(source, path.join(destinationParent, "node_modules", name), { recursive: true, dereference: true });
-    }
+  // Native canvas bindings and PDF.js's relative worker must remain real files on every platform.
+  const canvasRoot = path.dirname(Bun.resolveSync("@napi-rs/canvas/package.json", path.join(repoRoot, "packages/backend")));
+  for (const name of nativeModulePackages(process.platform, process.arch)) {
+    const source = path.dirname(Bun.resolveSync(`${name}/package.json`, name.startsWith("@napi-rs/canvas-") ? canvasRoot : path.join(repoRoot, "packages/backend")));
+    await cp(source, path.join(destinationParent, "node_modules", name), { recursive: true, dereference: true });
   }
   await copyFile(path.join(repoRoot, "packages/backend/src/services/chromium-node-bridge.mjs"), path.join(resources, "chromium-node-bridge.mjs"));
   const worker = await Bun.build({


### PR DESCRIPTION
## Summary
Found while verifying PR #23 through the macOS Velopack update channel: the packaged macOS app carried only `playwright-core` under its resources, so once the compiled binary tried to load `@napi-rs/canvas` (thumbnails, PNG export, PDF rasterization, Pinterest) the request died with an uncaught error (HTTP 500) and every Examples card showed 미리보기를 불러오지 못했어요.

- `scripts/package-runtime.ts` now stages `@napi-rs/canvas`, the platform binding and `pdfjs-dist` beside the resources on every platform (Windows behaviour unchanged).
- `services/export-native-modules.ts` resolves the binding by platform/arch through the new `services/native-binding.ts` instead of only on win32.
- The CI gate runs the new mapping test; doc/13 notes the staged modules.

## Verification
- RED→GREEN `native-binding.test.ts`; `package-resources.test.ts`, typecheck and lint green.
- Real update chain on this Mac: packaged 0.5.1 (pre-#23) → 0.5.2 (#23 build; the served bundle gained the comment-edit and prototype-navigation markers) → 0.5.3 (this fix). Each step went through `check`/`apply` with UpdateMac swapping the bundle; after 0.5.3 all twelve original-sample thumbnails render (200 image/png) and the Examples tab shows every card. Scratch version bumps were never committed.

Ultraworked with [omo](https://github.com/code-yeongyu/oh-my-openagent)
