### PR TITLE
fix: publish to Vercel without a quality gate and stop lazy-image audit hangs

### DIFF
--- a/packages/backend/src/services/design-audit-dom.ts
+++ b/packages/backend/src/services/design-audit-dom.ts
@@ -8,8 +8,15 @@ export async function inspectRenderedPage(page: Page, fixedCanvas = false): Prom
   await page.evaluate(async () => {
     const pending = [...document.images].filter((image) => !image.complete);
     await Promise.all(pending.map((image) => new Promise<void>((resolve) => {
-      const done = (): void => resolve();
+      const done = (): void => {
+        clearTimeout(timer);
+        image.removeEventListener("load", done); image.removeEventListener("error", done);
+        resolve();
+      };
+      const timer = setTimeout(done, 5000);
       image.addEventListener("load", done, { once: true }); image.addEventListener("error", done, { once: true });
+      image.loading = "eager";
+      if (image.complete) done();
     })));
   });
   return page.evaluate((fixedCanvas) => {

--- a/packages/backend/src/services/exports.ts
+++ b/packages/backend/src/services/exports.ts
@@ -85,12 +85,16 @@ async function runExport(input: RunInput): Promise<void> {
     const graphicCanvas = context.project.type === "graphic"
       ? parseStoredProjectOptions(context.project.options_json).graphic_canvas ?? undefined
       : undefined;
-    const audit = await auditRenderedTree({ projectId: context.identity.projectId, projectDir: renderRoot, entrypoint: context.project.entrypoint, revision: context.identity.revision, digest: context.identity.digest, treeDigest: renderManifest.tree_digest, safeFix: false, deck: context.project.type === "slide_deck", ...(graphicCanvas === undefined ? {} : { canvas: graphicCanvas }), signal: input.controller.signal });
-    const auditUnknowns = audit.checks.filter((check) => check.reason !== null).map((check) => ({ code: `design_audit:${check.code}:${check.status}`, path: null }));
-    const auditFindings = audit.checks.flatMap((check) => check.findings.map((finding) => ({ code: finding.check_code, path: finding.source.rel_path }))).slice(0, 200 - auditUnknowns.length);
-    recordExportAuditFindings(db, input.attemptId, [...auditFindings, ...auditUnknowns]);
-    const mustFixCount = audit.checks.flatMap((check) => check.findings).filter((finding) => finding.severity === "must_fix").length;
-    if (mustFixCount > 0) throw new ExportServiceError("design_audit_failed", `Design audit found ${mustFixCount} must-fix finding${mustFixCount === 1 ? "" : "s"}`);
+    if (context.format === "html_zip" && context.options.skip_quality_check === true) {
+      recordExportAuditFindings(db, input.attemptId, [{ code: "design_audit:skipped_by_user", path: null }]);
+    } else {
+      const audit = await auditRenderedTree({ projectId: context.identity.projectId, projectDir: renderRoot, entrypoint: context.project.entrypoint, revision: context.identity.revision, digest: context.identity.digest, treeDigest: renderManifest.tree_digest, safeFix: false, deck: context.project.type === "slide_deck", ...(graphicCanvas === undefined ? {} : { canvas: graphicCanvas }), signal: input.controller.signal });
+      const auditUnknowns = audit.checks.filter((check) => check.reason !== null).map((check) => ({ code: `design_audit:${check.code}:${check.status}`, path: null }));
+      const auditFindings = audit.checks.flatMap((check) => check.findings.map((finding) => ({ code: finding.check_code, path: finding.source.rel_path }))).slice(0, 200 - auditUnknowns.length);
+      recordExportAuditFindings(db, input.attemptId, [...auditFindings, ...auditUnknowns]);
+      const mustFixCount = audit.checks.flatMap((check) => check.findings).filter((finding) => finding.severity === "must_fix").length;
+      if (mustFixCount > 0) throw new ExportServiceError("design_audit_failed", `Design audit found ${mustFixCount} must-fix finding${mustFixCount === 1 ? "" : "s"}`);
+    }
     await resolveStaticClosure(renderRoot, context.project.entrypoint, renderManifest);
     const inputDigest = sha256(canonicalJson({ schema_version: 1, project: context.identity, entrypoint: context.project.entrypoint, manifest: renderManifest }));
     advanceExportAttempt(db, { attemptId: input.attemptId, status: "running", stage: "rendering", inputClosureDigest: inputDigest, designSystemDigest: context.identity.designSystemDigest });
@@ -128,7 +132,9 @@ async function renderOutput(input: RunInput, renderRoot: string, outputPath: str
   const { context } = input;
   switch (context.format) {
     case "html_zip": {
-      const session = await openRenderSession({ stagedDir: renderRoot, entrypoint: context.project.entrypoint, viewport: { width: 1280, height: 720, dpr: 1 }, deck: context.project.type === "slide_deck", signal: input.controller.signal }); await session.close();
+      if (context.options.skip_quality_check !== true) {
+        const session = await openRenderSession({ stagedDir: renderRoot, entrypoint: context.project.entrypoint, viewport: { width: 1280, height: 720, dpr: 1 }, deck: context.project.type === "slide_deck", signal: input.controller.signal }); await session.close();
+      }
       const archiveManifest = buildHtmlArchiveManifest({ schema_version: 1, entrypoint: context.project.entrypoint, project_revision: context.identity.revision, project_digest: context.identity.digest, input_closure_digest: inputDigest }, manifest.files.map((file) => ({ path: file.path, size: file.size, sha256: file.sha256 })));
       await writeFile(path.join(renderRoot, HTML_EXPORT_MANIFEST), canonicalJson(archiveManifest)); await zipDirectory(renderRoot, outputPath); await validateHtmlArchive(new Uint8Array(await readFile(outputPath)), archiveManifest); return { entries: archiveManifest.entries.length };
     }

--- a/packages/backend/tests/design-audit-export.test.ts
+++ b/packages/backend/tests/design-audit-export.test.ts
@@ -23,6 +23,19 @@ afterAll(async () => { for (const project of projects) { getSqlite().prepare("DE
 function nextTerminal(sessionId: string): Promise<SequencedEventEnvelope> { return new Promise((resolve, reject) => { const timeout = setTimeout(() => { unsubscribe(); reject(new TypeError("export terminal event timed out")); }, 60_000); const unsubscribe = sequencedBroker.subscribe(sessionId, (item) => { if (item.event.type !== "export.attempt" || !["failed", "validated", "cancelled"].includes(item.event.status)) return; clearTimeout(timeout); unsubscribe(); resolve(item); }); }); }
 
 describe("pre-export design audit", () => {
+  test("Given must-fix contrast When the user skips quality checks Then HTML publishes with the choice recorded", async () => {
+    const terminal = nextTerminal(projects[0].session);
+    const started = await enqueueProjectExport(projects[0].id, "html_zip", { skip_quality_check: true });
+    if (!started?.latest_attempt) throw new TypeError("export did not start");
+    await terminal;
+    const job = await getExportJob(started.id);
+    const attempt = await getExportAttemptDetail(started.latest_attempt.id);
+    expect(job?.status).toBe("succeeded");
+    expect(job?.options).toEqual({ skip_quality_check: true });
+    expect(attempt?.findings).toEqual([{ code: "design_audit:skipped_by_user", path: null }]);
+    expect(activeExportBrowserCount()).toBe(0);
+  });
+
   test("Given must-fix contrast When exporting Then publication is blocked and findings persist", async () => {
     const terminal = nextTerminal(projects[0].session); const started = await enqueueProjectExport(projects[0].id, "html_zip", {}); if (started === null || started.latest_attempt === null) throw new TypeError("export did not start"); await terminal; const job = await getExportJob(started.id); const attempt = await getExportAttemptDetail(started.latest_attempt.id);
     expect(job?.status).toBe("failed"); expect(job?.output_path).toBeNull(); expect(job?.error_message).toContain("must-fix"); expect(attempt?.stop_reason).toBe("validation_failed"); expect(attempt?.findings.some((finding) => finding.code === "contrast")).toBeTrue();

--- a/packages/backend/tests/design-audit-render.test.ts
+++ b/packages/backend/tests/design-audit-render.test.ts
@@ -80,3 +80,18 @@ describe("rendered design auditor", () => {
  }, 60_000);
 
 });
+
+test("Given offscreen lazy and stalled images When audited Then loading completes or stops within a bounded wait", async () => {
+  const browser = await launchChromium(new AbortController().signal);
+  try {
+    const page = await browser.newPage();
+    await page.route("https://audit.test/**", route => route.fulfill({ contentType: "image/svg+xml", body: '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"/>' }));
+    await page.setContent('<div style="height:10000px"></div><img data-bg-node-id="lazy" loading="lazy" src="https://audit.test/image.svg"><img data-bg-node-id="stalled">');
+    await page.evaluate(() => Object.defineProperty(document.querySelector('[data-bg-node-id="stalled"]'), "complete", { get: () => false }));
+    const started = performance.now();
+    const result = await inspectRenderedPage(page);
+    expect(performance.now() - started).toBeLessThan(10000);
+    expect(result.findings.some(f => f.code === "missing_image" && f.nodeId === "lazy")).toBe(false);
+    expect(result.findings.some(f => f.code === "missing_image" && f.nodeId === "stalled")).toBe(true);
+  } finally { await browser.close(); }
+}, 30000);

--- a/packages/backend/tests/export-quality-options.test.ts
+++ b/packages/backend/tests/export-quality-options.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "bun:test";
+import { parseExportOptions } from "@bg/shared";
+test("Given quality-check choice When parsing Then only explicit HTML booleans are accepted", () => {
+  expect(parseExportOptions("html_zip", {})).toEqual({});
+  for (const value of [true, false]) expect(parseExportOptions("html_zip", { skip_quality_check: value })).toEqual({ skip_quality_check: value });
+  for (const value of ["true", 1, null]) expect(() => parseExportOptions("html_zip", { skip_quality_check: value })).toThrow();
+  for (const format of ["pdf", "png", "pptx", "handoff"] as const) expect(() => parseExportOptions(format, { skip_quality_check: true })).toThrow();
+});

--- a/packages/frontend/src/components/export/VercelShare.tsx
+++ b/packages/frontend/src/components/export/VercelShare.tsx
@@ -27,7 +27,7 @@ export default function VercelShare({ projectId }: { projectId: string }) {
     refetchInterval: (query) => query.state.status === "error" ? false : query.state.data && ["succeeded", "failed"].includes(query.state.data.status) ? false : 1500 });
   async function prepare() {
     setBusy(true); setMessage(""); setDeployment(null);
-    try { setJobId((await createExport(projectId, "html_zip")).id); }
+    try { setJobId((await createExport(projectId, "html_zip", { skip_quality_check: true })).id); }
     catch { setMessage("HTML 내보내기를 준비하지 못했어요. 결과물과 내보내기 상태를 확인해 주세요."); }
     finally { setBusy(false); }
   }
@@ -43,13 +43,13 @@ export default function VercelShare({ projectId }: { projectId: string }) {
   return <Dialog open={open} onOpenChange={(value) => { if (!busy) { setOpen(value); if (!value) setToken(""); } }}>
     <DialogTrigger asChild><Button variant="outline" size="sm"><Share2 className="mr-1 size-4" />공유</Button></DialogTrigger>
     <DialogContent className="max-w-md"><DialogHeader><DialogTitle>Vercel에 게시하기</DialogTitle></DialogHeader>
-      <p className="text-sm text-muted-foreground">현재 결과물의 HTML·CSS·이미지를 공개 웹사이트로 게시해요. 먼저 미리보기에서 내용을 확인해 주세요.</p>
+      <p className="text-sm text-muted-foreground">현재 결과물의 HTML·CSS·이미지를 공개 웹사이트로 게시해요. 품질검사 통과 여부와 관계없이 현재 상태 그대로 게시할 수 있어요.</p>
       <p className="text-xs text-muted-foreground">Vercel Hobby는 개인·비상업 용도로 무료예요. 상업용은 계정 요금제를 확인해 주세요. 토큰은 저장하지 않아요.</p>
       <a className="text-sm underline" href="https://vercel.com/account/tokens" target="_blank" rel="noreferrer">Vercel 토큰 만들기</a>
       <label className="text-sm">Vercel 토큰<input className="mt-1 w-full rounded border bg-background p-2" disabled={busy} type="password" autoComplete="off" value={token} onChange={(event) => setToken(event.target.value)} /></label>
       <label className="text-sm">팀 ID (선택)<input className="mt-1 w-full rounded border bg-background p-2" disabled={busy} placeholder="team_…" value={teamId} onChange={(event) => setTeamId(event.target.value)} /></label>
       <Button variant="outline" disabled={busy || (!!jobId && !job.isError && !["succeeded", "failed"].includes(job.data?.status ?? ""))} onClick={() => void prepare()}>현재 결과물 준비</Button>
-      <p role="status" className="text-sm">{busy ? "요청 처리 중이에요…" : job.isError ? "내보내기 상태를 확인하지 못했어요. 다시 준비해 주세요." : job.data?.status === "succeeded" ? `리비전 ${job.data.latest_attempt?.project_revision} 준비 완료` : job.data?.status === "failed" ? "내보내기가 실패했어요. 내보내기 메뉴에서 원인을 확인해 주세요." : jobId ? "HTML과 포함된 파일을 검증하고 있어요…" : "준비 후 공개 게시 버튼을 눌러 주세요."}</p>
+      <p role="status" className="text-sm">{busy ? "요청 처리 중이에요…" : job.isError ? "내보내기 상태를 확인하지 못했어요. 다시 준비해 주세요." : job.data?.status === "succeeded" ? `리비전 ${job.data.latest_attempt?.project_revision} 준비 완료` : job.data?.status === "failed" ? "내보내기가 실패했어요. 내보내기 메뉴에서 원인을 확인해 주세요." : jobId ? "게시할 파일을 묶고 있어요…" : "준비 후 공개 게시 버튼을 눌러 주세요."}</p>
       {message && <p role="alert" className="text-sm text-destructive">{message}</p>}
       {!deployment?.ready && <Button disabled={busy || !token.trim() || job.data?.status !== "succeeded"} onClick={() => void publish()}>{deployment ? "배포 상태 확인" : "Vercel에 공개 게시"}</Button>}
       {deployment && !deployment.ready && <p className="text-sm">배포가 접수됐어요. 잠시 후 상태를 확인해 주세요.</p>}

--- a/packages/shared/src/export.ts
+++ b/packages/shared/src/export.ts
@@ -7,6 +7,7 @@ export type PdfPaper = "a4" | "letter" | "widescreen-16x9";
 export type PptxSize = "16x9" | "4x3";
 
 export type ExportOptions = {
+  readonly skip_quality_check?: boolean;
   readonly pdf_paper?: PdfPaper;
   readonly png_width?: number;
   readonly png_height?: number;
@@ -17,7 +18,13 @@ export type ExportOptions = {
 export function parseExportOptions(format: ExportFormat, input: unknown): ExportOptions {
   const record = decodeContract(input);
   switch (format) {
-    case "html_zip":
+    case "html_zip": {
+      requireKeys(record, ["skip_quality_check"]);
+      const value = record["skip_quality_check"];
+      if (value === undefined) return {};
+      if (typeof value !== "boolean") invalid("skip_quality_check");
+      return { skip_quality_check: value };
+    }
     case "handoff":
       requireKeys(record, []);
       return {};


### PR DESCRIPTION
Vercel sharing previously required a clean rendered design audit before preparing its HTML ZIP, preventing users from publishing unfinished work. Sharing now explicitly skips the visual audit and browser smoke render; canonical source, asset closure, archive, receipt, digest, and public-file validation remain enforced. Other exports retain their default quality gate.

The design audit also waited forever for offscreen lazy images. It now requests eager loading in the isolated audit page, waits at most five seconds, and reports images that remain unavailable. A read-only reproduction of the reported project stalled until the diagnostic 90-second cancellation before the fix and completed in 11.4 seconds afterward. No running app or project files were modified.

Validation: export/publishing/parser tests (13 passed), rendered-audit tests, typecheck, and lint. Vercel network behavior is mocked; no live deployment was made.
