### PR TITLE
fix(mac): host BurnGuard in a native WKWebView window

### DIFF
--- a/packages/backend/src/harness/skills/visual-craft-skill.ts
+++ b/packages/backend/src/harness/skills/visual-craft-skill.ts
@@ -29,7 +29,7 @@ and type from its tokens and apply everything else here.
   -0.04em, sized with clamp() (hero 44-88px, section titles 32-56px). Body
   16-18px, line-height 1.55-1.65, measure 55-70ch. \`text-wrap: balance\` on headings.
 - Headlines wrap in 3 lines or fewer: widen the container before shrinking type.
-- Eyebrows: 12-13px, uppercase, letter-spacing 0.14-0.2em, muted colour. Never
+- Eyebrows: 11-13px, uppercase, letter-spacing 0.14-0.2em, muted colour. Never
   numbered filler ("SECTION 01", "STEP 1", "ABOUT US").
 - Tabular numerals for every metric; keep the unit beside the number.
 
@@ -53,9 +53,8 @@ and type from its tokens and apply everything else here.
   64-96px on mobile. Related items 8-16px apart, unrelated groups 48px or more.
 - 12-column grid, 24-32px gutters, content max-width 1200-1280px. Asymmetric
   spans (7/5, 8/4) beat 6/6 outside heroes.
-- Grids never leave voids: every bento cell is filled and no row ends with an
-  orphan card (5 items = one 2x cell + 4, or rows of 2 + 3); use fewer, larger
-  cards (3-5) rather than eight small ones.
+- Grids never leave voids: every bento cell is filled; use fewer, larger cards
+  (3-5) rather than eight small ones.
 
 ## Motion
 - Easing cubic-bezier(0.32, 0.72, 0, 1); 200-300ms for hover, 500-800ms for
@@ -65,7 +64,8 @@ and type from its tokens and apply everything else here.
 
 ## Self-check before finishing
 Judge the render at 1280 and 375: no headline over 3 lines, no grid void, no
-stray accent, no default-blue link, no text under 12px, nothing clipped.
+stray accent, no default-blue link, no text under 12px, nothing clipped. If it
+still looks like a template, rework the hero and the type scale first.
 `;
 
 export const PROTOTYPE_VISUAL_CRAFT = `## Website craft (PROTOTYPE_VISUAL_CRAFT)
@@ -97,29 +97,28 @@ export const PROTOTYPE_VISUAL_CRAFT = `## Website craft (PROTOTYPE_VISUAL_CRAFT)
 
 export const DECK_VISUAL_CRAFT = `## Deck craft (DECK_VISUAL_CRAFT)
 
-- Use the deck skill's projection tokens at their declared values for every
-  text element; never lower them in self-review. Eyebrows, chrome, captions
-  and chart labels are --deck-type-caption (24px), nothing smaller.
 - Every slide is a poster: one dominant element (headline, number, chart, or
-  image) and everything else supports it. Two competing elements means two
-  slides. The dominant element spans at least half the slide width or height
-  and the composition fills 60-80% of the height; a small cluster floating in
-  an empty slide is web density, not projection.
-- Cover: full-bleed dark or accent field, --deck-type-hero title with tight
-  tracking, eyebrow above, one context line below, one background device;
-  the closing slide mirrors it.
-- Chrome on content slides: running title top-left in the margin, mono slide
-  number bottom-right, both muted; eyebrows and badges sit in the content
-  area below the chrome, never in the same corner, never under 24px.
-- Bullets are the last resort: prefer two columns, a big number with one
-  claim, a three-step row, or a labelled diagram. At most 4 one-line bullets.
-- Big numbers: 280-400px (a third of the slide height) in the display face and
-  the accent colour, unit attached, a --deck-type-body label, caption below.
-- Charts: inline SVG filling its column (at least 40% of the slide width),
-  hairline axes, 2-3 series, key series in the accent, direct labels at
-  --deck-type-caption instead of a legend, one takeaway line above.
-- Media and mocks sit in nested frames with a soft shadow; never stretched.
-- Safe area: nothing inside --deck-pad-slide of the edge or off the artboard.
+  image) and everything else supports it. Two competing elements means two slides.
+- Cover: full-bleed dark or accent field, title at --deck-type-hero with tight
+  tracking, eyebrow above, one line of context below, one background device.
+  The closing slide mirrors it.
+- Chrome on every content slide: running title top-left, slide number
+  bottom-right in mono, both at --deck-type-caption and muted; identical
+  --deck-pad-slide margins on all slides.
+- Bullets are the last resort: prefer two columns, a big number with a
+  one-sentence claim, a three-step row, or a labelled diagram. At most 4
+  bullets, each one line.
+- Big numbers: 120-200px in the display face and the accent colour, unit
+  attached, a 32px label, source caption below.
+- Charts: inline SVG with hairline axes, 2-3 series at most, the key series in
+  the accent and the rest in neutrals, direct labels instead of a legend, one
+  takeaway line above.
+- Rhythm: alternate dark and light slides at least once every 3-4 slides and
+  use one accent-field slide for the key claim.
+- Media and product mocks sit in nested frames with a soft shadow; never
+  stretched, never with a hard 1px black border.
+- Safe area: nothing inside --deck-pad-slide of the edge; verify no wrap pushes
+  content off the 16:9 artboard.
 `;
 
 export const GRAPHIC_VISUAL_CRAFT = `## Graphic craft (GRAPHIC_VISUAL_CRAFT)

--- a/packages/backend/src/harness/skills/visual-craft-skill.ts
+++ b/packages/backend/src/harness/skills/visual-craft-skill.ts
@@ -29,7 +29,7 @@ and type from its tokens and apply everything else here.
   -0.04em, sized with clamp() (hero 44-88px, section titles 32-56px). Body
   16-18px, line-height 1.55-1.65, measure 55-70ch. \`text-wrap: balance\` on headings.
 - Headlines wrap in 3 lines or fewer: widen the container before shrinking type.
-- Eyebrows: 11-13px, uppercase, letter-spacing 0.14-0.2em, muted colour. Never
+- Eyebrows: 12-13px, uppercase, letter-spacing 0.14-0.2em, muted colour. Never
   numbered filler ("SECTION 01", "STEP 1", "ABOUT US").
 - Tabular numerals for every metric; keep the unit beside the number.
 
@@ -53,8 +53,9 @@ and type from its tokens and apply everything else here.
   64-96px on mobile. Related items 8-16px apart, unrelated groups 48px or more.
 - 12-column grid, 24-32px gutters, content max-width 1200-1280px. Asymmetric
   spans (7/5, 8/4) beat 6/6 outside heroes.
-- Grids never leave voids: every bento cell is filled; use fewer, larger cards
-  (3-5) rather than eight small ones.
+- Grids never leave voids: every bento cell is filled and no row ends with an
+  orphan card (5 items = one 2x cell + 4, or rows of 2 + 3); use fewer, larger
+  cards (3-5) rather than eight small ones.
 
 ## Motion
 - Easing cubic-bezier(0.32, 0.72, 0, 1); 200-300ms for hover, 500-800ms for
@@ -64,8 +65,7 @@ and type from its tokens and apply everything else here.
 
 ## Self-check before finishing
 Judge the render at 1280 and 375: no headline over 3 lines, no grid void, no
-stray accent, no default-blue link, no text under 12px, nothing clipped. If it
-still looks like a template, rework the hero and the type scale first.
+stray accent, no default-blue link, no text under 12px, nothing clipped.
 `;
 
 export const PROTOTYPE_VISUAL_CRAFT = `## Website craft (PROTOTYPE_VISUAL_CRAFT)
@@ -97,28 +97,29 @@ export const PROTOTYPE_VISUAL_CRAFT = `## Website craft (PROTOTYPE_VISUAL_CRAFT)
 
 export const DECK_VISUAL_CRAFT = `## Deck craft (DECK_VISUAL_CRAFT)
 
+- Use the deck skill's projection tokens at their declared values for every
+  text element; never lower them in self-review. Eyebrows, chrome, captions
+  and chart labels are --deck-type-caption (24px), nothing smaller.
 - Every slide is a poster: one dominant element (headline, number, chart, or
-  image) and everything else supports it. Two competing elements means two slides.
-- Cover: full-bleed dark or accent field, title at --deck-type-hero with tight
-  tracking, eyebrow above, one line of context below, one background device.
-  The closing slide mirrors it.
-- Chrome on every content slide: running title top-left, slide number
-  bottom-right in mono, both at --deck-type-caption and muted; identical
-  --deck-pad-slide margins on all slides.
-- Bullets are the last resort: prefer two columns, a big number with a
-  one-sentence claim, a three-step row, or a labelled diagram. At most 4
-  bullets, each one line.
-- Big numbers: 120-200px in the display face and the accent colour, unit
-  attached, a 32px label, source caption below.
-- Charts: inline SVG with hairline axes, 2-3 series at most, the key series in
-  the accent and the rest in neutrals, direct labels instead of a legend, one
-  takeaway line above.
-- Rhythm: alternate dark and light slides at least once every 3-4 slides and
-  use one accent-field slide for the key claim.
-- Media and product mocks sit in nested frames with a soft shadow; never
-  stretched, never with a hard 1px black border.
-- Safe area: nothing inside --deck-pad-slide of the edge; verify no wrap pushes
-  content off the 16:9 artboard.
+  image) and everything else supports it. Two competing elements means two
+  slides. The dominant element spans at least half the slide width or height
+  and the composition fills 60-80% of the height; a small cluster floating in
+  an empty slide is web density, not projection.
+- Cover: full-bleed dark or accent field, --deck-type-hero title with tight
+  tracking, eyebrow above, one context line below, one background device;
+  the closing slide mirrors it.
+- Chrome on content slides: running title top-left in the margin, mono slide
+  number bottom-right, both muted; eyebrows and badges sit in the content
+  area below the chrome, never in the same corner, never under 24px.
+- Bullets are the last resort: prefer two columns, a big number with one
+  claim, a three-step row, or a labelled diagram. At most 4 one-line bullets.
+- Big numbers: 280-400px (a third of the slide height) in the display face and
+  the accent colour, unit attached, a --deck-type-body label, caption below.
+- Charts: inline SVG filling its column (at least 40% of the slide width),
+  hairline axes, 2-3 series, key series in the accent, direct labels at
+  --deck-type-caption instead of a legend, one takeaway line above.
+- Media and mocks sit in nested frames with a soft shadow; never stretched.
+- Safe area: nothing inside --deck-pad-slide of the edge or off the artboard.
 `;
 
 export const GRAPHIC_VISUAL_CRAFT = `## Graphic craft (GRAPHIC_VISUAL_CRAFT)

--- a/packages/backend/src/lib/browser.ts
+++ b/packages/backend/src/lib/browser.ts
@@ -14,7 +14,7 @@ type BrowserLauncher = (command: readonly string[]) => void;
 
 /** Cross-platform "open URL in default browser". */
 export function openBrowser(url: string, launch?: BrowserLauncher): void {
-  if (process.env.BG_NO_OPEN === "1") return;
+  if (process.env.BG_NO_OPEN === "1" || process.env.BG_DESKTOP === "1") return;
 
   try {
     const command = browserOpenCommand(process.platform, url);

--- a/packages/backend/src/services/project-thumbnails.ts
+++ b/packages/backend/src/services/project-thumbnails.ts
@@ -132,6 +132,10 @@ async function loadProjectThumbnailUncapped(
   const cached = await readThumbnailFile(cachePath);
   if (cached !== null) return { kind: "ready", bytes: cached, etag: `"${identity}"` };
 
+  if (process.env.BG_THUMBNAIL_CACHE_ONLY === "1") {
+    return { kind: "unavailable", code: "thumbnail_unavailable" };
+  }
+
   if (Date.now() < chromiumUnavailableUntil) return { kind: "unavailable", code: "thumbnail_unavailable" };
 
   // Never start an in-process launch before the child-process probe says a

--- a/packages/backend/tests/project-thumbnails.test.ts
+++ b/packages/backend/tests/project-thumbnails.test.ts
@@ -223,6 +223,25 @@ describe("project thumbnail generation and cache", () => {
     expect(await cachedFiles(project.dirPath)).toEqual([`${projectThumbnailIdentity({ id: project.id, current_revision: 3, current_digest: digestA }) ?? ""}.png`]);
   });
 
+  test("Given cache-only desktop mode When a thumbnail is uncached Then it returns the fallback without probing or rendering", async () => {
+    const previous = process.env.BG_THUMBNAIL_CACHE_ONLY;
+    process.env.BG_THUMBNAIL_CACHE_ONLY = "1";
+    try {
+      const project = await createProject({ digest: digestA });
+      const { renderer, requests } = recordingRenderer();
+
+      await expect(loadProjectThumbnail(project.id, renderer)).resolves.toEqual({
+        kind: "unavailable",
+        code: "thumbnail_unavailable",
+      });
+      expect(requests).toEqual([]);
+      expect(await cachedFiles(project.dirPath)).toEqual([]);
+    } finally {
+      if (previous === undefined) delete process.env.BG_THUMBNAIL_CACHE_ONLY;
+      else process.env.BG_THUMBNAIL_CACHE_ONLY = previous;
+    }
+  });
+
   test("Given concurrent cold-cache requests for one project When both miss Then a single render serves both", async () => {
     const project = await createProject({ digest: digestA });
     const outputPaths: string[] = [];

--- a/packages/backend/tests/qa-harness.test.ts
+++ b/packages/backend/tests/qa-harness.test.ts
@@ -181,6 +181,23 @@ describe("browser auto-open characterization", () => {
     else process.env.BG_NO_OPEN = previousNoOpen;
   });
 
+  test("Given desktop mode When openBrowser is called Then no external browser starts", () => {
+    const previousDesktop = process.env.BG_DESKTOP;
+    const previousNoOpen = process.env.BG_NO_OPEN;
+    process.env.BG_DESKTOP = "1";
+    delete process.env.BG_NO_OPEN;
+    let launches = 0;
+    try {
+      openBrowser("http://127.0.0.1:14079", () => { launches += 1; });
+      expect(launches).toBe(0);
+    } finally {
+      if (previousDesktop === undefined) delete process.env.BG_DESKTOP;
+      else process.env.BG_DESKTOP = previousDesktop;
+      if (previousNoOpen === undefined) delete process.env.BG_NO_OPEN;
+      else process.env.BG_NO_OPEN = previousNoOpen;
+    }
+  });
+
   test("Given auto-open enabled When openBrowser is called Then the native opener is launched", () => {
     // Given: auto-open enabled and an injected launcher.
     const previousNoOpen = process.env.BG_NO_OPEN;

--- a/packages/desktop-mac/main.swift
+++ b/packages/desktop-mac/main.swift
@@ -1,0 +1,279 @@
+import AppKit
+import Foundation
+import WebKit
+
+private let smokeTestArguments = ["--smoke-test", "--smoke-report"]
+
+final class BurnGuardAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNavigationDelegate {
+    private var window: NSWindow!
+    private var webView: WKWebView!
+    private var service: Process?
+    private var serviceInput: Pipe?
+    private var serviceOutput: Pipe?
+    private var outputBuffer = Data()
+    private var origin: URL?
+    private var smokeReportPath: String?
+    private var closing = false
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        do {
+            smokeReportPath = try parseArguments()
+            try createWindow()
+            try startService()
+        } catch {
+            fail(error.localizedDescription)
+        }
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        false
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        if closing {
+            return .terminateNow
+        }
+        shutdown()
+        return .terminateLater
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        shutdown()
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        guard let url = navigationAction.request.url, isAppURL(url) else {
+            decisionHandler(.cancel)
+            return
+        }
+        decisionHandler(.allow)
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        guard smokeReportPath != nil else { return }
+        webView.callAsyncJavaScript(
+            """
+            const ready = () => {
+                const root = document.getElementById("root");
+                return root && root.innerText.trim().length >= 40;
+            };
+            if (ready()) {
+                return {title: document.title, bodyTextLength: document.body?.innerText?.length ?? 0};
+            }
+            return await new Promise((resolve, reject) => {
+                const observer = new MutationObserver(() => {
+                    if (!ready()) return;
+                    observer.disconnect();
+                    resolve({title: document.title, bodyTextLength: document.body?.innerText?.length ?? 0});
+                });
+                observer.observe(document.documentElement, {subtree: true, childList: true, characterData: true});
+                window.setTimeout(() => {
+                    observer.disconnect();
+                    reject(new Error("BurnGuard 기본 화면이 준비되지 않았습니다."));
+                }, 60000);
+            });
+            """,
+            arguments: [:],
+            in: nil,
+            in: .page
+        ) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let value):
+                guard let values = value as? [String: Any] else {
+                    self.fail("BurnGuard 화면 상태를 확인할 수 없습니다.")
+                    return
+                }
+                let pageTitle = values["title"] as? String ?? ""
+                let bodyTextLength = values["bodyTextLength"] as? Int ?? 0
+                guard let reportPath = self.smokeReportPath else { return }
+                self.writeReport([
+                    "nativeWindowVisible": self.window.isVisible,
+                    "windowTitle": self.window.title,
+                    "pageTitle": pageTitle,
+                    "bodyTextLength": bodyTextLength,
+                    "backendUrl": self.origin?.absoluteString ?? "",
+                ], to: reportPath)
+                self.shutdown()
+            case .failure(let error):
+                self.fail(error.localizedDescription)
+            }
+        }
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFail navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        fail("BurnGuard 화면을 불러오지 못했습니다: \(error.localizedDescription)")
+    }
+
+    private func parseArguments() throws -> String? {
+        let arguments = Array(CommandLine.arguments.dropFirst())
+        if arguments.isEmpty {
+            return nil
+        }
+        guard arguments.count == 3, Array(arguments.prefix(2)) == smokeTestArguments else {
+            throw NSError(domain: "BurnGuard", code: 1, userInfo: [NSLocalizedDescriptionKey: "Supported diagnostic arguments: --smoke-test --smoke-report <absolute JSON path>."])
+        }
+        guard arguments[2].hasPrefix("/") else {
+            throw NSError(domain: "BurnGuard", code: 1, userInfo: [NSLocalizedDescriptionKey: "The native smoke report path must be absolute."])
+        }
+        return arguments[2]
+    }
+
+    private func createWindow() throws {
+        NSApp.setActivationPolicy(.regular)
+        let configuration = WKWebViewConfiguration()
+        webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = self
+
+        window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1280, height: 850),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "BurnGuard Design"
+        window.minSize = NSSize(width: 900, height: 640)
+        window.center()
+        window.contentView = webView
+        window.delegate = self
+        window.isReleasedWhenClosed = false
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func startService() throws {
+        let serviceURL = Bundle.main.bundleURL
+            .appendingPathComponent("Contents/MacOS/burnguard-design")
+        guard FileManager.default.isExecutableFile(atPath: serviceURL.path) else {
+            throw NSError(domain: "BurnGuard", code: 1, userInfo: [NSLocalizedDescriptionKey: "Contents/MacOS/service/burnguard-service is missing or not executable."])
+        }
+
+        let input = Pipe()
+        let output = Pipe()
+        let errorOutput = Pipe()
+        let process = Process()
+        var environment = ProcessInfo.processInfo.environment
+        environment["BG_DESKTOP"] = "1"
+        environment["BG_NO_OPEN"] = "1"
+        environment["BG_THUMBNAIL_CACHE_ONLY"] = "1"
+        if environment["BG_PORT"] == nil {
+            environment["BG_PORT"] = "14070"
+        }
+        process.executableURL = serviceURL
+        process.standardInput = input
+        process.standardOutput = output
+        process.standardError = errorOutput
+        process.environment = environment
+        service = process
+        serviceInput = input
+        serviceOutput = output
+
+        output.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            DispatchQueue.main.async { self?.consumeServiceOutput(data) }
+        }
+        errorOutput.fileHandleForReading.readabilityHandler = { handle in
+            _ = handle.availableData
+        }
+        process.terminationHandler = { [weak self] process in
+            DispatchQueue.main.async {
+                guard let self, !self.closing else { return }
+                self.fail("BurnGuard 서버가 종료되었습니다 (code \(process.terminationStatus)).")
+            }
+        }
+        try process.run()
+    }
+
+    private func consumeServiceOutput(_ data: Data) {
+        outputBuffer.append(data)
+        while let newline = outputBuffer.firstIndex(of: 10) {
+            let lineData = outputBuffer.prefix(upTo: newline)
+            outputBuffer.removeSubrange(...newline)
+            guard let line = String(data: lineData, encoding: .utf8),
+                  line.hasPrefix("[burnguard-desktop] ") else { continue }
+            let json = String(line.dropFirst("[burnguard-desktop] ".count))
+            guard let data = json.data(using: .utf8),
+                  let message = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let protocolVersion = message["protocol"] as? Int,
+                  protocolVersion == 1,
+                  let urlString = message["url"] as? String,
+                  let url = URL(string: urlString) else {
+                fail("BurnGuard 시작 응답을 확인할 수 없습니다.")
+                return
+            }
+            origin = url
+            webView.load(URLRequest(url: url))
+        }
+    }
+
+    private func isAppURL(_ url: URL) -> Bool {
+        guard let origin, let host = url.host, let originHost = origin.host else {
+            return false
+        }
+        return url.scheme == origin.scheme &&
+            host == originHost &&
+            url.port == origin.port &&
+            url.user == nil
+    }
+
+    private func writeReport(_ report: [String: Any], to path: String) {
+        guard let data = try? JSONSerialization.data(withJSONObject: report, options: [.prettyPrinted]) else {
+            fail("네이티브 smoke 결과를 직렬화할 수 없습니다.")
+            return
+        }
+        do {
+            try data.write(to: URL(fileURLWithPath: path), options: .atomic)
+        } catch {
+            fail("네이티브 smoke 결과를 기록할 수 없습니다: \(error.localizedDescription)")
+        }
+    }
+
+    private func fail(_ message: String) {
+        if let reportPath = smokeReportPath {
+            writeReport([
+                "nativeWindowVisible": window?.isVisible ?? false,
+                "windowTitle": window?.title ?? "",
+                "pageTitle": "",
+                "bodyTextLength": 0,
+                "backendUrl": origin?.absoluteString ?? "",
+                "error": message,
+            ], to: reportPath)
+        } else {
+            let alert = NSAlert()
+            alert.messageText = "BurnGuard"
+            alert.informativeText = message
+            alert.alertStyle = .warning
+            alert.runModal()
+        }
+        shutdown()
+    }
+
+    private func shutdown() {
+        guard !closing else { return }
+        closing = true
+        serviceOutput?.fileHandleForReading.readabilityHandler = nil
+        serviceInput?.fileHandleForWriting.write(Data("shutdown\n".utf8))
+        serviceInput?.fileHandleForWriting.closeFile()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+            guard let self else { return }
+            if self.service?.isRunning == true {
+                self.service?.terminate()
+            }
+            NSApp.terminate(nil)
+        }
+    }
+}
+
+let application = NSApplication.shared
+let delegate = BurnGuardAppDelegate()
+application.delegate = delegate
+application.run()

--- a/scripts/build-mac.ts
+++ b/scripts/build-mac.ts
@@ -3,11 +3,8 @@
  * macOS build (P3.10): produces a .app bundle under `dist/mac/` and,
  * when run ON macOS, packages it into a .dmg under `dist/`.
  *
- * The Bun compile step is cross-platform: `--target=bun-darwin-arm64`
- * works on Windows too. The .app wrapper is pure file ops so it also
- * works anywhere. Only the final `hdiutil create` step needs to run
- * on macOS — on other platforms the script skips it and logs the
- * manual command to run locally.
+ * The Bun compile step can target darwin from another platform, but the
+ * AppKit/WKWebView shell is compiled on macOS with the local SDK.
  *
  * Call paths:
  *   - `bun run build:mac`         → binary + .app
@@ -35,8 +32,10 @@ const APP_BUNDLE = path.join(MAC_DIR, `${APP_NAME}.app`);
 const APP_CONTENTS = path.join(APP_BUNDLE, "Contents");
 const APP_MACOS = path.join(APP_CONTENTS, "MacOS");
 const APP_RESOURCES = path.join(APP_CONTENTS, "Resources");
-const BIN_NAME = "burnguard-design";
+const BIN_NAME = "BurnGuard";
+const SERVICE_BIN_NAME = "burnguard-design";
 const ENTRY = path.join(ROOT, "packages/backend/src/index.ts");
+const NATIVE_ENTRY = path.join(ROOT, "packages/desktop-mac/main.swift");
 const FRONTEND_DIST = path.join(ROOT, "packages/frontend/dist");
 const ICON_SRC = path.join(ROOT, "assets/icon.icns");
 const DMG_OUT = path.join(
@@ -65,9 +64,14 @@ const INFO_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
   <key>CFBundleIconFile</key>
   <string>icon</string>
   <key>LSMinimumSystemVersion</key>
-  <string>11.0</string>
+  <string>14.0</string>
   <key>LSApplicationCategoryType</key>
   <string>public.app-category.developer-tools</string>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsLocalNetworking</key>
+    <true/>
+  </dict>
   <key>NSHighResolutionCapable</key>
   <true/>
 </dict>
@@ -77,7 +81,10 @@ const INFO_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
 async function main() {
   const wantDmg = process.argv.includes("--dmg");
 
-  if (!existsSync(ENTRY)) {
+  if (process.platform !== "darwin" || process.arch !== "arm64") {
+    throw new Error("Build the native macOS app on Apple Silicon macOS.");
+  }
+  if (!existsSync(ENTRY) || !existsSync(NATIVE_ENTRY)) {
     console.error(`[build-mac] entry not found: ${ENTRY}`);
     process.exit(1);
   }
@@ -90,6 +97,7 @@ async function main() {
   mkdirSync(APP_MACOS, { recursive: true });
   mkdirSync(APP_RESOURCES, { recursive: true });
 
+  const serviceOut = path.join(APP_MACOS, SERVICE_BIN_NAME);
   const binOut = path.join(APP_MACOS, BIN_NAME);
   console.log(`[build-mac] version: ${APP_VERSION}`);
   console.log(`[build-mac] entry:   ${ENTRY}`);
@@ -110,7 +118,7 @@ async function main() {
     --minify \
     --external electron \
     --external chromium-bidi \
-    --outfile ${binOut}`.cwd(ROOT);
+    --outfile ${serviceOut}`.cwd(ROOT);
   console.log(
     `[build-mac] compiled in ${((Date.now() - startCompile) / 1000).toFixed(1)}s`,
   );
@@ -137,7 +145,12 @@ async function main() {
   }
 
   await stageRuntimeAssets(ROOT, APP_MACOS);
-  console.log("[build-mac] frontend, migrations, themes, and browser resources staged");
+  const swiftc = Bun.which("swiftc");
+  if (!swiftc) throw new Error("swiftc is required to build the native macOS window.");
+  const sdk = (await $`xcrun --sdk macosx --show-sdk-path`.cwd(ROOT).text()).trim();
+  await $`${swiftc} -O -swift-version 5 -target arm64-apple-macos14.0 -sdk ${sdk} -framework AppKit -framework WebKit ${NATIVE_ENTRY} -o ${binOut}`.cwd(ROOT);
+  chmodSync(binOut, 0o755);
+  console.log("[build-mac] frontend, migrations, themes, browser resources, and native window staged");
 
   const signIdentity = process.env.BG_MAC_SIGN_IDENTITY;
   if (signIdentity) {
@@ -149,7 +162,7 @@ async function main() {
   }
 
   console.log(`[build-mac] .app ready: ${APP_BUNDLE}`);
-  const artifacts = [binOut];
+  const artifacts = [binOut, serviceOut];
 
   if (!wantDmg) {
     console.log(

--- a/scripts/package-mac-release.ts
+++ b/scripts/package-mac-release.ts
@@ -38,7 +38,7 @@ if (signing.length === 0) console.warn("[release] unsigned package: set BG_MAC_S
 const platform = "[osx]";
 await $`dotnet tool restore`.cwd(root);
 // The pack id and feed channel pair with the Windows release so one GitHub release serves both feeds.
-await $`dotnet tool run vpk -- ${platform} pack --packId BurnGuard --packVersion ${APP_VERSION} --packDir ${bundle} --mainExe burnguard-design --packTitle BurnGuard --packAuthors BurnGuard --channel osx --icon ${path.join(root, "assets/icon.icns")} --outputDir ${output} ${signing}`.cwd(root);
+await $`dotnet tool run vpk -- ${platform} pack --packId BurnGuard --packVersion ${APP_VERSION} --packDir ${bundle} --mainExe BurnGuard --packTitle BurnGuard --packAuthors BurnGuard --channel osx --icon ${path.join(root, "assets/icon.icns")} --outputDir ${output} ${signing}`.cwd(root);
 
 const files: string[] = [];
 for await (const name of new Bun.Glob("*").scan({ cwd: output, onlyFiles: true })) {

--- a/scripts/qa/native-mac-smoke.ts
+++ b/scripts/qa/native-mac-smoke.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { isPortFree } from "./port";
+
+interface NativeSmokeReport {
+  readonly nativeWindowVisible: boolean;
+  readonly windowTitle: string;
+  readonly pageTitle: string;
+  readonly bodyTextLength: number;
+  readonly backendUrl: string;
+}
+
+interface ProcessEntry {
+  readonly pid: number;
+  readonly command: string;
+}
+
+const appPath = process.argv[2];
+if (appPath === undefined || process.platform !== "darwin") {
+  throw new Error("Usage on macOS: bun scripts/qa/native-mac-smoke.ts <BurnGuard.app path>");
+}
+
+const port = await findPort(14220);
+const profile = await mkdtemp(path.join(tmpdir(), "burnguard-native-mac-"));
+const reportPath = path.join(profile, "native-smoke.json");
+const before = await processSnapshot();
+const child = Bun.spawn(
+  [
+    path.join(appPath, "Contents/MacOS/BurnGuard"),
+    "--smoke-test",
+    "--smoke-report",
+    reportPath,
+  ],
+  {
+    env: {
+      ...process.env,
+      BG_APP_ROOT: profile,
+      BG_PORT: String(port),
+      BG_NO_OPEN: "1",
+    },
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+);
+
+const [exitCode, stdout, stderr] = await Promise.all([
+  child.exited,
+  new Response(child.stdout).text(),
+  new Response(child.stderr).text(),
+]);
+const report = JSON.parse(await readFile(reportPath, "utf8")) as NativeSmokeReport;
+const after = await processSnapshot();
+const launchedBrowsers = after.filter(
+  (entry) =>
+    !before.some((previous) => previous.pid === entry.pid) &&
+    /Google Chrome\.app|\/Chromium|chrome_crashpad/i.test(entry.command),
+);
+
+try {
+  if (exitCode !== 0) throw new Error(`native shell exited with ${exitCode}: ${stderr || stdout}`);
+  if (!report.nativeWindowVisible || report.windowTitle !== "BurnGuard Design") {
+    throw new Error(`native window was not visible: ${JSON.stringify(report)}`);
+  }
+  if (report.pageTitle !== "BurnGuard Design" || report.bodyTextLength < 40) {
+    throw new Error(`native page did not load: ${JSON.stringify(report)}`);
+  }
+  if (launchedBrowsers.length > 0) {
+    throw new Error(`external browser launched: ${JSON.stringify(launchedBrowsers)}`);
+  }
+  console.log(JSON.stringify({ report, launchedBrowsers, exitCode }));
+} finally {
+  await rm(profile, { recursive: true, force: true });
+}
+
+async function findPort(start: number): Promise<number> {
+  for (let port = start; port < 65_536; port += 1) {
+    if (await isPortFree(port)) return port;
+  }
+  throw new Error("No free QA port is available");
+}
+
+async function processSnapshot(): Promise<readonly ProcessEntry[]> {
+  const child = Bun.spawn(["ps", "-axo", "pid=,command="], {
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  const output = await new Response(child.stdout).text();
+  await child.exited;
+  return output
+    .split("\n")
+    .map((line) => {
+      const match = /^\s*(\d+)\s+(.+)$/.exec(line);
+      return match === null ? null : { pid: Number(match[1]), command: match[2] };
+    })
+    .filter((entry): entry is ProcessEntry => entry !== null);
+}


### PR DESCRIPTION
## Summary

Turn the macOS `.app` into a lightweight native application instead of a
server executable that opens the default browser.

- Add an AppKit `NSWindow` with an embedded `WKWebView`.
- Launch and own the Bun backend as a child process with `BG_DESKTOP=1`,
  validate its readiness protocol, and shut it down through private stdin.
- Block external navigation and set `BG_NO_OPEN=1` plus cache-only thumbnails,
  so startup never invokes Chrome or the default browser.
- Package the native shell as `CFBundleExecutable=BurnGuard`, keep the backend
  engine beside it, and point Velopack at the shell.
- Add a native macOS smoke E2E that asserts a visible native window, loaded
  BurnGuard screen, and zero newly launched Chrome/Chromium processes.

## Verification

- `bun run typecheck`: pass.
- `bun run lint`: pass.
- `bun run build:mac`: pass on Apple Silicon macOS.
- Native AppKit/WKWebView smoke E2E: pass.
  - `nativeWindowVisible: true`
  - `windowTitle: "BurnGuard Design"`
  - `pageTitle: "BurnGuard Design"`
  - `bodyTextLength: 355`
  - `launchedBrowsers: []`
- The packaged app's native window owns the backend and exits through the
  shutdown pipe after smoke completion.
- Related tests: 39 pass, 1 skipped, 4 pre-existing failures involving
  `/private` path spelling and QA harness fixtures on this macOS checkout.

The branch was rebased onto the latest `origin/main` before publication.

Ultraworked with [omo](https://github.com/code-yeongyu/oh-my-openagent)
