### PR TITLE
feat(harness): visual craft rules and a default visual identity for every artifact type

### DIFF
--- a/packages/backend/src/adapters/claude-code/runner.ts
+++ b/packages/backend/src/adapters/claude-code/runner.ts
@@ -30,7 +30,7 @@ export interface RunnerResult {
 
 export function buildClaudeCommand(options: Pick<RunnerOptions, "binaryPath" | "generation">): string[] {
   return [options.binaryPath, "-p", "--output-format", "stream-json", "--verbose",
-    "--permission-mode", "acceptEdits", "--permission-prompts", "none",
+    "--permission-mode", "acceptEdits",
     "--effort", options.generation?.effort ?? "low",
     ...(options.generation?.model ? ["--model", options.generation.model] : []),
     ...(options.generation?.vanilla ? ["--safe-mode"] : []),

--- a/packages/backend/src/harness/prompt-builder.ts
+++ b/packages/backend/src/harness/prompt-builder.ts
@@ -10,6 +10,11 @@ import { getSqlite } from "../db/sqlite-client";
 import { DECK_SKILL_MD } from "./skills/deck-skill";
 import { DIAGRAM_SKILL_MD } from "./skills/diagram-skill";
 import { PROTOTYPE_NAVIGATION_CONTRACT, PROTOTYPE_SKILL_MD } from "./skills/prototype-skill";
+import {
+  DEFAULT_VISUAL_IDENTITY,
+  VISUAL_CRAFT_BY_TYPE,
+  VISUAL_CRAFT_CORE,
+} from "./skills/visual-craft-skill";
 import { appendAttachmentContext } from "./prompt-attachments";
 import {
   COMPACT_DECK_SKILL_MD,
@@ -261,6 +266,19 @@ export async function buildPrompt(
     lines.push("");
   }
 
+  const visualCraft = selectVisualCraft(project.project_type);
+  if (visualCraft !== null) {
+    lines.push("## Visual craft");
+    lines.push(VISUAL_CRAFT_CORE.trim());
+    lines.push(visualCraft.trim());
+    lines.push("");
+    if (!context.designSystem) {
+      lines.push("## Default visual identity");
+      lines.push(DEFAULT_VISUAL_IDENTITY.trim());
+      lines.push("");
+    }
+  }
+
   if (isDiagramRequest(userEvent.text)) {
     lines.push("## Diagram skill");
     lines.push(DIAGRAM_SKILL_MD.trim());
@@ -310,4 +328,15 @@ const DIAGRAM_REQUEST_PATTERN =
 
 function isDiagramRequest(request: string): boolean {
   return DIAGRAM_REQUEST_PATTERN.test(request);
+}
+
+function selectVisualCraft(projectType: SessionContext["project"]["project_type"]): string | null {
+  switch (projectType) {
+    case "prototype":
+    case "slide_deck":
+    case "graphic":
+      return VISUAL_CRAFT_BY_TYPE[projectType];
+    default:
+      return null;
+  }
 }

--- a/packages/backend/src/harness/prompt-compact-skills.ts
+++ b/packages/backend/src/harness/prompt-compact-skills.ts
@@ -27,5 +27,5 @@ export const COMPACT_PROTOTYPE_SKILL_MD = `# Prototype compact contract
 ## Structure & style
 - Keep \`index.html\` as home; each HTML page uses inline CSS and vanilla JS unless the user explicitly asks otherwise.
 - Top-level semantic sections need \`data-section\` and unique \`data-bg-node-id\` values for visible text and editable parent sections.
-- Strong visual hierarchy, asymmetric sections outside true heroes, responsive down to 360 px, no hidden primary value.
+- Strong visual hierarchy, asymmetric sections outside true heroes, responsive down to 320 px, no hidden primary value.
 - Keep CSS in one top \`<style>\` block. Reference design-system CSS variables (see list above) and avoid new palettes, font stacks, or typefaces.`;

--- a/packages/backend/src/harness/prompt-compact-skills.ts
+++ b/packages/backend/src/harness/prompt-compact-skills.ts
@@ -12,6 +12,9 @@ export const COMPACT_DECK_SKILL_MD = `# Slide deck compact contract
 - Preserve \`<script src="/runtime/deck-stage.js" defer></script>\`; do not set \`data-active\` statically or reimplement deck navigation.
 - Every visible text element needs a unique \`data-bg-node-id="slide-{N}-{purpose}"\`; parent slides use \`data-bg-node-id="slide-{N}"\`.
 
+## Projection scale
+- Declare and use \`--deck-type-hero: 80px; --deck-type-heading: 52px; --deck-type-body: 32px; --deck-type-caption: 24px; --deck-pad-slide: 72px; --deck-pad-block: 32px\`. Set \`.deck-slide { font-size: var(--deck-type-body) }\` so unstyled text inherits the scale; every other \`font-size\` is \`var(--deck-type-*)\` (or a \`calc()\` that scales one up), never a raw px value. At 1920x1080 no rendered text may be below \`24px\`; never shrink type or tighten spacing toward web density in self-review.
+
 ## Style
 - Use asymmetric layouts, oversized type or KPI numbers where useful, and avoid centered-everything except cover/closing slides.
 - Keep CSS inline in the top \`<style>\` block. Reference design-system CSS variables (see list above) and avoid new palettes, font stacks, or typefaces.`;

--- a/packages/backend/src/harness/skills/deck-skill.ts
+++ b/packages/backend/src/harness/skills/deck-skill.ts
@@ -58,6 +58,9 @@ export const DECK_SKILL_MD = `# Slide deck authoring conventions
 ## Projection scale
 
 - Declare and use \`--deck-type-hero: 80px; --deck-type-heading: 52px; --deck-type-body: 32px; --deck-type-caption: 24px\` and \`--deck-pad-slide: 72px; --deck-pad-block: 32px\`.
+- Set \`.deck-slide { font-size: var(--deck-type-body) }\` so unstyled text
+  inherits the scale; every other \`font-size\` is \`var(--deck-type-*)\` (or a
+  \`calc()\` that scales one up), never a raw px value.
 - At 1920x1080, no rendered text may be below \`24px\`.
 - In self-review, do not shrink type or tighten spacing toward web density.
   Projection readability wins.

--- a/packages/backend/src/harness/skills/diagram-skill.ts
+++ b/packages/backend/src/harness/skills/diagram-skill.ts
@@ -50,6 +50,26 @@ fewest marks. Do not combine types unless separate, titled panels are clearer.
 - Reference existing design-system tokens by CSS variable name with \`var(--...)\`.
   Do not hardcode colours, font families, or introduce a diagram palette.
 
+## DIAGRAM_VISUAL_CRAFT
+
+- Lay nodes on an 8px grid with equal gaps; align node edges in each lane and
+  keep every node the same height within a row.
+- Nodes: 8-12px corner radius, a tinted surface fill (accent or neutral at
+  8-14% opacity) with a 1px hairline stroke at 30-40% of the ink colour, 16-20px
+  inner padding, label 14-16px in the body face, weight 500. Decision nodes may
+  use a diamond or a pill; all other shapes stay rectangles.
+- Edges: 1.5px stroke in the muted ink colour, rounded joins, one arrowhead
+  style via a single \`<marker>\`; orthogonal or gently curved routes with 8px
+  clearance from nodes. Edge labels 12-13px on a small surface plate so they
+  never sit on the line.
+- Lanes and groups: a very light band (2-4% ink) with a 12-13px uppercase
+  tracked title in the corner; no heavy boxes around groups.
+- Emphasis: one accent for the main path or critical node; secondary paths in
+  neutrals; dashed strokes for optional or future links; add a compact legend
+  when more than one line style is used.
+- Title above the SVG at 20-24px with a one-line caption; keep 24px of
+  whitespace around the drawing.
+
 ## Anti-patterns
 
 - No decorative 3D, fake perspective, gradients that imply depth, or ornamental

--- a/packages/backend/src/harness/skills/visual-craft-skill.ts
+++ b/packages/backend/src/harness/skills/visual-craft-skill.ts
@@ -1,0 +1,180 @@
+/**
+ * Visual craft guidance injected by `prompt-builder.ts` for every artifact
+ * type, in both compact and full context modes. The per-type skills describe
+ * STRUCTURE (archetypes, node ids, runtime contracts); this module describes
+ * how the result must LOOK so generated output reads as senior-designer work
+ * instead of a template.
+ *
+ * Token ownership is unchanged: when a design system is selected its
+ * `colors_and_type.css` owns colour and type, and these rules only govern
+ * scale, rhythm, material, and composition. `DEFAULT_VISUAL_IDENTITY` ships
+ * only when no design system is selected and becomes the token source.
+ *
+ * Budget: `VISUAL_CRAFT_CORE` + one per-type block + `DEFAULT_VISUAL_IDENTITY`
+ * must stay within `MAX_VISUAL_CRAFT_CHARS`; the test pins it.
+ */
+export const MAX_VISUAL_CRAFT_CHARS = 6400;
+
+export const VISUAL_CRAFT_CORE = `# Visual craft (VISUAL_CRAFT_CORE)
+
+The bar is work a senior designer at Linear, Stripe, or Vercel would ship.
+Correct-but-flat is a failure. Structure rules say what goes where; these
+rules say how it must look. When a design system is selected, take colour
+and type from its tokens and apply everything else here.
+
+## Type
+- Two roles: display for headlines, body for text; mono for numbers and code.
+  Never show Arial, Helvetica, or system-ui as the visible face.
+- Display: weight 500-700, line-height 1.0-1.1, letter-spacing -0.02em to
+  -0.04em, sized with clamp() (hero 44-88px, section titles 32-56px). Body
+  16-18px, line-height 1.55-1.65, measure 55-70ch. \`text-wrap: balance\` on headings.
+- Headlines wrap in 3 lines or fewer: widen the container before shrinking type.
+- Eyebrows: 11-13px, uppercase, letter-spacing 0.14-0.2em, muted colour. Never
+  numbered filler ("SECTION 01", "STEP 1", "ABOUT US").
+- Tabular numerals for every metric; keep the unit beside the number.
+
+## Colour and material
+- One accent, on at most 3 elements per screen (primary CTA, one highlight,
+  one data mark). Everything else is neutrals from the token ramp.
+- Surfaces read as material, not outlines: hairlines at 6-10% of the ink
+  colour; shadows as two soft layers (0 1px 2px at 8% + 0 24px 48px at 6-10%),
+  never one hard grey shadow. No pure #000 on pure #FFF.
+- Nest featured frames: outer shell with 6-8px padding and a large radius,
+  inner core with radius minus that padding. Use it for hero media, the
+  featured card, and stage frames.
+- Give backgrounds depth with exactly one device per artifact: a large radial
+  glow of the accent at 10-20% opacity, a 1px grid at 4-6%, or paper grain.
+- Alternate a dark block against light blocks at least once so the artifact
+  has rhythm; the alternate band inverts surface and ink tokens.
+- Contrast: body 4.5:1 or better, large text 3:1; button text legible on its fill.
+
+## Space and rhythm
+- 8px spacing scale. Sections breathe: 96-160px vertical padding on desktop,
+  64-96px on mobile. Related items 8-16px apart, unrelated groups 48px or more.
+- 12-column grid, 24-32px gutters, content max-width 1200-1280px. Asymmetric
+  spans (7/5, 8/4) beat 6/6 outside heroes.
+- Grids never leave voids: every bento cell is filled; use fewer, larger cards
+  (3-5) rather than eight small ones.
+
+## Motion
+- Easing cubic-bezier(0.32, 0.72, 0, 1); 200-300ms for hover, 500-800ms for
+  reveals; transform and opacity only.
+- Hover: cards lift 2px and deepen their shadow, buttons shift fill, press
+  scales to 0.98. Nothing decorative moves.
+
+## Self-check before finishing
+Judge the render at 1280 and 375: no headline over 3 lines, no grid void, no
+stray accent, no default-blue link, no text under 12px, nothing clipped. If it
+still looks like a template, rework the hero and the type scale first.
+`;
+
+export const PROTOTYPE_VISUAL_CRAFT = `## Website craft (PROTOTYPE_VISUAL_CRAFT)
+
+- Navbar: a floating pill or thin bar detached 16-24px from the top, max-width
+  1200px, blur backdrop once scrolled, logo left, 3-5 links, one CTA. Never a
+  flat edge-to-edge grey bar.
+- Hero: h1 container at least 880px wide on desktop, 2-3 lines, subheadline
+  18-20px in 2 lines or fewer, one primary plus one ghost CTA. Pick one
+  architecture: cinematic centred over a lit field; editorial split with a
+  framed product stage; or an offset headline with an overlapping media card.
+- Product stage: build a believable interface in HTML/CSS (window chrome,
+  sidebar, rows, an SVG chart) or an inline SVG illustration inside a nested
+  frame. Never a grey placeholder box, never "image here", never a remote URL.
+- Pacing: each section changes at least one of background tone, column count,
+  or alignment from the previous one. No three look-alike card rows in a row.
+- Features: a bento with one 2x cell plus smaller cells, or alternating
+  media/text rows; 3-5 items, each with a 20-24px Lucide icon on a tinted disc.
+- Proof and stats: 48-72px display numbers with 12-13px labels; wordmarks
+  drawn as text at 60% opacity, never fabricated logos.
+- Pricing: the recommended tier lifted (larger, accent border, dark or accent
+  fill); other tiers quiet.
+- Footer: a dark or tinted band with 3-4 link columns and 12-13px legal text;
+  never a single grey line.
+- Mobile (375px): one column, hero type 36-44px, nav collapses to logo plus
+  CTA, cards full width, sections 64-80px padding, nothing that carries the
+  value hidden.
+`;
+
+export const DECK_VISUAL_CRAFT = `## Deck craft (DECK_VISUAL_CRAFT)
+
+- Every slide is a poster: one dominant element (headline, number, chart, or
+  image) and everything else supports it. Two competing elements means two slides.
+- Cover: full-bleed dark or accent field, title at --deck-type-hero with tight
+  tracking, eyebrow above, one line of context below, one background device.
+  The closing slide mirrors it.
+- Chrome on every content slide: running title top-left, slide number
+  bottom-right in mono, both at --deck-type-caption and muted; identical
+  --deck-pad-slide margins on all slides.
+- Bullets are the last resort: prefer two columns, a big number with a
+  one-sentence claim, a three-step row, or a labelled diagram. At most 4
+  bullets, each one line.
+- Big numbers: 120-200px in the display face and the accent colour, unit
+  attached, a 32px label, source caption below.
+- Charts: inline SVG with hairline axes, 2-3 series at most, the key series in
+  the accent and the rest in neutrals, direct labels instead of a legend, one
+  takeaway line above.
+- Rhythm: alternate dark and light slides at least once every 3-4 slides and
+  use one accent-field slide for the key claim.
+- Media and product mocks sit in nested frames with a soft shadow; never
+  stretched, never with a hard 1px black border.
+- Safe area: nothing inside --deck-pad-slide of the edge; verify no wrap pushes
+  content off the 16:9 artboard.
+`;
+
+export const GRAPHIC_VISUAL_CRAFT = `## Graphic craft (GRAPHIC_VISUAL_CRAFT)
+
+A single fixed artboard must read from across the room. Compose three layers:
+- Field: a background with depth (a mesh of 2-3 radial glows, a duotone
+  gradient, or a paper tone with 3-5% grain). Never flat default white.
+- Figure: one large element at 40-70% of the short side (an oversized number, a
+  typographic word, an SVG shape composition, or a framed product mock),
+  placed off-centre on a rule-of-thirds intersection.
+- Type: one headline at 8-14% of the artboard height in 3 lines or fewer with
+  tight tracking; one body line at 2-3%; optional eyebrow and small mark. Two
+  typefaces at most.
+- Margins: safe area 6-8% of the short side on every edge; only a deliberate
+  full-bleed figure crosses it.
+- Contrast: headline 7:1 or better against its local background; place text on
+  the calmest part of the field or on a translucent plate.
+- Format: portrait stacks figure above type; square centres the figure and
+  anchors type to the bottom; landscape splits 60/40.
+- Size in px relative to the artboard (or % of its width); no viewport units,
+  no scroll, no animation: the PNG export captures one static frame.
+`;
+
+export const DEFAULT_VISUAL_IDENTITY = `## Default visual identity (DEFAULT_VISUAL_IDENTITY)
+
+No design system is selected, so this identity is the design system. Declare
+these tokens in :root, link fonts/fonts.css (bundled, no CDN), and reference
+tokens everywhere. Do not invent other colours or typefaces.
+
+- Display voice, pick one from the content: product/tech "Space Grotesk";
+  editorial/premium "DM Serif Display" with "Gowun Batang" Korean fallback;
+  poster/impact "Bebas Neue". --font-body: "DM Sans", "Pretendard", sans-serif;
+  --font-mono: "IBM Plex Mono", "Pretendard", monospace; append "Pretendard" as
+  the fallback of --font-display.
+- Mode, pick one and keep it for the whole artifact:
+  Paper (calm, editorial): --bg:#F6F1E8 --surface:#FFFDF9 --surface-2:#EFE6D8
+  --ink:#18232D --ink-2:#52616C --ink-3:#8A949C --line:rgba(24,35,45,.10)
+  --accent:#C8512F --accent-ink:#FFF8F2 --accent-soft:rgba(200,81,47,.12)
+  Ink (bold, product, tech): --bg:#0B0D12 --surface:#141822 --surface-2:#1C2230
+  --ink:#F6F1E8 --ink-2:#B7B2A8 --ink-3:#7C7A74 --line:rgba(246,241,232,.10)
+  --accent:#E06B4C --accent-ink:#0B0D12 --accent-soft:rgba(224,107,76,.16)
+- Data accent only for charts: --accent-2:#2F6FDB (Paper) or #7DB4FF (Ink).
+  Status: --ok:#1F8A5B --warn:#B7791F --danger:#C0392B, always paired with
+  text or an icon.
+- Scale: --space-1..8 = 4 8 16 24 32 48 64 96px; --radius-s:8px
+  --radius-m:16px --radius-l:28px --radius-pill:999px.
+- Material: --shadow-1: 0 1px 2px rgba(0,0,0,.08); --shadow-2: 0 24px 48px
+  rgba(0,0,0,.10) (Ink: .35); borders 1px solid var(--line).
+- Motion: --ease: cubic-bezier(.32,.72,0,1); --dur-fast:200ms; --dur-slow:600ms.
+- Usage: --bg on body, --surface for cards, --surface-2 for the alternate band,
+  --accent on the primary CTA and one highlight only. The alternate band may
+  switch mode (a dark band on Paper) by using the other mode's values.
+`;
+
+export const VISUAL_CRAFT_BY_TYPE = {
+  prototype: PROTOTYPE_VISUAL_CRAFT,
+  slide_deck: DECK_VISUAL_CRAFT,
+  graphic: GRAPHIC_VISUAL_CRAFT,
+} as const;

--- a/packages/backend/src/harness/skills/visual-craft-skill.ts
+++ b/packages/backend/src/harness/skills/visual-craft-skill.ts
@@ -29,7 +29,7 @@ and type from its tokens and apply everything else here.
   -0.04em, sized with clamp() (hero 44-88px, section titles 32-56px). Body
   16-18px, line-height 1.55-1.65, measure 55-70ch. \`text-wrap: balance\` on headings.
 - Headlines wrap in 3 lines or fewer: widen the container before shrinking type.
-- Eyebrows: 11-13px, uppercase, letter-spacing 0.14-0.2em, muted colour. Never
+- Eyebrows: 12-13px, uppercase, letter-spacing 0.14-0.2em, muted colour. Never
   numbered filler ("SECTION 01", "STEP 1", "ABOUT US").
 - Tabular numerals for every metric; keep the unit beside the number.
 
@@ -53,8 +53,9 @@ and type from its tokens and apply everything else here.
   64-96px on mobile. Related items 8-16px apart, unrelated groups 48px or more.
 - 12-column grid, 24-32px gutters, content max-width 1200-1280px. Asymmetric
   spans (7/5, 8/4) beat 6/6 outside heroes.
-- Grids never leave voids: every bento cell is filled; use fewer, larger cards
-  (3-5) rather than eight small ones.
+- Grids never leave voids: every bento cell is filled and no row ends with an
+  orphan card (5 items = one 2x cell + 4, or rows of 2 + 3); use fewer, larger
+  cards (3-5) rather than eight small ones.
 
 ## Motion
 - Easing cubic-bezier(0.32, 0.72, 0, 1); 200-300ms for hover, 500-800ms for
@@ -64,8 +65,7 @@ and type from its tokens and apply everything else here.
 
 ## Self-check before finishing
 Judge the render at 1280 and 375: no headline over 3 lines, no grid void, no
-stray accent, no default-blue link, no text under 12px, nothing clipped. If it
-still looks like a template, rework the hero and the type scale first.
+stray accent, no default-blue link, no text under 12px, nothing clipped.
 `;
 
 export const PROTOTYPE_VISUAL_CRAFT = `## Website craft (PROTOTYPE_VISUAL_CRAFT)
@@ -97,28 +97,29 @@ export const PROTOTYPE_VISUAL_CRAFT = `## Website craft (PROTOTYPE_VISUAL_CRAFT)
 
 export const DECK_VISUAL_CRAFT = `## Deck craft (DECK_VISUAL_CRAFT)
 
+- Use the deck skill's projection tokens at their declared values for every
+  text element; never lower them in self-review. Eyebrows, chrome, captions
+  and chart labels are --deck-type-caption (24px), nothing smaller.
 - Every slide is a poster: one dominant element (headline, number, chart, or
-  image) and everything else supports it. Two competing elements means two slides.
-- Cover: full-bleed dark or accent field, title at --deck-type-hero with tight
-  tracking, eyebrow above, one line of context below, one background device.
-  The closing slide mirrors it.
-- Chrome on every content slide: running title top-left, slide number
-  bottom-right in mono, both at --deck-type-caption and muted; identical
-  --deck-pad-slide margins on all slides.
-- Bullets are the last resort: prefer two columns, a big number with a
-  one-sentence claim, a three-step row, or a labelled diagram. At most 4
-  bullets, each one line.
-- Big numbers: 120-200px in the display face and the accent colour, unit
-  attached, a 32px label, source caption below.
-- Charts: inline SVG with hairline axes, 2-3 series at most, the key series in
-  the accent and the rest in neutrals, direct labels instead of a legend, one
-  takeaway line above.
-- Rhythm: alternate dark and light slides at least once every 3-4 slides and
-  use one accent-field slide for the key claim.
-- Media and product mocks sit in nested frames with a soft shadow; never
-  stretched, never with a hard 1px black border.
-- Safe area: nothing inside --deck-pad-slide of the edge; verify no wrap pushes
-  content off the 16:9 artboard.
+  image) and everything else supports it. Two competing elements means two
+  slides. The dominant element spans at least half the slide width or height
+  and the composition fills 60-80% of the height; a small cluster floating in
+  an empty slide is web density, not projection.
+- Cover: full-bleed dark or accent field, --deck-type-hero title with tight
+  tracking, eyebrow above, one context line below, one background device;
+  the closing slide mirrors it.
+- Chrome on content slides: running title top-left in the margin, mono slide
+  number bottom-right, both muted; eyebrows and badges sit in the content
+  area below the chrome, never in the same corner, never under 24px.
+- Bullets are the last resort: prefer two columns, a big number with one
+  claim, a three-step row, or a labelled diagram. At most 4 one-line bullets.
+- Big numbers: 280-400px (a third of the slide height) in the display face and
+  the accent colour, unit attached, a --deck-type-body label, caption below.
+- Charts: inline SVG filling its column (at least 40% of the slide width),
+  hairline axes, 2-3 series, key series in the accent, direct labels at
+  --deck-type-caption instead of a legend, one takeaway line above.
+- Media and mocks sit in nested frames with a soft shadow; never stretched.
+- Safe area: nothing inside --deck-pad-slide of the edge or off the artboard.
 `;
 
 export const GRAPHIC_VISUAL_CRAFT = `## Graphic craft (GRAPHIC_VISUAL_CRAFT)

--- a/packages/backend/tests/generation-options.test.ts
+++ b/packages/backend/tests/generation-options.test.ts
@@ -47,6 +47,12 @@ test("Given CommandCode selection When building Claude invocation Then native se
   expect(command.join(" ")).not.toContain(config.commandcodeApiKey);
 });
 
+test("Given the installed Claude CLI option set When building the command Then no unknown permission flag is passed", () => {
+  const command = buildClaudeCommand({ binaryPath: "claude", generation: undefined });
+  expect(command).not.toContain("--permission-prompts");
+  expect(command.slice(command.indexOf("--permission-mode"), command.indexOf("--permission-mode") + 2)).toEqual(["--permission-mode", "acceptEdits"]);
+});
+
 test("Given initial graphic HTML When provider leaves it unchanged Then publication fails while existing image-backed edits remain valid", () => {
   const starter = '<p data-bg-node-id="graphic-copy">Start with one clear visual message.</p>';
   expect(() => assertGraphicStarterReplaced(starter, starter)).toThrow("graphic_starter_unchanged");

--- a/packages/backend/tests/visual-craft-skill.test.ts
+++ b/packages/backend/tests/visual-craft-skill.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+import { buildPrompt, MAX_SKILL_CHARS } from "../src/harness/prompt-builder";
+import { COMPACT_PROTOTYPE_SKILL_MD } from "../src/harness/prompt-compact-skills";
+import { DIAGRAM_SKILL_MD } from "../src/harness/skills/diagram-skill";
+import {
+  DECK_VISUAL_CRAFT,
+  DEFAULT_VISUAL_IDENTITY,
+  GRAPHIC_VISUAL_CRAFT,
+  MAX_VISUAL_CRAFT_CHARS,
+  PROTOTYPE_VISUAL_CRAFT,
+  VISUAL_CRAFT_CORE,
+} from "../src/harness/skills/visual-craft-skill";
+
+type BuildContext = Parameters<typeof buildPrompt>[0];
+type ProjectType = BuildContext["project"]["project_type"];
+
+const TYPE_SENTINELS: Record<string, string> = {
+  prototype: "PROTOTYPE_VISUAL_CRAFT",
+  slide_deck: "DECK_VISUAL_CRAFT",
+  graphic: "GRAPHIC_VISUAL_CRAFT",
+};
+
+function makeContext(
+  projectType: ProjectType,
+  designSystem: BuildContext["designSystem"] = null,
+): BuildContext {
+  return {
+    project: {
+      project_id: `visual-${projectType}`,
+      project_name: "Visual craft test",
+      project_type: projectType,
+      entrypoint: projectType === "slide_deck" ? "deck.html" : "index.html",
+      project_dir: `/missing/visual-${projectType}`,
+      options_json: projectType === "graphic"
+        ? JSON.stringify({ graphic_canvas: { width: 1080, height: 1350 } })
+        : null,
+    },
+    files: [],
+    attachments: [],
+    designSystem,
+    openComments: [],
+  } as BuildContext;
+}
+
+const FAKE_DESIGN_SYSTEM = {
+  name: "Northvale",
+  dir_path: "/missing/ds",
+  skill_md_path: null,
+  tokens_css_path: null,
+  readme_md_path: null,
+} as unknown as NonNullable<BuildContext["designSystem"]>;
+
+describe("visual craft skill", () => {
+  test("ships the core and the matching per-type craft block in both context modes", async () => {
+    for (const projectType of ["prototype", "slide_deck", "graphic"] as const) {
+      for (const contextMode of ["full", "compact"] as const) {
+        const prompt = await buildPrompt(
+          makeContext(projectType),
+          { type: "user.message", text: "Build it" },
+          { contextMode },
+        );
+        expect(prompt).toContain("## Visual craft");
+        expect(prompt).toContain("VISUAL_CRAFT_CORE");
+        for (const [type, sentinel] of Object.entries(TYPE_SENTINELS)) {
+          if (type === projectType) {
+            expect(prompt).toContain(sentinel);
+          } else {
+            expect(prompt).not.toContain(sentinel);
+          }
+        }
+      }
+    }
+  });
+
+  test("injects the default visual identity only when no design system is selected", async () => {
+    for (const contextMode of ["full", "compact"] as const) {
+      const bare = await buildPrompt(
+        makeContext("prototype"),
+        { type: "user.message", text: "Build it" },
+        { contextMode },
+      );
+      expect(bare).toContain("## Default visual identity");
+      expect(bare).toContain("DEFAULT_VISUAL_IDENTITY");
+
+      const branded = await buildPrompt(
+        makeContext("prototype", FAKE_DESIGN_SYSTEM),
+        { type: "user.message", text: "Build it" },
+        { contextMode },
+      );
+      expect(branded).not.toContain("DEFAULT_VISUAL_IDENTITY");
+    }
+  });
+
+  test("keeps every visual block inside the per-turn budget", () => {
+    const blocks = [
+      VISUAL_CRAFT_CORE,
+      PROTOTYPE_VISUAL_CRAFT,
+      DECK_VISUAL_CRAFT,
+      GRAPHIC_VISUAL_CRAFT,
+      DEFAULT_VISUAL_IDENTITY,
+    ];
+    for (const block of blocks) {
+      expect(block.length).toBeLessThanOrEqual(MAX_SKILL_CHARS);
+    }
+    const largestPerType = Math.max(
+      PROTOTYPE_VISUAL_CRAFT.length,
+      DECK_VISUAL_CRAFT.length,
+      GRAPHIC_VISUAL_CRAFT.length,
+    );
+    expect(
+      VISUAL_CRAFT_CORE.length + largestPerType + DEFAULT_VISUAL_IDENTITY.length,
+    ).toBeLessThanOrEqual(MAX_VISUAL_CRAFT_CHARS);
+  });
+
+  test("diagram skill carries its visual craft section within budget", () => {
+    expect(DIAGRAM_SKILL_MD).toContain("DIAGRAM_VISUAL_CRAFT");
+    expect(DIAGRAM_SKILL_MD.length).toBeLessThanOrEqual(MAX_SKILL_CHARS);
+  });
+
+  test("compact prototype skill uses the WCAG 320 px reflow floor", () => {
+    expect(COMPACT_PROTOTYPE_SKILL_MD).toContain("320");
+    expect(COMPACT_PROTOTYPE_SKILL_MD).not.toContain("360 px");
+  });
+});

--- a/packages/backend/tests/visual-craft-skill.test.ts
+++ b/packages/backend/tests/visual-craft-skill.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { buildPrompt, MAX_SKILL_CHARS } from "../src/harness/prompt-builder";
-import { COMPACT_PROTOTYPE_SKILL_MD } from "../src/harness/prompt-compact-skills";
+import { COMPACT_DECK_SKILL_MD, COMPACT_PROTOTYPE_SKILL_MD } from "../src/harness/prompt-compact-skills";
+import { DECK_SKILL_MD } from "../src/harness/skills/deck-skill";
 import { DIAGRAM_SKILL_MD } from "../src/harness/skills/diagram-skill";
 import {
   DECK_VISUAL_CRAFT,
@@ -110,6 +111,20 @@ describe("visual craft skill", () => {
     expect(
       VISUAL_CRAFT_CORE.length + largestPerType + DEFAULT_VISUAL_IDENTITY.length,
     ).toBeLessThanOrEqual(MAX_VISUAL_CRAFT_CHARS);
+  });
+
+  test("compact deck skill ships the same projection scale as the full skill", () => {
+    for (const declaration of [
+      "--deck-type-hero: 80px",
+      "--deck-type-heading: 52px",
+      "--deck-type-body: 32px",
+      "--deck-type-caption: 24px",
+      "--deck-pad-slide: 72px",
+    ]) {
+      expect(COMPACT_DECK_SKILL_MD).toContain(declaration);
+      expect(DECK_SKILL_MD).toContain(declaration);
+    }
+    expect(DECK_VISUAL_CRAFT).toContain("--deck-type-caption");
   });
 
   test("diagram skill carries its visual craft section within budget", () => {


### PR DESCRIPTION
## Summary

Generated prototypes, decks, graphics and diagrams read as generic AI output because the per-type skills only describe STRUCTURE (archetypes, node ids, runtime contracts) and nothing describes how the result must LOOK. When no design system is selected, no visual guidance is injected at all, the default `compact` context mode ships thinner skills, and the `graphic` type had no skill.

This PR adds a visual-craft layer to every artifact type and a concrete default visual identity, then tunes it against real generations.

### Changes
- **`packages/backend/src/harness/skills/visual-craft-skill.ts`** (new): `VISUAL_CRAFT_CORE` (type scale/tracking, 3-line headline rule, meta-label ban, single accent, material/shadow/nested-frame rules, background depth device, dark/light rhythm, 8px scale + section padding, 12-col asymmetric grid, no bento voids, easing/hover physics, self-check), per-type blocks `PROTOTYPE_VISUAL_CRAFT` / `DECK_VISUAL_CRAFT` / `GRAPHIC_VISUAL_CRAFT`, and `DEFAULT_VISUAL_IDENTITY` (bundled fonts with three display voices, Paper/Ink `:root` token sets, spacing/radius/shadow/motion tokens). Budgeted by `MAX_VISUAL_CRAFT_CHARS`.
- **`prompt-builder.ts`**: injects `## Visual craft` (core + per-type) for prototype, slide_deck and graphic in both compact and full modes, and `## Default visual identity` only when no design system is selected.
- **`diagram-skill.ts`**: `DIAGRAM_VISUAL_CRAFT` (node/edge/lane/label/legend styling) within the skill budget.
- **`deck-skill.ts` / `prompt-compact-skills.ts`**: the compact deck skill now ships the same projection scale as the full skill; every deck `font-size` must go through `--deck-type-*` with `.deck-slide` inheriting `--deck-type-body`; compact prototype floor 360 px -> 320 px (WCAG 1.4.10).
- **`adapters/claude-code/runner.ts`**: drop `--permission-prompts none` — the installed Claude CLI (2.1.226) rejects it as an unknown option, so every claude-code turn exited 1 before reading the prompt.
- Tests: `tests/visual-craft-skill.test.ts` (sentinels per type/mode, identity gating, budgets, deck token declarations, 320 px), plus a pin in `generation-options.test.ts`.

### Real-surface verification (no design system, default Sonnet / LOW / vanilla, compact mode)
- Prototype via claude-code: pill nav, editorial split hero with an HTML/CSS product mock, H1 3 lines at 1280 and 375, Paper tokens, dark proof band, lifted pricing tier, glowing CTA, 4-column footer; no meta labels; no horizontal overflow at 375.
- Deck via claude-code (after 6 rule iterations): `--deck-type-*` declared and used (26 token font-sizes), min rendered text 24 px on all six slides, zero text collisions, content slides fill 64-71% of the height.
- Graphic via codex: single artboard, paper field with grain, tilted invoice-card figure over an accent disc, 112 px three-line headline, safe margins.

### Tests
- Harness/adapter test files: green. Typecheck: 0.
- Full suite: 1113 pass / 24 fail; the failing names match the clean-HEAD baseline (load-dependent process-tree / watcher / thumbnail / fonts flakes); the only differing name passes 3/3 in isolation.

### Notes
- Output still varies run to run; the mechanical deck rules (token-only font sizes, inherited base size) were what made the 24 px floor hold.
- Diagram rules are verified at the prompt level only.
