### PR TITLE
fix(mac): start the packaged app anywhere, finish exports through the Node bridge, and repair /private path handling

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.13.0
       - run: bun install --frozen-lockfile
       - name: Verify tagged version
         run: |
@@ -27,6 +30,8 @@ jobs:
       - run: bun test packages/backend/tests/mac-updates.test.ts packages/backend/tests/app-update-routes.test.ts --timeout 30000
       # Signing/notarization stay off until BG_MAC_* secrets exist; unsigned packages are for verification only.
       - run: bun run build:mac:release
+      - name: Verify the bundled Node renderer runtime
+        run: test -x "dist/mac/BurnGuard Design.app/Contents/MacOS/resources/node/node"
       - uses: actions/upload-artifact@v4
         with:
           name: BurnGuard-macOS

--- a/doc/13-windows-updates-and-original-samples.md
+++ b/doc/13-windows-updates-and-original-samples.md
@@ -26,14 +26,14 @@ No tag or public release is created by the local build script. Package signing i
 
 ## macOS packaging and updates
 
-macOS packages use the same Velopack tool and the same GitHub release. Build on macOS with Bun 1.3.14 and the .NET 8 SDK:
+macOS packages use the same Velopack tool and the same GitHub release. Build on macOS with Bun 1.3.14, Node 24 (an official nodejs.org build; a Homebrew Node is skipped because it is not relocatable) and the .NET 8 SDK:
 
 ```bash
 bun install --frozen-lockfile
 bun run build:mac:release
 ```
 
-`dist/releases/` then contains `BurnGuard-osx-Setup.pkg`, `BurnGuard-osx-Portable.zip`, the full `.nupkg`, the `releases.osx.json` feed, and SHA256 sums. The packed bundle is `BurnGuard.app` with `Contents/MacOS/UpdateMac` beside the engine; only that bundle can update itself. The bundle also carries the native canvas binding and PDF.js under `Contents/MacOS/node_modules`, which thumbnails, PNG export and PDF rasterization need. The plain `dist/mac/BurnGuard Design.app` and the DMG are development builds without an updater.
+`dist/releases/` then contains `BurnGuard-osx-Setup.pkg`, `BurnGuard-osx-Portable.zip`, the full `.nupkg`, the `releases.osx.json` feed, and SHA256 sums. The packed bundle is `BurnGuard.app` with `Contents/MacOS/UpdateMac` beside the engine; only that bundle can update itself. The bundle also carries the native canvas binding and PDF.js under `Contents/MacOS/node_modules`, which thumbnails, PNG export and PDF rasterization need, and a Node runtime under `Contents/MacOS/resources/node` that owns headless Chromium for thumbnails, exports and audits: as on Windows, Playwright's in-process launch under Bun stalls on macOS. The plain `dist/mac/BurnGuard Design.app` and the DMG are development builds without an updater.
 
 The **macOS release package** workflow runs on the same `v*` tag as the Windows workflow and attaches its assets to the same draft release (whichever job finishes first creates the draft). Publish the draft with both `releases.win.json` and `releases.osx.json` attached. Signing and notarization run when `BG_MAC_SIGN_IDENTITY`, `BG_MAC_INSTALL_IDENTITY` and `BG_MAC_NOTARY_PROFILE` are configured; unsigned packages are for verification only and Gatekeeper will warn on first launch.
 

