### PR TITLE
chore: release 0.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burnguard-design",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "license": "Apache-2.0",
   "private": true,
   "workspaces": ["packages/*"],

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bg/backend",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/packages/desktop-windows/BurnGuard.Desktop.csproj
+++ b/packages/desktop-windows/BurnGuard.Desktop.csproj
@@ -10,7 +10,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon Condition="Exists('BurnGuard.ico')">BurnGuard.ico</ApplicationIcon>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-    <Version>0.5.5</Version>
+    <Version>0.5.6</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="qa/**/*.cs" />

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bg/frontend",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bg/shared",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/packages/shared/src/app.ts
+++ b/packages/shared/src/app.ts
@@ -4,7 +4,7 @@ export const APP_NAME = "BurnGuard Design";
 // When cutting a release, bump this in lockstep with the root
 // `package.json` and every `packages/<name>/package.json`. These
 // should always agree — verified manually at release time.
-export const APP_VERSION = "0.5.5";
+export const APP_VERSION = "0.5.6";
 
 export type BackendId = "claude-code" | "codex";
 export type ProjectType =


### PR DESCRIPTION
Release the merged Vercel publishing choice, bounded lazy-image audit waits, and macOS runtime/path fixes. Version metadata is aligned to 0.5.6. Publication requires Daybreak source/artifact review and Windows/macOS packaging verification.