### PR TITLE
Fix macOS security blocks and example previews

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -28,8 +28,12 @@ jobs:
       - run: bun run typecheck
       - run: bun run lint
       - run: bun test packages/backend/tests/mac-updates.test.ts packages/backend/tests/app-update-routes.test.ts --timeout 30000
-      # Signing/notarization stay off until BG_MAC_* secrets exist; unsigned packages are for verification only.
-      - run: bun run build:mac:release
+      - name: Build signed and notarized macOS release
+        env:
+          BG_MAC_SIGN_IDENTITY: ${{ secrets.BG_MAC_SIGN_IDENTITY }}
+          BG_MAC_INSTALL_IDENTITY: ${{ secrets.BG_MAC_INSTALL_IDENTITY }}
+          BG_MAC_NOTARY_PROFILE: ${{ secrets.BG_MAC_NOTARY_PROFILE }}
+        run: bun run build:mac:release
       - name: Verify the bundled Node renderer runtime
         run: test -x "dist/mac/BurnGuard Design.app/Contents/MacOS/resources/node/node"
       - uses: actions/upload-artifact@v4

--- a/packages/backend/src/db/seed-tutorials.ts
+++ b/packages/backend/src/db/seed-tutorials.ts
@@ -452,8 +452,6 @@ export async function seedTutorialsOnce(): Promise<void> {
     PROMPT_SAMPLES.map((sample) => sample.name),
   );
   const existingByName = new Map(existing.map((row) => [row.name, row]));
