### PR TITLE
fix: avoid unsafe startup font writes into existing projects

### DIFF
--- a/packages/backend/src/db/seed-tutorials.ts
+++ b/packages/backend/src/db/seed-tutorials.ts
@@ -452,6 +452,8 @@ export async function seedTutorialsOnce(): Promise<void> {
     PROMPT_SAMPLES.map((sample) => sample.name),
   );
   const existingByName = new Map(existing.map((row) => [row.name, row]));
+  const names = new Set(existing.map((row) => row.name));
+
   for (const row of existing) {
     if (
       row.name.startsWith(PROMPT_SAMPLE_TAG) &&
@@ -464,10 +466,7 @@ export async function seedTutorialsOnce(): Promise<void> {
     }
   }
 
-  const existingPrototype = existingByName.get(PROTOTYPE_TUTORIAL_NAME);
-  if (existingPrototype) {
-    await copyBundledFonts(existingPrototype.dirPath);
-  } else {
+  if (!names.has(PROTOTYPE_TUTORIAL_NAME)) {
     await writeTutorialProject({
       name: PROTOTYPE_TUTORIAL_NAME,
       type: "prototype",
@@ -475,10 +474,7 @@ export async function seedTutorialsOnce(): Promise<void> {
       html: PROTOTYPE_TUTORIAL_HTML,
     });
   }
-  const existingDeck = existingByName.get(DECK_TUTORIAL_NAME);
-  if (existingDeck) {
-    await copyBundledFonts(existingDeck.dirPath);
-  } else {
+  if (!names.has(DECK_TUTORIAL_NAME)) {
     await writeTutorialProject({
       name: DECK_TUTORIAL_NAME,
       type: "slide_deck",
@@ -905,10 +901,7 @@ async function syncPromptSampleProject(input: {
   const coordinator = new ArtifactCoordinator(getSqlite());
   if (input.currentDigest === null) { await coordinator.initialize(input.id, input.dirPath); return; }
   const current = await readFile(path.join(input.dirPath, input.entrypoint), "utf8").catch(() => null);
-  if (current === input.html) {
-    await copyBundledFonts(input.dirPath);
-    return;
-  }
+  if (current === input.html) return;
   const userOperations = getSqlite().query<{ readonly count: number }, [string]>("SELECT COUNT(*) count FROM artifact_operations WHERE project_id=? AND status='committed' AND json_extract(replay_json,'$.kind')!='initialize'").get(input.id)?.count ?? 0;
   if (userOperations > 0) return;
   try {

--- a/packages/backend/src/db/seed.ts
+++ b/packages/backend/src/db/seed.ts
@@ -120,16 +120,7 @@ export async function seedCoreData() {
     .from(projectsTable)
     .limit(1);
 
-  if (existingProjects.length > 0) {
-    const fixtureIds = new Set(homeProjectFixtures.map((project) => project.id));
-    const knownProjects = await db
-      .select({ id: projectsTable.id, dirPath: projectsTable.dirPath })
-      .from(projectsTable);
-    for (const project of knownProjects) {
-      if (fixtureIds.has(project.id)) await copyBundledFonts(project.dirPath);
-    }
-    return;
-  }
+  if (existingProjects.length > 0) return;
 
   for (const project of homeProjectFixtures) {
     const dirPath = path.join(projectsDir, project.id);

--- a/packages/backend/tests/bundled-fonts.test.ts
+++ b/packages/backend/tests/bundled-fonts.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from "bun:test";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { copyBundledFonts } from "../src/data/bundled-fonts";
 import { createProjectRecord } from "../src/db/seed";
+import { PROTOTYPE_TUTORIAL_NAME, seedTutorialsOnce } from "../src/db/seed-tutorials";
 import { appRootDir, resolveRepoRoot } from "../src/lib/paths";
 import { inspectCanonicalTree } from "../src/services/canonical-tree-manifest";
 import { getSqlite } from "../src/db/client";
@@ -30,4 +31,16 @@ test("Given bundled local fonts, when initializing projects and copying over bra
   expect(await readFile(path.join(branded, "fonts/Pretendard-OFL.txt"), "utf8")).toContain("SIL OPEN FONT LICENSE");
   expect(isRuntimeSource("assets/fonts/fonts.css")).toBe(true);
   expect(isRuntimeSource("assets/fonts/../../secret")).toBe(false);
+});
+
+test("Given an existing tutorial project When startup seeding runs again Then its live files are not mutated", async () => {
+  await seedTutorialsOnce();
+  const project = getSqlite().query<{ readonly dirPath: string }, [string]>("SELECT dir_path dirPath FROM projects WHERE name=?").get(PROTOTYPE_TUTORIAL_NAME);
+  if (project === null) throw new Error("tutorial fixture was not seeded");
+  const missingFont = path.join(project.dirPath, "fonts", "Pretendard-OFL.txt");
+  await rm(missingFont);
+
+  await seedTutorialsOnce();
+
+  await expect(readFile(missingFont)).rejects.toThrow();
 });


### PR DESCRIPTION
Daybreak release review found that live font backfill could follow a junction outside managed storage and invalidate artifact digests. Remove the newly added backfill while retaining staged font copying for new projects. Bundled font regression tests, backend typecheck, and lint pass.