### PR TITLE
fix: 워크스페이스 배치 정리와 릴리스 보안 보강

### DIFF
--- a/doc/13-windows-updates-and-original-samples.md
+++ b/doc/13-windows-updates-and-original-samples.md
@@ -15,6 +15,8 @@ Each local packaging run replaces the generated `dist/releases/` directory. Keep
 
 For each new version:
 
+Before publishing any release, run the mandatory Daybreak (`gpt-daybreak-blue-latest`, LOW by default) security review against the final changes and package. Retain its scope, commit/tree and evidence in `.omo/evidence/release-<version>/`, fix release blockers and obtain Daybreak verification of the fixes. Keep the release as a draft while this gate is incomplete. CI and package smoke checks remain separate requirements.
+
 1. Increase the version together in root/backend/frontend/shared `package.json`, `packages/shared/src/app.ts`, and `packages/desktop-windows/BurnGuard.Desktop.csproj`.
 2. Commit and merge the verified change. A tag must match the version, for example `v0.5.0`.
 3. Push that tag to run **Windows release package**. The workflow builds packages and creates a **draft** GitHub Release. A manual workflow run only produces a downloadable Actions artifact.

--- a/packages/backend/src/services/vercel-publish.ts
+++ b/packages/backend/src/services/vercel-publish.ts
@@ -14,7 +14,11 @@ export class VercelPublishError extends Error {
 
 // Only browser assets are public; never upload package/config files or archive metadata.
 export function isPublicAsset(name: string): boolean {
+  const basename = name.slice(name.lastIndexOf("/") + 1);
+  const stem = basename.replace(/\.[^.]+$/, "").replace(/([a-z0-9])([A-Z])/g, "$1-$2");
+  const sensitive = /(?:^|[._ -])(?:secrets?|tokens?|credentials?|passwords?|api[._ -]*keys?|(?:access|refresh|auth|bearer)[._ -]*tokens?|private[._ -]*keys?)(?:[._ -]|$)/i.test(stem);
   return !name.split("/").some((part) => !part || part.startsWith(".") || /^(?:attachments?|references?|node_modules|private|secrets?)$/i.test(part))
+    && (!sensitive || basename.toLowerCase() === "tokens.css")
     && !/[\\:%\x00-\x1f]/.test(name)
     && /\.(?:html?|css|js|mjs|svg|png|jpe?g|gif|webp|avif|ico|woff2?|ttf|otf|mp4|webm|mp3|wav)$/i.test(name)
     && !/(?:^|\/)(?:[^/]*config[^/]*|credentials[^/]*)$/i.test(name);

--- a/packages/backend/src/services/vercel-publish.ts
+++ b/packages/backend/src/services/vercel-publish.ts
@@ -14,11 +14,12 @@ export class VercelPublishError extends Error {
 
 // Only browser assets are public; never upload package/config files or archive metadata.
 export function isPublicAsset(name: string): boolean {
-  const basename = name.slice(name.lastIndexOf("/") + 1);
-  const stem = basename.replace(/\.[^.]+$/, "").replace(/([a-z0-9])([A-Z])/g, "$1-$2");
-  const sensitive = /(?:^|[._ -])(?:secrets?|tokens?|credentials?|passwords?|api[._ -]*keys?|(?:access|refresh|auth|bearer)[._ -]*tokens?|private[._ -]*keys?)(?:[._ -]|$)/i.test(stem);
-  return !name.split("/").some((part) => !part || part.startsWith(".") || /^(?:attachments?|references?|node_modules|private|secrets?)$/i.test(part))
-    && (!sensitive || basename.toLowerCase() === "tokens.css")
+  const parts = name.split("/");
+  return !parts.some((part, index) => {
+    if (!part || part.startsWith(".") || /^(?:attachments?|references?|node_modules|private)$/i.test(part)) return true;
+    if (index === parts.length - 1 && part.toLowerCase() === "tokens.css") return false;
+    return /(?:^|[._ -])(?:secrets?|tokens?|credentials?|passwords?|api[._ -]*keys?|(?:access|refresh|auth|bearer)[._ -]*tokens?|private[._ -]*keys?)(?:[._ -]|$)/i.test(part.replace(/([a-z0-9])([A-Z])/g, "$1-$2"));
+  })
     && !/[\\:%\x00-\x1f]/.test(name)
     && /\.(?:html?|css|js|mjs|svg|png|jpe?g|gif|webp|avif|ico|woff2?|ttf|otf|mp4|webm|mp3|wav)$/i.test(name)
     && !/(?:^|\/)(?:[^/]*config[^/]*|credentials[^/]*)$/i.test(name);

--- a/packages/backend/tests/vercel-publish.test.ts
+++ b/packages/backend/tests/vercel-publish.test.ts
@@ -25,6 +25,10 @@ test("Given sensitive basenames at any depth, when selecting public assets, then
   }
   expect(isPublicAsset("assets/tokens.css")).toBe(true);
   expect(isPublicAsset("assets/tokenizer.js")).toBe(true);
+  for (const directory of ["credentials", "tokens", "api-keys", "private-keys", "secrets-prod", "accessTokens", "tokens.css"]) {
+    expect(isPublicAsset(`${directory}/data.js`)).toBe(false);
+    expect(isPublicAsset(`assets/${directory}/tokens.css`)).toBe(false);
+  }
 });
 
 test("Given an image over 3MB, when uploading, then Vercel receives bytes and digest references without inline base64", async () => {

--- a/packages/backend/tests/vercel-publish.test.ts
+++ b/packages/backend/tests/vercel-publish.test.ts
@@ -18,6 +18,15 @@ test("Given a validated static export, when prepared for Vercel, then only brows
   expect(isPublicAsset("assets/tokens.css")).toBe(true);
 });
 
+test("Given sensitive basenames at any depth, when selecting public assets, then credentials are blocked but CSS design tokens remain", () => {
+  for (const filename of ["secret.js", "secrets.js", "token.js", "TOKENS.mjs", "api-key.js", "api_key.js", "apiKeys.js", "access-token.js", "refresh_tokens.js", "privatekey.js", "privateKeys.js", "site.secret.js", "authToken.js", "credentials.js", "passwords.js"]) {
+    expect(isPublicAsset(filename)).toBe(false);
+    expect(isPublicAsset(`assets/nested/${filename}`)).toBe(false);
+  }
+  expect(isPublicAsset("assets/tokens.css")).toBe(true);
+  expect(isPublicAsset("assets/tokenizer.js")).toBe(true);
+});
+
 test("Given an image over 3MB, when uploading, then Vercel receives bytes and digest references without inline base64", async () => {
   const data = new Uint8Array(4 * 1024 * 1024);
   const fetcher = (async (url: unknown, init?: RequestInit) => {

--- a/packages/desktop-windows/Program.cs
+++ b/packages/desktop-windows/Program.cs
@@ -123,6 +123,7 @@ namespace BurnGuard.Desktop
             ClientSize = new Size(1280, 850);
             MinimumSize = new Size(900, 640);
             StartPosition = FormStartPosition.CenterScreen;
+            if (report != null) { ShowInTaskbar = false; Opacity = 0; }
             AutoScaleMode = AutoScaleMode.Dpi;
             var icon = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "BurnGuard.ico");
             if (File.Exists(icon)) Icon = new Icon(icon);

--- a/packages/desktop-windows/Program.cs
+++ b/packages/desktop-windows/Program.cs
@@ -103,6 +103,7 @@ namespace BurnGuard.Desktop
         private bool closing;
         private bool stopped;
         private bool smokeStarted;
+        private long startupElapsedMs;
         private int port;
         private readonly ToolStrip updateStrip = new ToolStrip { Dock = DockStyle.Bottom, GripStyle = ToolStripGripStyle.Hidden };
         private readonly ToolStripButton checkUpdate = new ToolStripButton("업데이트 확인");
@@ -167,10 +168,13 @@ namespace BurnGuard.Desktop
                 try { listener.Start(); }
                 catch (SocketException) { throw new InvalidOperationException($"포트 {port}를 다른 프로그램이 사용 중입니다. 기존 BurnGuard 서버를 종료한 뒤 다시 실행해 주세요."); }
                 finally { listener.Stop(); }
+                status.Text = "BurnGuard를 준비하고 있어요. 처음 실행할 때는 샘플과 글꼴 준비에 시간이 걸릴 수 있어요.";
+                var startup = Stopwatch.StartNew();
                 StartService();
-                var completed = await Task.WhenAny(ready.Task, Task.Delay(TimeSpan.FromSeconds(60)));
+                var completed = await Task.WhenAny(ready.Task, Task.Delay(TimeSpan.FromSeconds(120)));
+                startupElapsedMs = startup.ElapsedMilliseconds;
                 if (closing) return;
-                if (completed != ready.Task) throw new TimeoutException("BurnGuard 서버가 60초 안에 시작되지 않았습니다.");
+                if (completed != ready.Task) throw new TimeoutException("BurnGuard 서버가 120초 안에 시작되지 않았습니다.");
                 origin = new Uri(await ready.Task);
                 string userData = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "BurnGuard", "WebView2", identity);
                 if (report != null) userData = Path.Combine(Environment.GetEnvironmentVariable("BG_APP_ROOT"), "cache", "webview2");
@@ -353,9 +357,9 @@ namespace BurnGuard.Desktop
                 var screenshot = Path.ChangeExtension(report, ".png");
                 Directory.CreateDirectory(Path.GetDirectoryName(screenshot));
                 using (var stream = File.Create(screenshot)) await web.CoreWebView2.CapturePreviewAsync(CoreWebView2CapturePreviewImageFormat.Png, stream);
-                Program.WriteReport(report, new { ok = true, processId = Process.GetCurrentProcess().Id, servicePid = service.Id, webViewVersion = web.CoreWebView2.Environment.BrowserVersionString, screenshot, dom });
+                Program.WriteReport(report, new { ok = true, startupElapsedMs, processId = Process.GetCurrentProcess().Id, servicePid = service.Id, webViewVersion = web.CoreWebView2.Environment.BrowserVersionString, screenshot, dom });
             }
-            catch (Exception exception) { Program.ExitCode = 1; Program.WriteReport(report, new { ok = false, error = exception.Message }); }
+            catch (Exception exception) { Program.ExitCode = 1; Program.WriteReport(report, new { ok = false, startupElapsedMs, error = exception.Message }); }
             Close();
         }
 
@@ -363,7 +367,7 @@ namespace BurnGuard.Desktop
         {
             if (closing) return;
             Program.ExitCode = 1;
-            if (report != null) Program.WriteReport(report, new { ok = false, error = message });
+            if (report != null) Program.WriteReport(report, new { ok = false, startupElapsedMs, error = message });
             else MessageBox.Show(this, message, "BurnGuard", MessageBoxButtons.OK, MessageBoxIcon.Error);
             Close();
         }

--- a/packages/frontend/src/components/canvas/Canvas.tsx
+++ b/packages/frontend/src/components/canvas/Canvas.tsx
@@ -295,16 +295,8 @@ export default function Canvas({
         onUndo={onUndo}
         colorPalette={colorPalette}
       />
-      <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-1 text-xs" aria-label="미리보기 배율과 이동">
-        <button type="button" aria-label="미리보기 축소" disabled={zoom <= 0.25} onClick={() => setZoom((v) => Math.max(0.25, v - 0.25))}>−</button>
-        <button type="button" title="배율과 위치 초기화" onClick={() => { setZoom(1); setPan({ x: 0, y: 0 }); }}>{Math.round(zoom * 100)}%</button>
-        <button type="button" aria-label="미리보기 확대" disabled={zoom >= 3} onClick={() => setZoom((v) => Math.min(3, v + 0.25))}>+</button>
-        <button type="button" aria-pressed={moving} className="rounded border border-border px-2 py-1" onClick={() => setMoving((v) => !v)}>화면 이동</button>
-        {moving && <span className="text-muted-foreground">드래그해서 이동해요</span>}
-        {sceneTools && <button type="button" aria-pressed={showSceneTools} className="rounded border border-border px-2 py-1" onClick={() => setShowSceneTools((value) => !value)}>3D 장면</button>}
-      </div>
-      <div ref={containerRef} className="relative flex-1 overflow-hidden">
-        <div ref={stageRef} className="absolute inset-0" style={{ transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`, transformOrigin: "center" }}
+      <div ref={containerRef} className="relative flex-1 overflow-hidden bg-muted/70">
+        <div ref={stageRef} className="absolute inset-3 rounded-md shadow-md ring-1 ring-border/60 max-[600px]:inset-2" style={{ transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`, transformOrigin: "center" }}
           onWheel={(event) => {
             if (!mode || moving || !stageRef.current) return;
             const [x, y] = canvasPoint(stageRef.current, event.clientX, event.clientY);
@@ -320,7 +312,7 @@ export default function Canvas({
             sandbox="allow-scripts allow-popups"
             referrerPolicy="no-referrer"
             allow="fullscreen"
-            className="absolute inset-0 h-full w-full border-0 bg-background"
+            className="absolute inset-0 h-full w-full rounded-md border-0 bg-background"
             onLoad={() => {
               if (frameSrcDoc !== null) setLoadedFrameKey(frameKey ?? src);
             }}
@@ -333,7 +325,7 @@ export default function Canvas({
             sandbox="allow-scripts allow-popups"
             referrerPolicy="no-referrer"
             allow="fullscreen"
-            className="absolute inset-0 h-full w-full border-0 bg-background"
+            className="absolute inset-0 h-full w-full rounded-md border-0 bg-background"
           />
         )}
         <CommentLayer
@@ -420,6 +412,16 @@ export default function Canvas({
           onPointerCancel={() => { dragRef.current = null; }}
           onLostPointerCapture={() => { dragRef.current = null; }}
         />}
+      </div>
+      <div className="flex shrink-0 items-center justify-between gap-3 border-t border-border bg-background px-3 py-1 text-xs" aria-label="미리보기 배율과 이동">
+        <span className="min-w-0 truncate text-[11px] text-muted-foreground">{moving ? "화면을 드래그해서 이동해요" : activeRelPath ?? "캔버스"}</span>
+        <div className="flex shrink-0 items-center gap-1">
+          <button type="button" className="h-8 w-8 rounded hover:bg-muted disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-ring" aria-label="미리보기 축소" disabled={zoom <= 0.25} onClick={() => setZoom((v) => Math.max(0.25, v - 0.25))}>−</button>
+          <button type="button" className="h-8 min-w-12 rounded px-1 tabular-nums hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring" title="배율과 위치 초기화" onClick={() => { setZoom(1); setPan({ x: 0, y: 0 }); }}>{Math.round(zoom * 100)}%</button>
+          <button type="button" className="h-8 w-8 rounded hover:bg-muted disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-ring" aria-label="미리보기 확대" disabled={zoom >= 3} onClick={() => setZoom((v) => Math.min(3, v + 0.25))}>+</button>
+          <button type="button" aria-pressed={moving} className={`ml-1 h-8 rounded-md px-2 focus-visible:ring-2 focus-visible:ring-ring ${moving ? "bg-accent/10 text-accent" : "text-muted-foreground hover:bg-muted"}`} onClick={() => setMoving((v) => !v)}>화면 이동</button>
+          {sceneTools && <button type="button" aria-pressed={showSceneTools} className={`h-8 rounded-md px-2 focus-visible:ring-2 focus-visible:ring-ring ${showSceneTools ? "bg-accent/10 text-accent" : "text-muted-foreground hover:bg-muted"}`} onClick={() => setShowSceneTools((value) => !value)}>3D 장면</button>}
+        </div>
       </div>
       {showSceneTools && sceneTools}
     </div>

--- a/packages/frontend/src/components/canvas/CanvasTopBar.tsx
+++ b/packages/frontend/src/components/canvas/CanvasTopBar.tsx
@@ -36,10 +36,10 @@ export default function CanvasTopBar({
   colorPalette?: ReactNode;
 }) {
   return (
-    <div className="shrink-0 border-b border-border bg-background px-3 py-2">
-      <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
-      <div className="grid flex-1 grid-cols-4 gap-1 min-[1400px]:flex" aria-label="캔버스 도구">
-        <button type="button" onClick={() => onModeChange(null)} aria-pressed={mode === null} className={cn("flex min-h-10 items-center justify-center gap-1.5 rounded-md px-2 text-xs font-medium max-[900px]:min-h-11", mode === null ? "bg-accent/10 text-accent" : "text-muted-foreground hover:bg-muted hover:text-foreground")}><Eye className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />미리보기</button>
+    <div className="z-20 shrink-0 border-b border-border bg-background px-2 py-1.5">
+      <div className="flex flex-wrap items-center justify-between gap-1 min-[901px]:flex-nowrap">
+      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-0.5 min-[901px]:flex-nowrap" aria-label="캔버스 도구">
+        <button type="button" title="미리보기" aria-label="미리보기" onClick={() => onModeChange(null)} aria-pressed={mode === null} className={cn("flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-md px-2 text-xs font-medium max-[900px]:min-h-11", mode === null ? "bg-accent/10 text-accent" : "text-muted-foreground hover:bg-muted hover:text-foreground")}><Eye className="h-4 w-4 shrink-0" aria-hidden="true" /><span className={mode === null ? "hidden min-[1100px]:inline" : "hidden min-[1500px]:inline"}>미리보기</span></button>
         {MODES.map((m) => {
           const active = m.id === mode;
           const Icon = m.icon;
@@ -49,26 +49,27 @@ export default function CanvasTopBar({
               type="button"
               onClick={() => onModeChange(active ? null : m.id)}
               aria-pressed={active}
+              aria-label={m.label}
               title={active ? "다시 누르면 모드 끄기" : m.hint}
               className={cn(
-                "flex min-h-10 min-w-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-md px-2 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring max-[900px]:min-h-11",
+                "flex h-9 min-w-9 shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-md px-2 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring max-[900px]:min-h-11",
                 active
                   ? "bg-accent/10 text-accent"
                   : "text-muted-foreground hover:bg-muted hover:text-foreground",
               )}
             >
-              <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />{m.label}
+              <Icon className="h-4 w-4 shrink-0" aria-hidden="true" /><span className={active || m.id === "quality" ? "hidden min-[1100px]:inline" : "hidden min-[1500px]:inline"}>{m.label}</span>
             </button>
           );
         })}
         {colorPalette}
       </div>
 
-      <div className="ml-auto flex items-center gap-1">
+      <div className="ml-auto flex shrink-0 items-center gap-0.5 border-l border-border pl-1">
         <Button
           variant="ghost"
           size="icon"
-          className="h-10 w-10 max-[900px]:h-11 max-[900px]:w-11"
+          className="h-9 w-9 max-[900px]:h-11 max-[900px]:w-11"
           aria-label="마지막 저장 실행 취소"
           onClick={onUndo}
           disabled={!canUndo || undoPending || !onUndo}
@@ -83,7 +84,7 @@ export default function CanvasTopBar({
         <Button
           variant="ghost"
           size="icon"
-          className="h-10 w-10 max-[900px]:h-11 max-[900px]:w-11"
+          className="h-9 w-9 max-[900px]:h-11 max-[900px]:w-11"
           aria-label="캔버스 새로고침"
           onClick={onRefresh}
           title="캔버스 새로고침"
@@ -92,7 +93,6 @@ export default function CanvasTopBar({
         </Button>
       </div>
       </div>
-      {mode !== null && <p className="mt-2 border-t border-border/70 pt-2 text-xs leading-relaxed text-muted-foreground" role="status">{MODES.find((item) => item.id === mode)?.hint}</p>}
     </div>
   );
 }

--- a/packages/frontend/src/components/canvas/ColorPalette.tsx
+++ b/packages/frontend/src/components/canvas/ColorPalette.tsx
@@ -33,8 +33,8 @@ export default function ColorPalette({ projectId, relPath, refreshKey, disabled,
     onError: (error) => { if (isStaleIdentityError(error)) void palette.refetch(); },
   });
   return <div className="relative">
-    <button type="button" aria-expanded={open} aria-label="컬러 팔레트" onClick={() => setOpen((value) => !value)} className="flex min-h-10 w-full items-center justify-center gap-1.5 whitespace-nowrap rounded-md px-2 text-xs font-medium text-muted-foreground hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring max-[900px]:min-h-11">
-      <Palette className="h-3.5 w-3.5" aria-hidden="true" />컬러 팔레트
+    <button type="button" title="컬러 팔레트" aria-expanded={open} aria-label="컬러 팔레트" onClick={() => setOpen((value) => !value)} className="flex h-9 items-center justify-center gap-1.5 whitespace-nowrap rounded-md px-2 text-xs font-medium text-muted-foreground hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring max-[900px]:min-h-11">
+      <Palette className="h-4 w-4" aria-hidden="true" /><span className="hidden min-[1500px]:inline">컬러 팔레트</span>
     </button>
     {open && <section aria-label="현재 페이지 색상" className="absolute right-0 top-full z-50 mt-2 w-80 max-w-[85vw] rounded-xl border border-border bg-popover p-4 text-popover-foreground shadow-xl" onKeyDown={(event) => { if (event.key === "Escape") { event.stopPropagation(); setOpen(false); } }}>
       <div className="mb-2 flex items-center justify-between gap-2"><h2 className="text-sm font-semibold">현재 페이지 색상</h2><button type="button" className="text-xs text-muted-foreground" onClick={() => setOpen(false)}>닫기</button></div>

--- a/packages/frontend/src/components/chat/ChatPane.tsx
+++ b/packages/frontend/src/components/chat/ChatPane.tsx
@@ -102,7 +102,7 @@ export default function ChatPane({
 
   return (
     <aside aria-label="AI 대화와 코멘트" className="flex h-full min-h-0 w-full shrink-0 flex-col overflow-hidden bg-background min-[901px]:w-[340px] min-[901px]:border-r min-[901px]:border-border">
-      <div className="flex shrink-0 items-stretch gap-4 border-b border-border px-4 pt-2">
+      <div className="flex shrink-0 items-center gap-3 border-b border-border px-3">
         <ChatTab
           id="chat"
           active={tab}
@@ -119,16 +119,10 @@ export default function ChatPane({
         >
           코멘트 {openCommentCount > 0 && <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">{openCommentCount}</span>}
         </ChatTab>
+        <div className="ml-auto shrink-0"><BackendToggle current={session.backend_id} disabled={switchBackend.isPending || sessionRunning} onSwitch={(next) => switchBackend.mutate(next)} /></div>
+
       </div>
       <div hidden={tab !== "chat"} className={tab === "chat" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
-        <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border/60 px-4 py-3">
-          <span className="text-xs font-medium text-muted-foreground">AI 모델</span>
-          <BackendToggle
-            current={session.backend_id}
-            disabled={switchBackend.isPending || sessionRunning}
-            onSwitch={(next) => switchBackend.mutate(next)}
-          />
-        </div>
           <MessageStream
             events={events}
             session={session}
@@ -200,7 +194,7 @@ function BackendToggle({
                 : `다음 턴부터 ${backendLabel(opt)} 사용`
           }
           className={cn(
-            "min-h-8 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring max-[900px]:min-h-11 max-[900px]:min-w-11",
+            "min-h-8 rounded-md px-2 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring max-[900px]:min-h-11 max-[900px]:min-w-11",
             opt === current
               ? "bg-background text-foreground shadow-sm"
               : "text-muted-foreground hover:text-foreground",
@@ -237,7 +231,7 @@ function ChatTab({
       onClick={() => setActive(id)}
       aria-pressed={active === id}
       className={cn(
-        "flex min-h-11 items-center gap-2 border-b-2 -mb-px px-1 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        "flex min-h-11 items-center gap-1.5 border-b-2 -mb-px px-0.5 py-2 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         active === id
           ? "border-primary text-primary"
           : "border-transparent text-muted-foreground hover:text-foreground",

--- a/packages/frontend/src/components/chat/Composer.tsx
+++ b/packages/frontend/src/components/chat/Composer.tsx
@@ -141,7 +141,7 @@ export default function Composer({
     <div
       data-qa="composer"
       className={cn(
-        "max-h-[60%] shrink-0 overflow-y-auto border-t border-border bg-background p-3",
+        "max-h-[55%] shrink-0 overflow-y-auto border-t border-border bg-background p-3",
         dragOver && "ring-2 ring-accent ring-inset",
       )}
       onDragOver={(e) => {
@@ -161,7 +161,6 @@ export default function Composer({
         onRoleChange={visualSources.setRole}
         onRemove={visualSources.remove}
       />
-      <div className="mb-3"><GenerationControls backendId={backendId} value={generation} onChange={draft.setGeneration} disabled={disabled || sending || !draft.ready} /></div>
       {!draft.ready && <p role="status" className="text-xs text-muted-foreground">작성 중이던 내용을 불러오고 있어요…</p>}
       {draft.storageError && <p role="status" className="text-xs text-warning-foreground">이 브라우저에서 초안을 저장하지 못했어요. 페이지를 닫기 전에 메시지를 보내 주세요.</p>}
 
@@ -185,7 +184,7 @@ export default function Composer({
           }
         }}
         placeholder={placeholder}
-        rows={4}
+        rows={3}
         disabled={disabled || sending || !draft.ready}
         aria-label="메시지 입력"
         onKeyDown={(e) => {
@@ -194,10 +193,11 @@ export default function Composer({
             void send();
           }
         }}
-        className="block min-h-[104px] w-full resize-none rounded-xl border border-input bg-muted/25 p-3 text-sm leading-relaxed placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+        className="block min-h-[88px] w-full resize-none rounded-xl border border-input bg-muted/25 p-3 text-sm leading-relaxed placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
       />
 
-      <div className="mt-2 flex items-center gap-1.5">
+      <div className="mt-2"><GenerationControls compact backendId={backendId} value={generation} onChange={draft.setGeneration} disabled={disabled || sending || !draft.ready} /></div>
+      <div className="mt-1 flex items-center gap-1.5">
         <input
           ref={fileInput}
           type="file"

--- a/packages/frontend/src/components/chat/MessageStream.tsx
+++ b/packages/frontend/src/components/chat/MessageStream.tsx
@@ -70,17 +70,13 @@ export default function MessageStream({
         className="chat-scroll absolute inset-0 space-y-4 overflow-y-auto px-4 py-5"
       >
         {groups.length === 0 && (
-          <div className="py-7">
-            <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+          <div className="py-4">
+            <div className="mb-3 flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10 text-primary">
               <MessageSquare className="h-5 w-5" aria-hidden="true" />
             </div>
-            <h2 className="text-base font-semibold tracking-tight">무엇을 만들어 볼까요?</h2>
-            <p className="mt-2 text-sm leading-relaxed text-muted-foreground">목적과 원하는 내용을 알려 주세요. 완성된 결과를 보면서 계속 다듬을 수 있어요.</p>
-            <ol className="mt-5 space-y-3 text-xs leading-relaxed text-muted-foreground">
-              <li className="flex gap-2.5"><span className="font-medium text-primary">01</span> 아래에 작업을 요청해요.</li>
-              <li className="flex gap-2.5"><span className="font-medium text-primary">02</span> 미리보기에서 결과를 확인해요.</li>
-              <li className="flex gap-2.5"><span className="font-medium text-primary">03</span> 수정하거나 코멘트를 남겨요.</li>
-            </ol>
+            <h2 className="text-sm font-semibold tracking-tight">무엇을 만들어 볼까요?</h2>
+            <p className="mt-2 text-xs leading-relaxed text-muted-foreground">목적과 원하는 내용을 알려 주세요. 완성된 결과를 보면서 계속 다듬을 수 있어요.</p>
+
           </div>
         )}
         {groups.map((g, i) => {

--- a/packages/frontend/src/components/modes/ModePanel.tsx
+++ b/packages/frontend/src/components/modes/ModePanel.tsx
@@ -93,7 +93,7 @@ export default function ModePanel({
   if (!mode) return null;
 
   return (
-    <aside aria-label="캔버스 도구 설정" className="flex min-h-0 w-[280px] shrink-0 flex-col overflow-hidden border-l border-border bg-background min-[1400px]:w-[320px] max-[1200px]:max-h-[40%] max-[1200px]:w-full max-[1200px]:shrink max-[1200px]:border-l-0 max-[1200px]:border-t">
+    <aside aria-label="캔버스 도구 설정" className="flex min-h-0 w-[260px] shrink-0 flex-col overflow-hidden border-l border-border bg-background min-[1500px]:w-[288px] max-[1000px]:max-h-[40%] max-[1000px]:w-full max-[1000px]:shrink max-[1000px]:border-l-0 max-[1000px]:border-t">
       {(mode === "select" || mode === "tweaks") && (
         <TweaksPanel
           target={tweaksTarget}

--- a/packages/frontend/src/components/modes/TweaksPanel.tsx
+++ b/packages/frontend/src/components/modes/TweaksPanel.tsx
@@ -130,7 +130,7 @@ export default function TweaksPanel({ target, saving, onApply, onResetAll, onCle
 function GeometryControls({ target, saving, onApply }: { target: TweaksTarget; saving: boolean; onApply: ApplyFn }) {
   const { width, height, rotation } = targetDimensions(target);
   const locked = isAspectLocked(target);
-  return <section aria-label="크기와 회전" className="space-y-3 px-3 py-4">
+  return <section aria-label="크기와 회전" className="m-3 space-y-3 rounded-lg border border-border bg-card p-3">
     <div className="grid grid-cols-2 gap-3">
       <GeometryNumber label="가로" unit="px" value={width} min={1} max={MAX_ELEMENT_SIZE} disabled={saving} onCommit={value => onApply(dimensionPatch(target, value, height, locked))} />
       <GeometryNumber label="세로" unit="px" value={height} min={1} max={MAX_ELEMENT_SIZE} disabled={saving} onCommit={value => onApply(dimensionPatch(target, width, value, locked))} />
@@ -145,7 +145,7 @@ function GeometryControls({ target, saving, onApply }: { target: TweaksTarget; s
         </select>
       </label>
     </div>
-    <p className="text-xs leading-relaxed text-muted-foreground">박스 손잡이로 크기를, 위쪽 둥근 손잡이로 회전을 조절해요. Esc로 드래그를 취소하고 Ctrl/⌘+Z로 되돌릴 수 있어요.</p>
+    <p className="text-[11px] leading-relaxed text-muted-foreground">손잡이를 끌어 크기·회전을 조절하세요.<br />Esc 취소 · Ctrl/⌘+Z 실행 취소</p>
   </section>;
 }
 

--- a/packages/frontend/src/components/project/ProjectTopBar.tsx
+++ b/packages/frontend/src/components/project/ProjectTopBar.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { ChevronRight, Play } from "lucide-react";
+import { ChevronRight, PanelLeftClose, PanelLeftOpen, Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { ReactNode } from "react";
 import type { ProjectDetail } from "@bg/shared";
@@ -14,6 +14,8 @@ export default function ProjectTopBar({
   canPresent,
   qualityGate,
   onOpenQuality,
+  chatCollapsed,
+  onToggleChat,
 }: {
   project: ProjectDetail;
   tabsSlot?: ReactNode;
@@ -21,12 +23,15 @@ export default function ProjectTopBar({
   canPresent: boolean;
   qualityGate: ExportQualityGate;
   onOpenQuality: () => void;
+  chatCollapsed?: boolean;
+  onToggleChat?: () => void;
 }) {
   const displayName = stripInternalProjectTag(project.name);
   return (
     <header className="shrink-0 border-b border-border bg-background">
-      <div className="flex min-h-[72px] flex-wrap items-center justify-between gap-x-5 gap-y-3 px-5 py-3 max-[600px]:px-3">
+      <div className="flex min-h-14 flex-wrap items-center justify-between gap-x-4 gap-y-2 px-4 py-2 max-[600px]:px-3">
       <div className="flex min-w-0 flex-1 items-center gap-3 max-[600px]:basis-full">
+        {onToggleChat && <button type="button" onClick={onToggleChat} aria-label={chatCollapsed ? "AI 대화 펼치기" : "AI 대화 접기"} title={chatCollapsed ? "AI 대화 펼치기" : "AI 대화 접기"} className="hidden h-9 w-9 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted min-[901px]:flex">{chatCollapsed ? <PanelLeftOpen className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}</button>}
         <Link
           to="/"
           className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -65,7 +70,7 @@ export default function ProjectTopBar({
         <ExportMenu projectId={project.id} projectType={project.type} projectOptionsJson={project.options_json} qualityGate={qualityGate} onOpenQuality={onOpenQuality} />
       </div>
       </div>
-      {tabsSlot && <div className="h-12 min-w-0 overflow-hidden border-t border-border bg-muted/30">{tabsSlot}</div>}
+      {tabsSlot && <div className="h-10 min-w-0 overflow-hidden border-t border-border bg-muted/20 max-[900px]:h-11">{tabsSlot}</div>}
     </header>
   );
 }

--- a/packages/frontend/src/components/settings/GenerationControls.tsx
+++ b/packages/frontend/src/components/settings/GenerationControls.tsx
@@ -2,8 +2,8 @@ import { useQuery } from "@tanstack/react-query";
 import { COMMANDCODE_MODELS, type BackendId, type GenerationOptions } from "@bg/shared";
 import { detectBackends, getSettings } from "@/api/home";
 
-export default function GenerationControls({ backendId, value, onChange, disabled = false }: {
-  backendId: BackendId; value: GenerationOptions; onChange: (value: GenerationOptions) => void; disabled?: boolean;
+export default function GenerationControls({ backendId, value, onChange, disabled = false, compact = false }: {
+  backendId: BackendId; value: GenerationOptions; onChange: (value: GenerationOptions) => void; disabled?: boolean; compact?: boolean;
 }) {
   const detection = useQuery({ queryKey: ["backends", "detect"], queryFn: detectBackends });
   const settings = useQuery({ queryKey: ["settings"], queryFn: getSettings });
@@ -11,14 +11,17 @@ export default function GenerationControls({ backendId, value, onChange, disable
   const model = models.find((candidate) => candidate.id === value.model) ?? models[0];
   const efforts = model?.efforts ?? ["low"];
   const selectClass = "mt-1 min-h-9 w-full rounded-lg border border-border bg-background px-2 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
-  return <fieldset disabled={disabled} className="space-y-2 text-xs disabled:opacity-60">
-    <legend className="sr-only">생성 모델과 추론 설정</legend>
+  const secondary = <>
     {backendId === "claude-code" && <label className="block">연결
       <select aria-label="모델 연결" className={selectClass} value={value.provider} onChange={(event) => onChange({ ...value, provider: event.target.value as GenerationOptions["provider"], model: "", effort: "low" })}>
         <option value="native">Claude Code 로그인</option>
         <option value="commandcode" disabled={!settings.data?.commandcode_api_key_set}>CommandCode · Claude 모델{settings.data?.commandcode_api_key_set ? "" : " (설정에서 API 키 저장)"}</option>
       </select>
     </label>}
+    <label className="flex items-center gap-2"><input type="checkbox" checked={value.vanilla} onChange={(event) => onChange({ ...value, vanilla: event.target.checked })} />바닐라 모드 · 개인 플러그인과 지침 제외</label>
+  </>;
+  return <fieldset disabled={disabled} className="space-y-2 text-xs disabled:opacity-60">
+    <legend className="sr-only">생성 모델과 추론 설정</legend>
     <div className="grid grid-cols-[minmax(0,1fr)_90px] gap-2">
       <label>모델<select aria-label="생성 모델" className={selectClass} value={value.model} onChange={(event) => onChange({ ...value, model: event.target.value, effort: "low" })}>
         <option value="">{model ? `기본 · ${models[0]?.label}` : "도구 기본 모델"}</option>
@@ -28,6 +31,9 @@ export default function GenerationControls({ backendId, value, onChange, disable
         {efforts.map((effort) => <option key={effort} value={effort}>{effort.toUpperCase()}</option>)}
       </select></label>
     </div>
-    <label className="flex items-center gap-2"><input type="checkbox" checked={value.vanilla} onChange={(event) => onChange({ ...value, vanilla: event.target.checked })} />바닐라 모드 · 개인 플러그인과 지침 제외</label>
+    {compact ? <details className="text-muted-foreground">
+      <summary className="cursor-pointer rounded py-1 text-[11px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">연결 및 추가 설정</summary>
+      <div className="mt-1 space-y-3 rounded-lg bg-muted/40 p-2.5">{secondary}</div>
+    </details> : secondary}
   </fieldset>;
 }

--- a/packages/frontend/src/views/ProjectView.tsx
+++ b/packages/frontend/src/views/ProjectView.tsx
@@ -149,6 +149,7 @@ export default function ProjectView() {
   }, []);
   const [activeTabId, setActiveTabId] = useState("design-system");
   const [mobilePane, setMobilePane] = useState<"workspace" | "chat">("workspace");
+  const [chatCollapsed, setChatCollapsed] = useState(false);
   const [openFileTabs, setOpenFileTabs] = useState<ArtifactTab[]>([]);
   const [canvasNavigation, setCanvasNavigation] = useState<{ projectId: string; relPath: string; url: string } | null>(null);
   const [mode, setMode] = useState<CanvasMode | null>(null);
@@ -181,6 +182,7 @@ export default function ProjectView() {
   const [autoFixPending, setAutoFixPending] = useState(false);
   const autoFixRef = useRef(false);
   const [chatFocusKey, setChatFocusKey] = useState(0);
+  useEffect(() => { if (chatFocusKey > 0) setChatCollapsed(false); }, [chatFocusKey]);
   const [directionActionError, setDirectionActionError] = useState<Error | null>(null);
   const activeTabIdRef = useRef(activeTabId);
   const openFileTabsRef = useRef<ArtifactTab[]>(openFileTabs);
@@ -1100,6 +1102,8 @@ export default function ProjectView() {
       {refreshError && <div role="alert" aria-label="작업 정보 새로고침 오류" className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-warning/30 bg-warning/10 px-4 py-2 text-sm"><span>최신 작업 정보를 불러오지 못했어요. 작성 중인 내용은 유지돼요.</span><button type="button" className="min-h-10 rounded-lg border border-border bg-background px-3 py-2 text-xs font-medium" onClick={() => { for (const query of loadQueries) if (query.isError) void query.refetch(); }}>작업 정보 다시 불러오기</button></div>}
       {stream.error && <div role="alert" className="flex items-center justify-between bg-warning/15 px-4 py-2 text-sm"><span>실시간 연결이 끊겼어요. 다시 연결하는 중이에요.</span><button type="button" className="rounded border px-3 py-2" onClick={stream.retry}>다시 연결</button></div>}
       <ProjectTopBar
+        chatCollapsed={chatCollapsed}
+        onToggleChat={() => setChatCollapsed((value) => !value)}
         project={project}
         canPresent={
           project.type === "slide_deck" &&
@@ -1130,7 +1134,7 @@ export default function ProjectView() {
         <button type="button" aria-pressed={mobilePane === "chat"} aria-controls="project-chat-pane" onClick={() => setMobilePane("chat")} className={cn("flex min-h-11 flex-1 items-center justify-center gap-2 rounded-lg text-sm font-medium", mobilePane === "chat" ? "bg-accent/10 text-accent" : "text-muted-foreground hover:bg-muted")}><MessageSquare className="h-4 w-4" aria-hidden="true" />AI 대화{session.status === "running" && <span className="h-2 w-2 rounded-full bg-accent" aria-label="AI 작업 중" />}</button>
       </div>
       <div className="flex min-h-0 flex-1 overflow-hidden">
-        <div id="project-chat-pane" className={cn("min-h-0 shrink-0 max-[900px]:flex-1", mobilePane !== "chat" && "max-[900px]:hidden")}>
+        <div id="project-chat-pane" className={cn("min-h-0 shrink-0 max-[900px]:flex-1", mobilePane !== "chat" && "max-[900px]:hidden", chatCollapsed && "min-[901px]:hidden")}>
         <ChatPane
           chatFocusKey={chatFocusKey}
           events={events}
@@ -1223,7 +1227,7 @@ export default function ProjectView() {
         )}
 
         {activeTab?.kind === "file" && (
-          <div className="flex min-h-0 min-w-0 flex-1 max-[1200px]:flex-col">
+          <div className="flex min-h-0 min-w-0 flex-1 max-[1000px]:flex-col">
             <Canvas
               colorPalette={activeRelPath && /\.html?$/i.test(activeRelPath) ? <ColorPalette
                 key={activeRelPath}

--- a/scripts/qa/windows-native-smoke.mjs
+++ b/scripts/qa/windows-native-smoke.mjs
@@ -62,7 +62,7 @@ try {
   await once(guard, "listening");
   checks.push("window-close-stops-owned-service-and-releases-port");
   await cp(receipt.screenshot, path.join(evidence, "native-window.png"));
-  const result = { ok: true, release, checks, webViewVersion: receipt.webViewVersion, dom: receipt.dom };
+  const result = { ok: true, release, checks, startupElapsedMs: receipt.startupElapsedMs, webViewVersion: receipt.webViewVersion, dom: receipt.dom };
   await writeFile(path.join(evidence, release ? "release-native-smoke.json" : "native-smoke.json"), JSON.stringify(result, null, 2));
   console.log(JSON.stringify(result));
 } catch (error) {
@@ -83,7 +83,7 @@ try {
 
 async function run(report) {
   child = spawn(path.join(app, release ? "current/BurnGuard.exe" : "BurnGuard.exe"), ["--smoke-test", "--smoke-report", report], { cwd: fixture, env, windowsHide: false, stdio: "ignore" });
-  const [code] = await bounded(once(child, "exit"), 120_000);
+  const [code] = await bounded(once(child, "exit"), 180_000);
   return code;
 }
 

--- a/scripts/qa/windows-native-smoke.mjs
+++ b/scripts/qa/windows-native-smoke.mjs
@@ -46,8 +46,10 @@ try {
   await new Promise((resolve) => guard.close(resolve));
   guard = null;
 
-  assert.equal(await run(report), 0, "real native smoke must exit successfully");
+  await rm(report, { force: true });
+  const nativeExit = await run(report);
   receipt = JSON.parse(await readFile(report, "utf8"));
+  assert.equal(nativeExit, 0, "real native smoke must exit successfully");
   assert.equal(receipt.ok, true);
   assert.equal(receipt.dom.origin, `http://127.0.0.1:${port}`);
   assert.equal(receipt.dom.modelSelected, true);


### PR DESCRIPTION
워크스페이스에서 여러 줄 도구막대와 생성 설정이 캔버스를 좁히던 문제를 정리했습니다. 도구막대를 한 줄로 줄이고 확대·이동은 아래로 옮겼으며, 대화 접기와 간결한 요소 크기 패널을 추가했습니다. 모델·추론 강도 선택은 계속 표시하고 연결·바닐라 설정은 접을 수 있습니다.

Daybreak 보안 검토에서 발견한 Vercel 공개 업로드의 비밀 파일명 누락을 수정했습니다. 모든 경로 세그먼트의 secret/token/API key/credential 이름을 차단하며, 최종 파일인 tokens.css만 디자인 토큰 예외로 유지합니다. Daybreak 소스 재검토에서 차단 이슈가 해소됐습니다. 릴리스 전 Daybreak 검토와 수정 재검증을 필수 절차로 문서화했습니다. 네이티브 진단 창은 숨기고, 재실행 시 이전 결과를 재사용하지 않도록 검사 기록도 정리했습니다.

검증: 타입 검사·lint·Windows 릴리스 빌드 통과. 프런트엔드 집중 검사 38개와 Vercel 검사 5개 통과. 격리된 헤드리스 브라우저에서 1280px 다크/1600px 라이트의 가로 넘침과 도구 한 줄, 모델·LOW 선택, 대화 접기 시 캔버스 340px 확장, 실제 40px 크기 조절을 확인했습니다. 사용자 프로필과 실행 중인 앱은 변경하지 않았습니다.

Windows 설치 파일은 기존 정책에 따라 서명되지 않은 프로토타입입니다. Vercel 실계정 게시 및 실제 유료 AI 요청은 검증 범위에 포함하지 않았습니다. 실제 공개 업데이트 적용은 릴리스 게시 후 별도 확인합니다.

Windows 첫 실행은 샘플·글꼴 준비를 안내하고 120초 안에 시작하도록 제한했습니다. 진단 결과에 시작 시간을 기록하여 시간 초과와 화면 초기화 실패를 구분합니다.

최종 검증: 실제 격리 네이티브 앱이 65.593초에 준비되어 WebView2 화면·모델 선택·LOW/바닐라와 종료 후 서버·포트 정리까지 통과했습니다. Daybreak가 최종 소스 2370431과 설치 파일·포터블·업데이트 패키지의 해시 및 포함 범위를 검토해 보안 게이트 PASS를 확인했습니다. GitHub Security CI 두 실행도 통과했습니다.