-  const names = new Set(existing.map((row) => row.name));
-
   for (const row of existing) {
     if (
       row.name.startsWith(PROMPT_SAMPLE_TAG) &&
@@ -466,7 +464,10 @@ export async function seedTutorialsOnce(): Promise<void> {
     }
   }
 
-  if (!names.has(PROTOTYPE_TUTORIAL_NAME)) {
+  const existingPrototype = existingByName.get(PROTOTYPE_TUTORIAL_NAME);
+  if (existingPrototype) {
+    await copyBundledFonts(existingPrototype.dirPath);
+  } else {
     await writeTutorialProject({
       name: PROTOTYPE_TUTORIAL_NAME,
       type: "prototype",
@@ -474,7 +475,10 @@ export async function seedTutorialsOnce(): Promise<void> {
       html: PROTOTYPE_TUTORIAL_HTML,
     });
   }
-  if (!names.has(DECK_TUTORIAL_NAME)) {
+  const existingDeck = existingByName.get(DECK_TUTORIAL_NAME);
+  if (existingDeck) {
+    await copyBundledFonts(existingDeck.dirPath);
+  } else {
     await writeTutorialProject({
       name: DECK_TUTORIAL_NAME,
       type: "slide_deck",
@@ -901,7 +905,10 @@ async function syncPromptSampleProject(input: {
   const coordinator = new ArtifactCoordinator(getSqlite());
   if (input.currentDigest === null) { await coordinator.initialize(input.id, input.dirPath); return; }
   const current = await readFile(path.join(input.dirPath, input.entrypoint), "utf8").catch(() => null);
-  if (current === input.html) return;
+  if (current === input.html) {
+    await copyBundledFonts(input.dirPath);
+    return;
+  }
   const userOperations = getSqlite().query<{ readonly count: number }, [string]>("SELECT COUNT(*) count FROM artifact_operations WHERE project_id=? AND status='committed' AND json_extract(replay_json,'$.kind')!='initialize'").get(input.id)?.count ?? 0;
   if (userOperations > 0) return;
   try {

--- a/packages/backend/src/db/seed.ts
+++ b/packages/backend/src/db/seed.ts
@@ -120,7 +120,16 @@ export async function seedCoreData() {
     .from(projectsTable)
     .limit(1);
 
-  if (existingProjects.length > 0) return;
+  if (existingProjects.length > 0) {
+    const fixtureIds = new Set(homeProjectFixtures.map((project) => project.id));
+    const knownProjects = await db
+      .select({ id: projectsTable.id, dirPath: projectsTable.dirPath })
+      .from(projectsTable);
+    for (const project of knownProjects) {
+      if (fixtureIds.has(project.id)) await copyBundledFonts(project.dirPath);
+    }
+    return;
+  }
 
   for (const project of homeProjectFixtures) {
     const dirPath = path.join(projectsDir, project.id);

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -76,6 +76,7 @@ if (isDev) {
 let shuttingDown = false;
 const shutdown = async (): Promise<void> => {
   if (shuttingDown) return; shuttingDown = true; console.log("\n[burnguard] shutting down");
+  if (isDesktop) console.log('[burnguard-desktop] {"protocol":1,"event":"shutdown"}');
   // Turns first: an in-flight CLI subprocess owns the project directory and
   // would keep writing into it after the server is gone.
   server.stop(false); await interruptAllUserTurns(); await closeActiveExportBrowsers(); server.stop(true); profileOwner?.close(); process.exit(0);

--- a/packages/backend/src/services/mac-updates.ts
+++ b/packages/backend/src/services/mac-updates.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, rename, rm } from "node:fs/promises";
+import { mkdir, rename, rm, stat } from "node:fs/promises";
 import path from "node:path";
 import { APP_VERSION } from "@bg/shared/app";
 import type { AppUpdateStatus, AppUpdateUnsupportedReason } from "@bg/shared/updates";
@@ -106,7 +106,7 @@ export function updaterBinaryPath(execPath: string): string {
 
 /** Only a Velopack-packaged macOS bundle (UpdateMac beside the executable) can update itself. */
 export function detectUpdateSupport(input: { readonly platform: NodeJS.Platform; readonly execPath: string; readonly desktopShell: boolean }): UpdateSupport {
-  if (input.desktopShell) return { supported: false, reason: "windows_shell" };
+  if (input.platform === "win32" && input.desktopShell) return { supported: false, reason: "windows_shell" };
   if (input.platform !== "darwin") return { supported: false, reason: "platform" };
   return existsSync(updaterBinaryPath(input.execPath)) ? { supported: true, reason: null } : { supported: false, reason: "not_installed" };
 }
@@ -117,6 +117,8 @@ export type AppUpdaterDependencies = {
   readonly source: AppUpdateSource;
   readonly support: UpdateSupport;
   readonly updaterPath: string;
+  /** Process that owns the app bundle and must exit before replacement. */
+  readonly waitPid?: number;
   /** Starts the detached updater process; must not throw for a well-formed command. */
   readonly spawn: (cmd: readonly string[]) => void;
   /** The application's graceful shutdown; the updater swaps the bundle once this pid exits. */
@@ -161,7 +163,7 @@ export function createAppUpdater(deps: AppUpdaterDependencies): AppUpdater {
       patch({ state: "idle", available_version: null, checked_at: Date.now() });
       return;
     }
-    if (staged !== null && staged.asset.FileName === asset.FileName && staged.asset.SHA256 === asset.SHA256 && existsSync(staged.file)) {
+    if (staged !== null && staged.asset.FileName === asset.FileName && staged.asset.SHA256 === asset.SHA256 && existsSync(staged.file) && await packageMatches(staged.file, asset)) {
       patch({ state: "ready", available_version: asset.Version, checked_at: Date.now() });
       return;
     }
@@ -186,11 +188,39 @@ export function createAppUpdater(deps: AppUpdaterDependencies): AppUpdater {
     async apply() {
       if (!deps.support.supported) return "unsupported";
       if (staged === null || state.state !== "ready") return "not_ready";
-      deps.spawn([deps.updaterPath, "apply", "--package", staged.file, "--waitPid", String(process.pid)]);
+      if (!(await packageMatches(staged.file, staged.asset))) {
+        staged = null;
+        patch({ state: "error", error: "package_digest_mismatch", checked_at: Date.now() });
+        return "not_ready";
+      }
+      deps.spawn([deps.updaterPath, "apply", "--package", staged.file, "--waitPid", String(deps.waitPid ?? process.pid)]);
       (deps.scheduleShutdown ?? ((run) => { setTimeout(run, 250); }))(() => { void deps.shutdown(); });
       return "applying";
     },
   };
+}
+
+async function packageMatches(file: string, asset: VelopackFeedAsset): Promise<boolean> {
+  let fileSize: number;
+  try {
+    fileSize = (await stat(file)).size;
+  } catch {
+    return false;
+  }
+  if (fileSize !== asset.Size) return false;
+
+  const hash = createHash("sha256");
+  const reader = Bun.file(file).stream().getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      hash.update(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return hash.digest("hex").toUpperCase() === asset.SHA256;
 }
 
 async function downloadPackage(deps: AppUpdaterDependencies, asset: VelopackFeedAsset, onProgress: (percent: number) => void): Promise<string> {
@@ -311,6 +341,7 @@ export function configureAppUpdater(overrides: Partial<AppUpdaterDependencies> &
     source: overrides.source ?? resolveUpdateSource(),
     support,
     updaterPath: overrides.updaterPath ?? updaterBinaryPath(execPath),
+    waitPid: overrides.waitPid ?? (Number.parseInt(process.env.BG_UPDATE_WAIT_PID ?? "", 10) || process.pid),
     spawn: overrides.spawn ?? ((cmd) => { Bun.spawn([...cmd], { stdin: "ignore", stdout: "ignore", stderr: "ignore" }).unref(); }),
     shutdown: overrides.shutdown,
     ...(overrides.scheduleShutdown === undefined ? {} : { scheduleShutdown: overrides.scheduleShutdown }),

--- a/packages/backend/tests/mac-updates.test.ts
+++ b/packages/backend/tests/mac-updates.test.ts
@@ -77,6 +77,25 @@ describe("update support detection", () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  test("Given a native macOS shell with UpdateMac When support is detected Then updates remain enabled", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "bg-mac-native-support-"));
+    try {
+      const macos = path.join(root, "BurnGuard.app", "Contents", "MacOS");
+      await Bun.write(path.join(macos, "burnguard-design"), "bin");
+      await writeFile(path.join(macos, "UpdateMac"), "#!/bin/sh\n", "utf8");
+      await chmod(path.join(macos, "UpdateMac"), 0o755);
+      expect(
+        detectUpdateSupport({
+          platform: "darwin",
+          execPath: path.join(macos, "burnguard-design"),
+          desktopShell: true,
+        }),
+      ).toEqual({ supported: true, reason: null });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("app updater flow", () => {
@@ -110,12 +129,51 @@ describe("app updater flow", () => {
       const sha = createHash("sha256").update(good).digest("hex").toUpperCase();
       const spawned: string[][] = [];
       let shutdowns = 0;
-      const updater = createAppUpdater({ currentVersion: "0.5.1", cacheDir: root, source: fakeSource([asset({ SHA256: sha })], { "BurnGuard-0.5.2-osx-full.nupkg": good }), support: { supported: true, reason: null }, updaterPath: "/Applications/BurnGuard.app/Contents/MacOS/UpdateMac", spawn: (cmd) => { spawned.push(cmd); }, shutdown: async () => { shutdowns += 1; }, scheduleShutdown: (run) => run() });
+      const updater = createAppUpdater({ currentVersion: "0.5.1", cacheDir: root, source: fakeSource([asset({ SHA256: sha })], { "BurnGuard-0.5.2-osx-full.nupkg": good }), support: { supported: true, reason: null }, updaterPath: "/Applications/BurnGuard.app/Contents/MacOS/UpdateMac", waitPid: 4242, spawn: (cmd) => { spawned.push(cmd); }, shutdown: async () => { shutdowns += 1; }, scheduleShutdown: (run) => run() });
       expect(await updater.apply()).toBe("not_ready");
       await updater.check();
       expect(await updater.apply()).toBe("applying");
-      expect(spawned).toEqual([["/Applications/BurnGuard.app/Contents/MacOS/UpdateMac", "apply", "--package", path.join(root, "updates", "BurnGuard-0.5.2-osx-full.nupkg"), "--waitPid", String(process.pid)]]);
+      expect(spawned).toEqual([["/Applications/BurnGuard.app/Contents/MacOS/UpdateMac", "apply", "--package", path.join(root, "updates", "BurnGuard-0.5.2-osx-full.nupkg"), "--waitPid", "4242"]]);
       expect(shutdowns).toBe(1);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("Given a staged package modified after download When checked again Then tampering clears readiness and blocks apply", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "bg-updater-tamper-"));
+    try {
+      const good = new TextEncoder().encode("pkg");
+      const sha = createHash("sha256").update(good).digest("hex").toUpperCase();
+      const spawned: string[][] = [];
+      let shutdowns = 0;
+      const updater = createAppUpdater({
+        currentVersion: "0.5.1",
+        cacheDir: root,
+        source: fakeSource(
+          [asset({ SHA256: sha })],
+          { "BurnGuard-0.5.2-osx-full.nupkg": good },
+        ),
+        support: { supported: true, reason: null },
+        updaterPath: "/Applications/BurnGuard.app/Contents/MacOS/UpdateMac",
+        spawn: (cmd) => { spawned.push([...cmd]); },
+        shutdown: async () => { shutdowns += 1; },
+        scheduleShutdown: (run) => run(),
+      });
+      await updater.check();
+      await writeFile(
+        path.join(root, "updates", "BurnGuard-0.5.2-osx-full.nupkg"),
+        "tampered",
+        "utf8",
+      );
+
+      expect(await updater.apply()).toBe("not_ready");
+      expect(updater.status()).toMatchObject({
+        state: "error",
+        error: "package_digest_mismatch",
+      });
+      expect(spawned).toEqual([]);
+      expect(shutdowns).toBe(0);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/desktop-mac/main.swift
+++ b/packages/desktop-mac/main.swift
@@ -163,7 +163,7 @@ final class BurnGuardAppDelegate: NSObject, NSApplicationDelegate, NSWindowDeleg
         var environment = ProcessInfo.processInfo.environment
         environment["BG_DESKTOP"] = "1"
         environment["BG_NO_OPEN"] = "1"
-        environment["BG_THUMBNAIL_CACHE_ONLY"] = "1"
+        environment["BG_UPDATE_WAIT_PID"] = String(ProcessInfo.processInfo.processIdentifier)
         if environment["BG_PORT"] == nil {
             environment["BG_PORT"] = "14070"
         }
@@ -204,8 +204,16 @@ final class BurnGuardAppDelegate: NSObject, NSApplicationDelegate, NSWindowDeleg
             guard let data = json.data(using: .utf8),
                   let message = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let protocolVersion = message["protocol"] as? Int,
-                  protocolVersion == 1,
-                  let urlString = message["url"] as? String,
+                  protocolVersion == 1 else {
+                fail("BurnGuard 시작 응답을 확인할 수 없습니다.")
+                return
+            }
+            if message["event"] as? String == "shutdown" {
+                closing = true
+                NSApp.terminate(nil)
+                return
+            }
+            guard let urlString = message["url"] as? String,
                   let url = URL(string: urlString) else {
                 fail("BurnGuard 시작 응답을 확인할 수 없습니다.")
                 return

--- a/scripts/package-mac-release.ts
+++ b/scripts/package-mac-release.ts
@@ -4,7 +4,7 @@
  * .nupkg, releases.osx.json feed) from the .app that `build-mac.ts` produced.
  * Publication is a separate release step; this only writes dist/releases.
  *
- * Signing and notarization run only when credentials are present:
+ * Release packaging requires signing and notarization credentials:
  *   BG_MAC_SIGN_IDENTITY       Developer ID Application certificate subject
  *   BG_MAC_INSTALL_IDENTITY    Developer ID Installer certificate subject
  *   BG_MAC_NOTARY_PROFILE      notarytool keychain profile name
@@ -29,10 +29,16 @@ if (path.dirname(output) !== distribution || path.basename(output) !== "releases
 await rm(output, { recursive: true, force: true });
 
 const signing: string[] = [];
-if (process.env.BG_MAC_SIGN_IDENTITY) signing.push("--signAppIdentity", process.env.BG_MAC_SIGN_IDENTITY);
-if (process.env.BG_MAC_INSTALL_IDENTITY) signing.push("--signInstallIdentity", process.env.BG_MAC_INSTALL_IDENTITY);
-if (process.env.BG_MAC_NOTARY_PROFILE) signing.push("--notaryProfile", process.env.BG_MAC_NOTARY_PROFILE);
-if (signing.length === 0) console.warn("[release] unsigned package: set BG_MAC_SIGN_IDENTITY, BG_MAC_INSTALL_IDENTITY and BG_MAC_NOTARY_PROFILE for a distributable build");
+const requiredSigning = [
+  ["BG_MAC_SIGN_IDENTITY", "--signAppIdentity"],
+  ["BG_MAC_INSTALL_IDENTITY", "--signInstallIdentity"],
+  ["BG_MAC_NOTARY_PROFILE", "--notaryProfile"],
+] as const;
+for (const [environmentKey, argument] of requiredSigning) {
+  const value = process.env[environmentKey];
+  if (!value) throw new Error(`[release] ${environmentKey} is required; refusing to publish an unsigned macOS package`);
+  signing.push(argument, value);
+}
 
 // `[osx]` is interpolated so the Bun shell never treats it as a glob.
 const platform = "[osx]";


### PR DESCRIPTION
## Summary
- enable macOS native-shell self-updates when the bundled UpdateMac exists
- revalidate staged package size and SHA-256 before reuse and apply
- coordinate native-owner shutdown and restore bundled fonts for existing examples
- require signing, installer signing, and notarization credentials for macOS releases

## Verification
- focused updater and thumbnail tests: 39 passed
- typecheck: passed
- frontend and macOS builds: passed
- Swift parse check: passed
- public releases.osx.json selected v0.5.5; real 83.9 MB package downloaded, verified, and handed off
- native macOS smoke: passed
- cache-only baseline: 21/21 example thumbnails returned 503 before the fix

The full suite still has 10 unrelated pre-existing environment/fixture failures and 11 skipped Chromium/Windows cases; none are caused by these changes. The current local build is intentionally unsigned until the configured Developer ID/notary credentials are supplied; release CI now refuses to publish without them.