### PR TITLE
Build v0.5.8 for Windows and unsigned macOS

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -28,11 +28,7 @@ jobs:
       - run: bun run typecheck
       - run: bun run lint
       - run: bun test packages/backend/tests/mac-updates.test.ts packages/backend/tests/app-update-routes.test.ts --timeout 30000
-      - name: Build signed and notarized macOS release
-        env:
-          BG_MAC_SIGN_IDENTITY: ${{ secrets.BG_MAC_SIGN_IDENTITY }}
-          BG_MAC_INSTALL_IDENTITY: ${{ secrets.BG_MAC_INSTALL_IDENTITY }}
-          BG_MAC_NOTARY_PROFILE: ${{ secrets.BG_MAC_NOTARY_PROFILE }}
+      - name: Build unsigned macOS release
         run: bun run build:mac:release
       - name: Verify the bundled Node renderer runtime
         run: test -x "dist/mac/BurnGuard Design.app/Contents/MacOS/resources/node/node"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burnguard-design",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "license": "Apache-2.0",
   "private": true,
   "workspaces": ["packages/*"],

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bg/backend",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/packages/desktop-windows/BurnGuard.Desktop.csproj
+++ b/packages/desktop-windows/BurnGuard.Desktop.csproj
@@ -10,7 +10,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon Condition="Exists('BurnGuard.ico')">BurnGuard.ico</ApplicationIcon>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-    <Version>0.5.7</Version>
+    <Version>0.5.8</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="qa/**/*.cs" />

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bg/frontend",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bg/shared",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/packages/shared/src/app.ts
+++ b/packages/shared/src/app.ts
@@ -4,7 +4,7 @@ export const APP_NAME = "BurnGuard Design";
 // When cutting a release, bump this in lockstep with the root
 // `package.json` and every `packages/<name>/package.json`. These
 // should always agree — verified manually at release time.
-export const APP_VERSION = "0.5.7";
+export const APP_VERSION = "0.5.8";
 
 export type BackendId = "claude-code" | "codex";
 export type ProjectType =

--- a/scripts/package-mac-release.ts
+++ b/scripts/package-mac-release.ts
@@ -4,7 +4,7 @@
  * .nupkg, releases.osx.json feed) from the .app that `build-mac.ts` produced.
  * Publication is a separate release step; this only writes dist/releases.
  *
- * Release packaging requires signing and notarization credentials:
+ * Signing and notarization are optional; omit all three for free unsigned distribution:
  *   BG_MAC_SIGN_IDENTITY       Developer ID Application certificate subject
  *   BG_MAC_INSTALL_IDENTITY    Developer ID Installer certificate subject
  *   BG_MAC_NOTARY_PROFILE      notarytool keychain profile name
@@ -34,11 +34,14 @@ const requiredSigning = [
   ["BG_MAC_INSTALL_IDENTITY", "--signInstallIdentity"],
   ["BG_MAC_NOTARY_PROFILE", "--notaryProfile"],
 ] as const;
-for (const [environmentKey, argument] of requiredSigning) {
+const signingConfigured = requiredSigning.some(([key]) => Boolean(process.env[key]));
+for (const [environmentKey, argument] of signingConfigured ? requiredSigning : []) {
   const value = process.env[environmentKey];
-  if (!value) throw new Error(`[release] ${environmentKey} is required; refusing to publish an unsigned macOS package`);
+  if (!value) throw new Error(`[release] ${environmentKey} is required when signing is configured`);
   signing.push(argument, value);
 }
+
+if (!signingConfigured) console.log("[release] Building without Developer ID signing or notarization.");
 
 // `[osx]` is interpolated so the Bun shell never treats it as a glob.
 const platform = "[osx]";
@@ -48,7 +51,7 @@ await $`dotnet tool run vpk -- ${platform} pack --packId BurnGuard --packVersion
 
 const files: string[] = [];
 for await (const name of new Bun.Glob("*").scan({ cwd: output, onlyFiles: true })) {
-  if (name === "SHA256SUMS.txt") continue;
+  if (name === "SHA256SUMS-macos.txt") continue;
   const bytes = await readFile(path.join(output, name));
   files.push(`${new Bun.CryptoHasher("sha256").update(bytes).digest("hex")}  ${name}`);
 }

--- a/scripts/package-mac-release.ts
+++ b/scripts/package-mac-release.ts
@@ -55,5 +55,5 @@ for await (const name of new Bun.Glob("*").scan({ cwd: output, onlyFiles: true }
   const bytes = await readFile(path.join(output, name));
   files.push(`${new Bun.CryptoHasher("sha256").update(bytes).digest("hex")}  ${name}`);
 }
-await writeFile(path.join(output, "SHA256SUMS.txt"), files.sort().join("\n") + "\n");
+await writeFile(path.join(output, "SHA256SUMS-macos.txt"), files.sort().join("\n") + "\n");
 console.log(`[release] ${APP_VERSION}: macOS installer, portable app, and update feed ready in dist/releases`);


### PR DESCRIPTION
Build 0.5.8 (user-approved replacement for unsupported four-part 0.5.7.1) for Windows x64 and unsigned macOS Apple Silicon. Signing is optional for macOS; partial credential configuration fails. A separate SHA256SUMS-macos.txt avoids Windows manifest collisions.

Validation: typecheck/lint and 12 update tests passed. Windows installer/portable/update packages built; .NET UpdateChecks passed without applying a live update. macOS workflow 34451801390 succeeded at 4695ce57bd52d565201663ef1a9a2184ca53e4bd; security CI passed. Daybreak source and both platform artifact checks found no unresolved security blockers after the checksum fix; all package hashes/feed versions verified.

Runtime limitation: the standard Windows relocated smoke timed out at its 90-second startup deadline twice. Direct isolated startup passed under 120 seconds. The same full package smoke with a diagnostic-only 180-second startup budget passed all seven checks (health, fresh migrations/seeds, original samples/images, UI/JS, Three runtime/license/save, bundled Node browser probe). macOS interactive launch and live automatic update installation were not tested. No public release published.
