### PR TITLE
fix: publish website assets without internal project files

### DIFF
--- a/packages/backend/src/services/vercel-publish.ts
+++ b/packages/backend/src/services/vercel-publish.ts
@@ -21,16 +21,17 @@ export function isPublicAsset(name: string): boolean {
     return /(?:^|[._ -])(?:secrets?|tokens?|credentials?|passwords?|api[._ -]*keys?|(?:access|refresh|auth|bearer)[._ -]*tokens?|private[._ -]*keys?)(?:[._ -]|$)/i.test(part.replace(/([a-z0-9])([A-Z])/g, "$1-$2"));
   })
     && !/[\\:%\x00-\x1f]/.test(name)
-    && /\.(?:html?|css|js|mjs|svg|png|jpe?g|gif|webp|avif|ico|woff2?|ttf|otf|mp4|webm|mp3|wav)$/i.test(name)
+    && (/\.(?:html?|css|js|mjs|svg|png|jpe?g|gif|webp|avif|ico|woff2?|ttf|otf|mp4|webm|mp3|wav)$/i.test(name) || /^fonts\/[a-z0-9_-]+-OFL\.txt$/i.test(name))
     && !/(?:^|\/)(?:[^/]*config[^/]*|credentials[^/]*)$/i.test(name);
 }
 
 export async function deploymentFiles(bytes: Uint8Array, expected: Omit<HtmlArchiveManifest, "entries">) {
   const manifest = await validateHtmlArchive(bytes, expected);
-  if (manifest.entries.reduce((n, file) => n + file.size, 0) > 100_000_000) throw new VercelPublishError("publish_size_limit");
-  if (manifest.entries.some((file) => !isPublicAsset(file.path))) throw new VercelPublishError("publish_unsafe_asset");
+  if (!isPublicAsset(manifest.entrypoint)) throw new VercelPublishError("publish_unsafe_asset");
+  const publicEntries = manifest.entries.filter((file) => isPublicAsset(file.path));
+  if (publicEntries.reduce((n, file) => n + file.size, 0) > 100_000_000) throw new VercelPublishError("publish_size_limit");
   const zip = await JSZip.loadAsync(bytes, { checkCRC32: true });
-  const files = await Promise.all(manifest.entries.map(async ({ path }) => ({ file: path, data: await zip.file(path)!.async("uint8array") })));
+  const files = await Promise.all(publicEntries.map(async ({ path }) => ({ file: path, data: await zip.file(path)!.async("uint8array") })));
   // Keep nested entrypoints in place so relative asset URLs retain their meaning.
   if (manifest.entrypoint !== "index.html") {
     if (manifest.entries.some((entry) => entry.path === "index.html")) throw new VercelPublishError("publish_entrypoint_conflict");

--- a/packages/backend/src/services/vercel-publish.ts
+++ b/packages/backend/src/services/vercel-publish.ts
@@ -84,5 +84,7 @@ export async function requestVercel(endpoint: string, token: string, teamId: str
   if (!value || typeof value !== "object" || !("id" in value) || typeof value.id !== "string" || !/^dpl_[a-zA-Z0-9]+$/.test(value.id) || !("url" in value) || typeof value.url !== "string" || !/^[a-zA-Z0-9-]+\.vercel\.app$/.test(value.url)) throw new VercelPublishError("publish_provider_failed");
   const state = "readyState" in value ? value.readyState : "status" in value ? value.status : undefined;
   if (state === "ERROR" || state === "CANCELED") throw new VercelPublishError("publish_build_failed");
-  return { schema_version: 1, id: value.id, url: `https://${value.url}`, ready: state === "READY" };
+  const alias = state === "READY" && "alias" in value && Array.isArray(value.alias)
+    ? value.alias.find((item: unknown): item is string => typeof item === "string" && /^[a-zA-Z0-9-]+\.vercel\.app$/.test(item)) : undefined;
+  return { schema_version: 1, id: value.id, url: `https://${alias ?? value.url}`, ready: state === "READY" };
 }

--- a/packages/backend/tests/vercel-publish.test.ts
+++ b/packages/backend/tests/vercel-publish.test.ts
@@ -61,3 +61,13 @@ test("Given provider responses, when checking deployment, then only validated UR
   await expect(requestVercel("/v13/deployments/dpl_abc", "secret", undefined, signal, undefined, respond({ id: "dpl_abc", url: "evil.example", readyState: "READY" }))).rejects.toThrow("publish_provider_failed");
   await expect(requestVercel("/v13/deployments/dpl_abc", "secret", undefined, signal, undefined, respond({ message: "private secret" }, 403))).rejects.toThrow("publish_auth_failed");
 });
+
+test("Given internal generation notes and font licenses When publishing Then notes stay private and website assets publish", async () => {
+  const zip = new JSZip();
+  const expected = { schema_version: 1 as const, entrypoint: "index.html", project_revision: 20, project_digest: "digest", input_closure_digest: "closure" };
+  const contents = { "index.html": '<html><body>Hello</body></html>', "assets/site.css": "body{color:black}", "assets/generated-assets.json": "{}", "assets/image-prompts.txt": "private prompt", "fonts/manifest.json": "{}", "fonts/DMSans-OFL.txt": "font license", "attachments/source.pdf": "private document", "secrets.js": "private credential" };
+  for (const [name, data] of Object.entries(contents)) zip.file(name, data);
+  zip.file("burnguard-export.json", JSON.stringify({ ...expected, entries: Object.entries(contents).sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0).map(([path, data]) => ({ path, size: Buffer.byteLength(data), sha256: sha256(data) })) }));
+  const files = await deploymentFiles(await zip.generateAsync({ type: "uint8array" }), expected);
+  expect(files.map(file => file.file).sort()).toEqual(["assets/site.css", "fonts/DMSans-OFL.txt", "index.html"]);
+});

--- a/packages/backend/tests/vercel-publish.test.ts
+++ b/packages/backend/tests/vercel-publish.test.ts
@@ -71,3 +71,8 @@ test("Given internal generation notes and font licenses When publishing Then not
   const files = await deploymentFiles(await zip.generateAsync({ type: "uint8array" }), expected);
   expect(files.map(file => file.file).sort()).toEqual(["assets/site.css", "fonts/DMSans-OFL.txt", "index.html"]);
 });
+
+test("Given a ready production alias When checking deployment Then the shared URL uses that alias", async () => {
+  const fetcher = (async () => Response.json({ id: "dpl_test", url: "preview.vercel.app", readyState: "READY", alias: ["https://invalid.example", "public-site.vercel.app"] })) as typeof fetch;
+  expect((await requestVercel("/v13/deployments/dpl_test", "test-token", undefined, new AbortController().signal, undefined, fetcher)).url).toBe("https://public-site.vercel.app");
+});


### PR DESCRIPTION
Vercel publishing rejected an entire valid HTML export whenever it contained generation records, prompt notes, font manifests, or license files. Filter the verified archive to public website assets instead, retaining font OFL notices and rejecting private entrypoints. Internal files never reach Vercel; archive integrity validation remains unchanged. Ready deployments now return a validated production alias when available, avoiding the authenticated per-deployment URL.

Validation: 7 Vercel tests, typecheck and lint passed. An authorized real deployment reached READY. Its public production URL required no login; all 41 published files returned HTTP 200. Browser inspection verified rendered styling/images and navigation to the project subpage. No token was saved in source/config.