### PR TITLE
chore: release latest BurnGuard as 0.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burnguard-design",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "license": "Apache-2.0",
   "private": true,
   "workspaces": ["packages/*"],

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bg/backend",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/packages/desktop-windows/BurnGuard.Desktop.csproj
+++ b/packages/desktop-windows/BurnGuard.Desktop.csproj
@@ -10,7 +10,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon Condition="Exists('BurnGuard.ico')">BurnGuard.ico</ApplicationIcon>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-    <Version>0.5.3</Version>
+    <Version>0.5.4</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="qa/**/*.cs" />

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bg/frontend",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bg/shared",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/packages/shared/src/app.ts
+++ b/packages/shared/src/app.ts
@@ -4,7 +4,7 @@ export const APP_NAME = "BurnGuard Design";
 // When cutting a release, bump this in lockstep with the root
 // `package.json` and every `packages/<name>/package.json`. These
 // should always agree — verified manually at release time.
-export const APP_VERSION = "0.5.3";
+export const APP_VERSION = "0.5.4";
 
 export type BackendId = "claude-code" | "codex";
 export type ProjectType =


### PR DESCRIPTION
최신 main에 병합된 변경을 Windows·macOS 자동 업데이트에서 새 버전으로 인식하도록 앱과 패키지 버전을 0.5.4로 맞춥니다.

이번 릴리즈에는 산출물별 시각 디자인 규칙과 기본 디자인 정체성, Claude Code 추론 설정 호환성, 미리보기 캡처 개선, macOS WKWebView 네이티브 창이 포함됩니다. 이 PR 자체는 버전 6곳만 변경합니다.

타입 검사·lint, 관련 회귀 검사 50개(기존 Windows 제외 6개), Windows updater QA, PR 보안 CI 2건을 통과했습니다. Windows 설치·portable·업데이트 패키지를 빌드했으며 실제 WebView2의 모델 선택, LOW 기본값, 격리 프로필 시작·종료 및 포트 충돌 방어를 확인했습니다. macOS 빌드 workflow 34418273628도 동일 소스에서 성공했습니다.

Daybreak 최종 소스 및 Windows·macOS 패키지 보안 검토를 통과했으며 차단 이슈는 없습니다. 양 플랫폼의 패키지 내용·버전·SHA256과 병합 후 동일 source tree를 확인했습니다. macOS 네이티브 창 실행 증거는 PR #32의 기존 Apple Silicon 검증이며 이번 CI는 빌드·검사 범위입니다.
