### PR TITLE
chore: release 0.5.7 through PR40

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burnguard-design",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "license": "Apache-2.0",
   "private": true,
   "workspaces": ["packages/*"],

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bg/backend",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/packages/desktop-windows/BurnGuard.Desktop.csproj
+++ b/packages/desktop-windows/BurnGuard.Desktop.csproj
@@ -10,7 +10,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon Condition="Exists('BurnGuard.ico')">BurnGuard.ico</ApplicationIcon>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-    <Version>0.5.6</Version>
+    <Version>0.5.7</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="qa/**/*.cs" />

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bg/frontend",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bg/shared",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/packages/shared/src/app.ts
+++ b/packages/shared/src/app.ts
@@ -4,7 +4,7 @@ export const APP_NAME = "BurnGuard Design";
 // When cutting a release, bump this in lockstep with the root
 // `package.json` and every `packages/<name>/package.json`. These
 // should always agree — verified manually at release time.
-export const APP_VERSION = "0.5.6";
+export const APP_VERSION = "0.5.7";
 
 export type BackendId = "claude-code" | "codex";
 export type ProjectType =


### PR DESCRIPTION
Bump aligned release versions to 0.5.7, including merged PR39 and PR40. Publication requires Daybreak source/artifact security approval and Windows packaging verification. macOS signing credentials remain unavailable.