--- a/packages/backend/src/security/path-boundary.ts
+++ b/packages/backend/src/security/path-boundary.ts
@@ -122,8 +122,14 @@ export function resolveWithin(root: string, ...segments: string[]): string {
 
   // macOS exposes temporary directories through both `/var` and its
   // canonical `/private/var` spelling. Preserve the public path spelling
-  // callers used while retaining the realpath-based containment check.
-  if (process.platform === "darwin" && resolved.startsWith("/private/")) {
+  // callers used while retaining the realpath-based containment check. A
+  // root the caller already spelled under `/private/` keeps that spelling:
+  // stripping it there would move the result out of the caller's root.
+  if (
+    process.platform === "darwin" &&
+    resolved.startsWith("/private/") &&
+    !path.resolve(root).startsWith("/private/")
+  ) {
     return resolved.slice("/private".length);
   }
   return resolved;

--- a/packages/backend/src/services/chromium-capability.ts
+++ b/packages/backend/src/services/chromium-capability.ts
@@ -145,7 +145,7 @@ export async function spawnLaunchProbe(node = chromiumNodeCommand(), timeoutMs =
 }
 
 export async function runChromiumProbeProcess(): Promise<never> {
-  const { chromium } = await import("playwright-core");
+  const { chromium } = await import("./playwright-runtime");
   for (const options of [{ headless: true }, { headless: true, channel: "chrome" }, { headless: true, channel: "msedge" }]) {
     try { const browser = await chromium.launch(options); await browser.close(); process.stdout.write("usable"); process.exit(0); } catch {}
   }

--- a/packages/backend/src/services/chromium-node-launch.ts
+++ b/packages/backend/src/services/chromium-node-launch.ts
@@ -1,7 +1,8 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { chromium, type Browser } from "playwright-core";
+import type { Browser } from "playwright-core";
+import { chromium } from "./playwright-runtime";
 import { resolveRepoRoot } from "../lib/paths";
 import { registerExportBrowser } from "./export-browser-registry";
 import { closeOwnedProcessTree, ownedProcessSpawnOptions } from "../adapters/owned-process-tree";

--- a/packages/backend/src/services/export-render-session.ts
+++ b/packages/backend/src/services/export-render-session.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath, pathToFileURL } from "node:url";
 import path from "node:path";
-import { chromium, type Browser, type BrowserContext, type Page } from "playwright-core";
+import type { Browser, BrowserContext, Page } from "playwright-core";
+import { chromium } from "./playwright-runtime";
 import { resolveWithin } from "../security/path-boundary";
 import { isChromiumLaunchable } from "./chromium-capability";
 import { registerExportBrowser } from "./export-browser-registry";

--- a/packages/backend/src/services/export-render-session.ts
+++ b/packages/backend/src/services/export-render-session.ts
@@ -53,14 +53,14 @@ export async function openRenderSession(input: { readonly stagedDir: string; rea
   }
 }
 
-/** Some hosts (Bun on Windows) start Chromium but never complete the Playwright handshake, so every attempt is capped. */
+/** Bun's in-process launch (seen on Windows and macOS) can start Chromium yet never complete the Playwright handshake or resolve browser.close(), so every attempt is capped. */
 export const CHROMIUM_LAUNCH_TIMEOUT_MS = 20_000;
 type ChromiumLaunchAttempt = { readonly headless: true; readonly channel?: string };
 export type ChromiumLauncher = (options: ChromiumLaunchAttempt) => Promise<Browser>;
 type LaunchOutcome = { readonly kind: "browser"; readonly browser: Browser } | { readonly kind: "failed"; readonly error: unknown } | { readonly kind: "timeout" } | { readonly kind: "aborted" };
 const LAUNCH_ATTEMPTS: readonly ChromiumLaunchAttempt[] = [{ headless: true }, { headless: true, channel: "chrome" }, { headless: true, channel: "msedge" }];
 
-export async function launchChromium(signal: AbortSignal, launch: ChromiumLauncher = (options) => process.platform === "win32" && chromiumNodeCommand() !== null ? launchChromiumViaNode(options, signal) : chromium.launch(options)): Promise<Browser> {
+export async function launchChromium(signal: AbortSignal, launch: ChromiumLauncher = (options) => chromiumNodeCommand() !== null ? launchChromiumViaNode(options, signal) : chromium.launch(options)): Promise<Browser> {
   // A launch that never completes its handshake blocks the Bun event loop, so
   // the in-process attempt below would freeze every other request and even the
   // timer meant to cap it. The child-process probe answers that question

--- a/packages/backend/src/services/playwright-install.ts
+++ b/packages/backend/src/services/playwright-install.ts
@@ -2,9 +2,9 @@ import { stat } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import type { PlaywrightInstallStatus } from "@bg/shared";
-import { resolveRepoRoot } from "../lib/paths";
 import { chromiumNodeCommand } from "./chromium-node-launch";
 import { resetChromiumCapability } from "./chromium-capability";
+import { playwrightCoreDirectory } from "./playwright-runtime";
 
 const MAX_TAIL = 120;
 
@@ -32,7 +32,7 @@ let probe: Promise<void> | null = null;
 function probeChromiumOnDisk(): Promise<void> {
   probe ??= (async () => {
     try {
-      const { chromium } = await import("playwright-core");
+      const { chromium } = await import("./playwright-runtime");
       chromiumOnDisk = (await stat(chromium.executablePath())).isFile();
     } catch {
       chromiumOnDisk = false;
@@ -126,8 +126,7 @@ export function startPlaywrightInstall(): { started: boolean } {
 export function playwrightInstallCommand(): string[] {
   const node = chromiumNodeCommand()?.node;
   if (node === undefined) throw new Error("Browser installer runtime is unavailable");
-  const packagedCli = path.join(resolveRepoRoot(), "node_modules", "playwright-core", "cli.js");
-  const cli = existsSync(packagedCli) ? packagedCli : path.join(path.dirname(Bun.resolveSync("playwright-core/package.json", import.meta.dir)), "cli.js");
+  const cli = path.join(playwrightCoreDirectory(), "cli.js");
   if (!existsSync(cli)) throw new Error("Browser installer is unavailable");
   return [node, cli, "install", "chromium"];
 }

--- a/packages/backend/src/services/playwright-runtime.ts
+++ b/packages/backend/src/services/playwright-runtime.ts
@@ -1,0 +1,21 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import type { chromium as ChromiumType } from "playwright-core";
+import { resolveRepoRoot } from "../lib/paths";
+
+/**
+ * playwright-core resolves its own package.json while it loads
+ * (lib/server/utils/nodePlatform.js: require.resolve("../../../package.json")).
+ * Bun's --compile rewrites that call to the build machine's absolute path, so a
+ * bundled copy throws on every other machine before the server listens. The
+ * package therefore stays out of the bundle (--external) and is loaded from the
+ * real file tree: the staged copy under resources/node_modules in a package,
+ * the workspace copy in development. Same pattern as export-native-modules.ts.
+ */
+const runtimeRequire = createRequire(path.join(resolveRepoRoot(), "packages/backend/package.json"));
+
+export function playwrightCoreDirectory(): string {
+  return path.dirname(runtimeRequire.resolve("playwright-core/package.json"));
+}
+
+export const { chromium } = runtimeRequire("playwright-core") as { readonly chromium: typeof ChromiumType };

--- a/packages/backend/tests/path-boundary.test.ts
+++ b/packages/backend/tests/path-boundary.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   mkdirSync,
   mkdtempSync,
+  realpathSync,
   rmSync,
   symlinkSync,
 } from "node:fs";
@@ -44,6 +45,18 @@ describe("resolveWithin", () => {
     mkdirSync(child);
 
     expect(resolveWithin(root, "child")).toBe(child);
+  });
+
+  test("keeps a root spelled under macOS /private when resolving below it", () => {
+    if (process.platform !== "darwin") return;
+    // Given: the canonical spelling of a temporary root, as realpath() returns it.
+    const root = realpathSync(makeTempDir("bg-path-root-"));
+    expect(root.startsWith("/private/")).toBe(true);
+    mkdirSync(path.join(root, "child"));
+
+    // When / Then: the result stays inside the root the caller passed.
+    expect(resolveWithin(root, "child")).toBe(path.join(root, "child"));
+    expect(resolveWithin(root, "new", "artifact.zip")).toBe(path.join(root, "new", "artifact.zip"));
   });
 
   test("rejects parent traversal", () => {

--- a/scripts/build-binary.ts
+++ b/scripts/build-binary.ts
@@ -33,12 +33,16 @@ async function main() {
   // --external electron/chromium-bidi: playwright-core imports both in
   // optional loaders we never hit (we only drive headless chromium).
   // Without the flags bun fails to resolve those optional modules at compile.
+  // --external playwright-core: it resolves its own package.json at load time,
+  // which --compile would bake as this machine's absolute path; the runtime
+  // loader in services/playwright-runtime.ts reads the staged copy instead.
   await $`bun build ${ENTRY} \
     --compile \
     --target=bun-windows-x64 \
     --minify \
     --external electron \
     --external chromium-bidi \
+    --external playwright-core \
     --external @napi-rs/canvas \
     --external pdfjs-dist \
     --outfile ${OUT}`.cwd(ROOT);

--- a/scripts/build-mac.ts
+++ b/scripts/build-mac.ts
@@ -148,13 +148,13 @@ async function main() {
     );
   }
 
-  await stageRuntimeAssets(ROOT, APP_MACOS);
+  await stageRuntimeAssets(ROOT, APP_MACOS, true);
   const swiftc = Bun.which("swiftc");
   if (!swiftc) throw new Error("swiftc is required to build the native macOS window.");
   const sdk = (await $`xcrun --sdk macosx --show-sdk-path`.cwd(ROOT).text()).trim();
   await $`${swiftc} -O -swift-version 5 -target arm64-apple-macos14.0 -sdk ${sdk} -framework AppKit -framework WebKit ${NATIVE_ENTRY} -o ${binOut}`.cwd(ROOT);
   chmodSync(binOut, 0o755);
-  console.log("[build-mac] frontend, migrations, themes, browser resources, and native window staged");
+  console.log("[build-mac] frontend, migrations, themes, browser resources, Node renderer runtime, and native window staged");
 
   const signIdentity = process.env.BG_MAC_SIGN_IDENTITY;
   if (signIdentity) {

--- a/scripts/build-mac.ts
+++ b/scripts/build-mac.ts
@@ -112,12 +112,16 @@ async function main() {
   // turns the import into a null resolution that throws only if
   // the loader is ever actually called — which it isn't in our
   // code path.
+  // `--external playwright-core`: it resolves its own package.json at
+  // load time and --compile would bake this machine's absolute path into
+  // the binary; services/playwright-runtime.ts loads the staged copy instead.
   await $`bun build ${ENTRY} \
     --compile \
     --target=bun-darwin-arm64 \
     --minify \
     --external electron \
     --external chromium-bidi \
+    --external playwright-core \
     --outfile ${serviceOut}`.cwd(ROOT);
   console.log(
     `[build-mac] compiled in ${((Date.now() - startCompile) / 1000).toFixed(1)}s`,

--- a/scripts/package-runtime.ts
+++ b/scripts/package-runtime.ts
@@ -1,4 +1,4 @@
-import { cp, copyFile, lstat, mkdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { chmod, cp, copyFile, lstat, mkdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { APP_NAME, APP_VERSION } from "../packages/shared/src/app";
 import { nativeModulePackages } from "../packages/backend/src/services/native-binding";
@@ -12,7 +12,7 @@ export function isRuntimeSource(relativePath: string): boolean {
 }
 
 /** The resource folder is the portable app's data source, never its user-data folder. */
-export async function stageRuntimeAssets(repoRoot: string, outputDirectory: string, includeWindowsNode = false): Promise<string> {
+export async function stageRuntimeAssets(repoRoot: string, outputDirectory: string, includeNode = false): Promise<string> {
   await mkdir(outputDirectory, { recursive: true });
   const destinationParent = await realpath(outputDirectory);
   const resources = path.join(destinationParent, "resources");
@@ -59,10 +59,10 @@ export async function stageRuntimeAssets(repoRoot: string, outputDirectory: stri
   const threeEntry = Bun.resolveSync("three", path.join(repoRoot, "packages/frontend"));
   await copyFile(path.resolve(path.dirname(threeEntry), "../LICENSE"), path.join(threeDirectory, "LICENSE"));
   let nodeVersion: string | null = null;
-  if (includeWindowsNode) {
-    if (process.platform !== "win32") throw new Error("Windows portable packaging requires a Windows Node runtime");
-    const node = Bun.which("node");
-    if (!node) throw new Error("Node is required to package the Windows browser renderer");
+  // The packaged app drives Chromium from a Node child (chromium-node-bridge.mjs) because
+  // Bun's in-process Playwright launch stalls on Windows and macOS.
+  const node = includeNode ? await packagableNode() : null;
+  if (node !== null) {
     const versionProbe = Bun.spawn([node, "--version"], { stdout: "pipe", stderr: "pipe" });
     const versionDeadline = setTimeout(() => versionProbe.kill(), 10_000);
     const [exitCode, version] = await Promise.all([versionProbe.exited, new Response(versionProbe.stdout).text(), new Response(versionProbe.stderr).text()]).finally(() => clearTimeout(versionDeadline));
@@ -82,9 +82,39 @@ export async function stageRuntimeAssets(repoRoot: string, outputDirectory: stri
     }
     if (!license.includes("Node.js") || !license.includes("Permission is hereby granted")) throw new Error("Invalid cached Node redistribution license");
     await mkdir(path.join(resources, "node"));
-    await copyFile(node, path.join(resources, "node/node.exe"));
+    const target = path.join(resources, "node", process.platform === "win32" ? "node.exe" : "node");
+    await copyFile(node, target);
+    if (process.platform !== "win32") await chmod(target, 0o755);
     await writeFile(path.join(resources, "node/LICENSE"), license);
   }
   await writeFile(path.join(resources, "burnguard-runtime.json"), JSON.stringify({ schema_version: 1, name: APP_NAME, version: APP_VERSION, nodeVersion, sourceFiles: files }, null, 2));
   return resources;
+}
+
+/**
+ * The Node binary to ship, or null when this build cannot carry one. Windows requires it.
+ * On macOS a Homebrew node links Homebrew dylibs (@rpath, /opt/homebrew) and would not run on
+ * another machine, so only a self-contained build (nodejs.org, actions/setup-node) is staged;
+ * without one the app falls back to a Node on the user's PATH at runtime.
+ */
+async function packagableNode(): Promise<string | null> {
+  if (process.platform !== "win32" && process.platform !== "darwin") throw new Error("Portable packaging with a Node runtime supports Windows and macOS only");
+  const node = Bun.which("node");
+  if (!node) {
+    if (process.platform === "win32") throw new Error("Node is required to package the Windows browser renderer");
+    console.warn("[package] no Node on PATH: the macOS bundle will use the user's Node for Chromium rendering");
+    return null;
+  }
+  if (process.platform === "darwin") {
+    const otool = Bun.spawn(["otool", "-L", node], { stdout: "pipe", stderr: "pipe" });
+    const deadline = setTimeout(() => otool.kill(), 10_000);
+    const [exitCode, listing] = await Promise.all([otool.exited, new Response(otool.stdout).text(), new Response(otool.stderr).text()]).finally(() => clearTimeout(deadline));
+    if (exitCode !== 0) throw new Error("Could not inspect the Node runtime's linked libraries");
+    const foreign = listing.split("\n").slice(1).map((line) => line.trim().split(" ")[0] ?? "").filter((library) => library !== "" && !library.startsWith("/usr/lib/") && !library.startsWith("/System/"));
+    if (foreign.length > 0) {
+      console.warn(`[package] ${node} links ${foreign.length} non-system libraries and is not relocatable; the macOS bundle will use the user's Node for Chromium rendering`);
+      return null;
+    }
+  }
+  return node;
 }


### PR DESCRIPTION
## Summary

Three fixes from the macOS native-app verification on 2026-09-09, one commit each.

### 1. P0 — published macOS apps crash at launch (`fix(build)`)
`BurnGuard-osx-Portable.zip` from v0.5.2 and v0.5.3 exits immediately with
`Cannot find module '/Users/runner/work/BurnGuard/.../playwright-core/package.json'`.
playwright-core resolves its own `package.json` while loading (`lib/server/utils/nodePlatform.js`), and `bun build --compile` bakes that `require.resolve()` into the build machine's absolute path. Because `export-render-session.ts` / `chromium-node-launch.ts` import it statically, the app dies before it listens.

Fix: `--external playwright-core` on both compile targets and a `services/playwright-runtime.ts` loader (`createRequire` anchored at the resource tree, same pattern as `export-native-modules.ts`). Packages read `resources/node_modules/playwright-core`, dev reads the workspace copy.

### 2. macOS exports never finish (`fix(render)`)
Every export (png/pdf/pptx/html_zip) stayed at `rendering 2/6`, a Chrome child leaked per attempt, and SIGTERM shutdown hung. Playwright's protocol log shows Chrome closing cleanly while Bun's in-process `browser.close()` never resolves; other runs never complete the launch handshake. Windows already avoids this through the Node bridge (`chromium-node-bridge.mjs`), but `launchChromium()` only used it on win32.

Fix: use the Node bridge wherever a Node runtime exists; stage Node into the macOS bundle (`resources/node/node` + LICENSE, `nodeVersion` in `burnguard-runtime.json`) like the Windows package does. A Homebrew Node links `/opt/homebrew` dylibs and is not relocatable, so packaging checks with `otool` and skips it (app then falls back to PATH Node); the release workflow installs Node 24.13.0 via `actions/setup-node` and fails if the bundle lacks it.

### 3. macOS test infrastructure broken by `/private` handling (`fix(security)`)
`resolveWithin` stripped `/private` from every resolved path on darwin. When the root itself was spelled `/private/...` (what `realpath()`, `bun test` tmpdirs and the QA harness produce), the result left the caller's root: `EACCES: mkdir '/private/var/folders/<x>/var'` in tests and `Canonical tree does not match its receipt` at startup for any `BG_APP_ROOT` under `/private`. Only strip when the caller's root does not carry the prefix; darwin regression test added.

## Verification (macOS arm64, Bun 1.3.14)

- `bun run typecheck`, `bun run lint`: pass.
- Fix 1: fresh `.app` contains no build-tree path (`strings`), and starts + serves `/api/health` with the repository `node_modules` renamed away (the exact v0.5.2/v0.5.3 failure condition).
- Fix 2: packaged app built with official Node 24.13.0 on PATH → `resources/node/node` present, `otool -L` shows 0 non-system libraries. Against that app: png (903 980 B), pdf (8.47 MB), pptx, html_zip exports of the VELUNE samples all `succeeded` in 3–6 s with valid downloads; thumbnails 200 image/png; 0 Chrome / bridge processes left; SIGTERM shutdown in 11 ms. `BG_BROWSER_SMOKE=1 bun test chromium-node-launch.test.ts`: 3/3.
- Fix 3: `path-boundary.test.ts` 28/28; the previously failing `review-artifact-concurrency`, `review-turn-execution`, `original-samples`, `project-thumbnails` cases now pass on macOS.
- Full `bun test` on this branch (macOS): **1168 pass / 8 fail**, up from 1114 / 23 on the same host before fix 3. All 8 remaining failures reproduce on `origin/main` or on the fix-3-only commit and are unrelated to these changes:
  - `qa-harness` preflight/manifest (2), `attachments service` symlinked `.attachments`, `daisyui-seed-themes` token contract, `serve-path-boundary` legacy export (assertion drift / missing built frontend) — identical on `origin/main`.
  - `graphic-export` "PNG IHDR statistics" fails with `missing_asset: fonts/fonts.css` before any render; on `origin/main` this file never ran (its `beforeAll` died on the `/private` EACCES), and the fix-3-only commit shows the same failure, so fix 3 unmasked it. Follow-up.
  - `attachment-pdf` / `attachment-pdf-intake` (2) fail only in the full run and pass in isolation (order-dependent).

## Not covered here
- The public GitHub feed update path was rehearsed locally (0.5.3 → 0.5.9 via loopback `BG_UPDATE_FEED_URL`: check → SHA-256 verified download → apply → `UpdateMac` swap → relaunch on the same port); a real GitHub-feed update needs the next tagged release built from this branch.
- Windows CI exe is compiled the same way and likely had the same baked path; fix 1 covers it but was not run on Windows here.
- Signing/notarization remain off (no `BG_MAC_*` secrets).

Ultraworked with [omo](https://github.com/code-yeongyu/oh-my-openagent)
