### PR TITLE
Import exported HTML projects without AI approval

### DIFF
--- a/packages/backend/src/db/seed.ts
+++ b/packages/backend/src/db/seed.ts
@@ -299,6 +299,7 @@ export async function createProjectRecord(input: {
   optionsJson: string | null;
   entrypoint: string;
   thumbnailPath: string | null;
+  initializeArtifact?: (stage: string) => Promise<void>;
 }) {
   const db = getDb();
   const now = Date.now();
@@ -357,7 +358,8 @@ export async function createProjectRecord(input: {
 
   try {
     await new ArtifactCoordinator(getSqlite()).initializeProject(projectId, dirPath, async (stage) => {
-      if (original && originalFormat) await copyOriginalSample(original.slug, originalFormat.directory, stage);
+      if (input.initializeArtifact) await input.initializeArtifact(stage);
+      else if (original && originalFormat) await copyOriginalSample(original.slug, originalFormat.directory, stage);
       else {
         await copyBundledFonts(stage);
         await writeFile(path.join(stage, input.entrypoint), initialArtifact, "utf8");

--- a/packages/backend/src/routes/home.ts
+++ b/packages/backend/src/routes/home.ts
@@ -22,6 +22,7 @@ import {
   ProjectInputError,
 } from "./home-project-input";
 import { serveProjectThumbnail } from "./project-thumbnail-handler";
+import { importProject, ProjectImportError } from "../services/project-import";
 
 const VALID_PROJECT_TABS = new Set(["recent", "mine", "examples"]);
 const VALID_SYSTEM_STATUSES = new Set<DesignSystemStatus>([
@@ -89,6 +90,19 @@ function toSettingsSummary(config: Awaited<ReturnType<typeof loadConfig>>): Sett
 }
 
 export const homeRoutes = new Hono();
+
+homeRoutes.post("/api/projects/import", async (c) => {
+  try {
+    const form = await c.req.formData().catch(() => null);
+    if (!form) throw new ProjectImportError("invalid_project_import");
+    const imported = await importProject(form);
+    await ensureProjectWatcher(imported.id);
+    return c.json(ok(imported), 201);
+  } catch (error) {
+    if (error instanceof ProjectImportError) return c.json(fail(error.code, "프로젝트 파일을 가져오지 못했어요."), error.code === "project_import_limit" ? 413 : 400);
+    throw error;
+  }
+});
 
 homeRoutes.get("/api/projects", async (c) => {
   const tab = c.req.query("tab") ?? "recent";

--- a/packages/backend/src/security/request-limits.ts
+++ b/packages/backend/src/security/request-limits.ts
@@ -14,6 +14,7 @@ const JSON_BODY_BYTES = 1 * MiB;
 export const MAX_USER_MESSAGE_CHARS = 200_000;
 
 const MULTIPART_ROUTES = [
+  /^\/api\/projects\/import$/,
   /^\/api\/design-systems\/upload$/,
   /^\/api\/design-systems\/[^/]+\/fonts$/,
   /^\/api\/sessions\/[^/]+\/(?:events|documents)$/,

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -156,7 +156,7 @@ export function classifyApiRoute(pathname: string, method: string): ApiRouteDoma
   if (pathname.startsWith("/api/sessions")) return "session";
   if (pathname.startsWith("/api/runtime")) return "runtime";
   if (pathname.startsWith("/api/settings/")) return "settings";
-  if (pathname === "/api/settings" || pathname.startsWith("/api/backends") || pathname.startsWith("/api/home") || pathname === "/api/projects") return "home";
+  if (pathname === "/api/settings" || pathname.startsWith("/api/backends") || pathname.startsWith("/api/home") || pathname === "/api/projects" || pathname === "/api/projects/import") return "home";
   if (method === "GET" && /^\/api\/projects\/[^/]+\/thumbnail$/.test(pathname)) return "home";
   if (/^\/api\/projects\/[^/]+\/three-scene$/.test(pathname)) return "three-scene";
   if (pathname.startsWith("/api/projects")) {

--- a/packages/backend/src/services/project-import.ts
+++ b/packages/backend/src/services/project-import.ts
@@ -1,0 +1,96 @@
+import { Readable } from "node:stream";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import JSZip from "jszip";
+import { parse } from "node-html-parser";
+import { createProjectRecord } from "../db/seed";
+import { assertSafeName, resolveWithin } from "../security/path-boundary";
+import { inspectCanonicalTree } from "./canonical-tree-manifest";
+import { HTML_EXPORT_MANIFEST } from "./export-html-validation";
+
+const MAX_UPLOAD = 48 * 1024 * 1024;
+const MAX_EXPANDED = 128 * 1024 * 1024;
+const MAX_FILES = 10_000;
+export class ProjectImportError extends Error {
+  constructor(readonly code: "invalid_project_import" | "project_import_limit" | "project_import_entrypoint") { super(code); }
+}
+type Entry = { name: string; bytes: Uint8Array };
+
+function safePath(name: string): string {
+  if (name.length > 1024 || name.includes("\\") || name.split("/").length > 32) throw new ProjectImportError("invalid_project_import");
+  try { name.split("/").forEach(assertSafeName); } catch { throw new ProjectImportError("invalid_project_import"); }
+  return name.normalize("NFC");
+}
+
+/** Reads uploaded bytes only. Never follows a client-supplied filesystem path or executes imported code. */
+export async function importProject(form: FormData) {
+  const name = form.get("name");
+  const source = form.get("source");
+  const files = form.getAll("files");
+  if (typeof name !== "string" || !name.trim() || name.length > 200 || !["zip", "folder"].includes(String(source)) || !files.length || files.length > MAX_FILES || files.some(file => !(file instanceof File))) throw new ProjectImportError("invalid_project_import");
+  const uploads = files as File[];
+  if (uploads.reduce((sum, file) => sum + file.size, 0) > MAX_UPLOAD) throw new ProjectImportError("project_import_limit");
+  let entries: Entry[] = [];
+  if (source === "zip") {
+    if (uploads.length !== 1) throw new ProjectImportError("invalid_project_import");
+    let zip: JSZip;
+    try { zip = await JSZip.loadAsync(await uploads[0]!.arrayBuffer()); } catch { throw new ProjectImportError("invalid_project_import"); }
+    if (Object.keys(zip.files).length > MAX_FILES) throw new ProjectImportError("project_import_limit");
+    let remaining = MAX_EXPANDED;
+    for (const file of Object.values(zip.files)) {
+      const raw = (file as JSZip.JSZipObject & { unsafeOriginalName?: string }).unsafeOriginalName ?? file.name;
+      const normalized = safePath(raw.replace(/\/$/, ""));
+      if (file.unixPermissions !== null && (Number(file.unixPermissions) & 0xf000) === 0xa000) throw new ProjectImportError("invalid_project_import");
+      if (file.dir) continue;
+      const bytes = await boundedZip(file, remaining);
+      remaining -= bytes.length;
+      entries.push({ name: normalized, bytes });
+    }
+  } else {
+    const paths = form.getAll("paths");
+    if (paths.length !== uploads.length || paths.some(value => typeof value !== "string")) throw new ProjectImportError("invalid_project_import");
+    for (let i = 0; i < uploads.length; i++) entries.push({ name: safePath(paths[i] as string), bytes: new Uint8Array(await uploads[i]!.arrayBuffer()) });
+  }
+  // Browser folder selection and Finder ZIPs both include one enclosing directory.
+  entries = entries.filter(entry => !entry.name.split("/").some(part => part === "__MACOSX" || part === ".DS_Store" || part.startsWith("._")));
+  while (entries.length && entries.every(entry => entry.name.includes("/") && entry.name.split("/")[0] === entries[0]!.name.split("/")[0])) entries = entries.map(entry => ({ ...entry, name: entry.name.slice(entry.name.indexOf("/") + 1) }));
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    const key = entry.name.toLowerCase();
+    if (seen.has(key) || entry.name.split("/").some(part => part.startsWith(".")) || /(?:^|\/)(?:node_modules|docs|AGENTS\.md|CLAUDE\.md)(?:\/|$)/i.test(entry.name) || /\.(?:exe|dll|sh|bat|cmd|ps1|pem|key|p12|pfx)$/i.test(entry.name)) throw new ProjectImportError("invalid_project_import");
+    seen.add(key);
+  }
+  const manifest = entries.find(entry => entry.name === HTML_EXPORT_MANIFEST);
+  let entrypoint = entries.some(entry => entry.name === "index.html") ? "index.html" : entries.some(entry => entry.name === "deck.html") ? "deck.html" : "";
+  if (manifest) {
+    try { const value: unknown = JSON.parse(new TextDecoder().decode(manifest.bytes)); if (typeof value !== "object" || !value || !("entrypoint" in value) || typeof value.entrypoint !== "string") throw new Error(); entrypoint = safePath(value.entrypoint); } catch { throw new ProjectImportError("invalid_project_import"); }
+  }
+  if (!entrypoint) { const html = entries.filter(entry => /\.html?$/i.test(entry.name)); if (html.length === 1) entrypoint = html[0]!.name; }
+  const entry = entries.find(item => item.name === entrypoint);
+  if (!entry || !/\.html?$/i.test(entrypoint)) throw new ProjectImportError("project_import_entrypoint");
+  const html = parse(new TextDecoder().decode(entry.bytes));
+  const type = html.querySelector("[data-slide]") ? "slide_deck" : "prototype";
+  const created = await createProjectRecord({ name: name.trim(), type, designSystemId: null, backendId: "codex", optionsJson: null, entrypoint, thumbnailPath: null,
+    initializeArtifact: async stage => {
+      for (const item of entries.filter(item => item.name !== HTML_EXPORT_MANIFEST)) {
+        const target = resolveWithin(stage, item.name);
+        await mkdir(path.dirname(target), { recursive: true });
+        await writeFile(target, item.bytes, { flag: "wx" });
+      }
+      await inspectCanonicalTree(stage);
+    },
+  });
+  return { id: created.id, session_id: created.session_id, entrypoint: created.entrypoint };
+}
+
+function boundedZip(file: JSZip.JSZipObject, limit: number): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    const chunks: Uint8Array[] = [];
+    const stream = file.nodeStream("nodebuffer");
+    stream.on("data", (chunk: Uint8Array) => { size += chunk.length; if (size > limit) { stream.pause(); if (stream instanceof Readable) stream.destroy(); reject(new ProjectImportError("project_import_limit")); } else chunks.push(chunk); });
+    stream.on("error", () => reject(new ProjectImportError("invalid_project_import")));
+    stream.on("end", () => resolve(Buffer.concat(chunks)));
+    stream.resume();
+  });
+}

--- a/packages/backend/tests/project-import.test.ts
+++ b/packages/backend/tests/project-import.test.ts
@@ -1,0 +1,68 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { readFile, rm } from "node:fs/promises";
+import path from "node:path";
+import JSZip from "jszip";
+import { importProject } from "../src/services/project-import";
+import { runMigrations } from "../src/db/migrate-local";
+import { getSqlite } from "../src/db/sqlite-client";
+import { getProjectDetail } from "../src/db/project-read-repository";
+import { inspectCanonicalTree } from "../src/services/canonical-tree-manifest";
+import { createApp } from "../src/server";
+import { enqueueProjectExport } from "../src/services/exports";
+import { getExportJob } from "../src/db/exports";
+import { sequencedBroker } from "../src/services/broker";
+
+const created: { id: string; dir: string }[] = [];
+beforeAll(runMigrations);
+afterAll(async () => { for (const project of created) { getSqlite().query("DELETE FROM projects WHERE id=?").run(project.id); await rm(project.dir, { recursive: true, force: true }); } });
+async function zipForm(files: Record<string, string>, name = "한국흑연") {
+  const zip = new JSZip(); for (const [name, content] of Object.entries(files)) zip.file(name, content);
+  const form = new FormData(); form.set("name", name); form.set("source", "zip"); form.set("files", new File([await zip.generateAsync({ type: "uint8array" })], "project.zip")); return form;
+}
+async function track(form: FormData) {
+  const result = await importProject(form); const project = await getProjectDetail(result.id); if (!project) throw new Error("missing project"); created.push({ id: result.id, dir: project.dir_path }); return { result, project };
+}
+
+test("Given an exported Korean multipage website When imported, exported and imported again Then CSS, images, subpages and canonical authority survive without AI", async () => {
+  const html = '<!doctype html><html><head><link rel="stylesheet" href="css/site.css"></head><body><h1>한국흑연</h1><img src="images/logo.svg"><a href="회사/소개.html">소개</a></body></html>';
+  const { result, project } = await track(await zipForm({ "한국흑연/index.html": html, "한국흑연/css/site.css": "h1{color:red}", "한국흑연/images/logo.svg": '<svg xmlns="http://www.w3.org/2000/svg"/>', "한국흑연/회사/소개.html": "소개" }));
+  expect(await readFile(path.join(project.dir_path, "index.html"), "utf8")).toBe(html);
+  expect(project.current_digest).toBe((await inspectCanonicalTree(project.dir_path)).tree_digest);
+  expect(result).not.toHaveProperty("dir_path");
+  const terminal = new Promise<void>((resolve, reject) => { const timer = setTimeout(() => { stop(); reject(new Error("export timeout")); }, 30000); const stop = sequencedBroker.subscribe(result.session_id, event => { if (event.event.type === "export.attempt" && ["validated", "failed"].includes(event.event.status)) { clearTimeout(timer); stop(); resolve(); } }); });
+  const job = await enqueueProjectExport(result.id, "html_zip", {}); await terminal;
+  const exported = await getExportJob(job!.id); expect(exported?.status).toBe("succeeded");
+  const form = new FormData(); form.set("name", "재가져오기"); form.set("source", "zip"); form.set("files", new File([await readFile(exported!.output_path!)], "export.zip"));
+  const again = await track(form);
+  expect(await readFile(path.join(again.project.dir_path, "회사/소개.html"), "utf8")).toBe("소개");
+  expect(again.project.current_digest).toBe(project.current_digest);
+}, 60000);
+
+test("Given a folder selection When imported Then relative paths and the deck entrypoint are retained", async () => {
+  const form = new FormData(); form.set("name", "슬라이드"); form.set("source", "folder");
+  form.append("files", new File(['<section data-slide>slide</section>'], "deck.html")); form.append("paths", "내 폴더/deck.html");
+  const { project } = await track(form); expect(project.type).toBe("slide_deck"); expect(project.entrypoint).toBe("deck.html");
+});
+
+test("Given unsafe archives When imported Then traversal, case collisions and missing HTML fail without creating projects", async () => {
+  const count = () => getSqlite().query<{ count: number }, []>("SELECT count(*) as count FROM projects").get()!.count;
+  const before = count();
+  for (const files of [{ "../index.html": "bad" }, { "index.html": "ok", "INDEX.html": "collision" }, { "index.html": "ok", ".env": "secret" }, { "readme.txt": "no HTML" }]) await expect(importProject(await zipForm(files))).rejects.toThrow();
+  expect(count()).toBe(before);
+});
+
+test("Given import requests without launch authority When submitted Then the shared API gate denies them", async () => {
+  const app = createApp({ capability: "import-test", appAuthority: "127.0.0.1:14070" });
+  const response = await app.request(new Request("http://127.0.0.1:14070/api/projects/import", { method: "POST", headers: { host: "127.0.0.1:14070", origin: "http://127.0.0.1:14070" }, body: await zipForm({ "index.html": "ok" }) }));
+  expect(response.status).toBe(403);
+});
+
+test("Given symlinks or highly compressed oversized content When imported Then extraction is rejected", async () => {
+  for (const kind of ["symlink", "oversized"]) {
+    const zip = new JSZip();
+    zip.file("index.html", kind === "oversized" ? "x".repeat(128 * 1024 * 1024 + 1) : "outside", kind === "symlink" ? { unixPermissions: 0o120777 } : {});
+    const form = new FormData(); form.set("name", "unsafe"); form.set("source", "zip");
+    form.set("files", new File([await zip.generateAsync({ type: "uint8array", platform: "UNIX", compression: "DEFLATE" })], "unsafe.zip"));
+    await expect(importProject(form)).rejects.toThrow();
+  }
+}, 60000);

--- a/packages/backend/tests/project-import.test.ts
+++ b/packages/backend/tests/project-import.test.ts
@@ -55,6 +55,10 @@ test("Given import requests without launch authority When submitted Then the sha
   const app = createApp({ capability: "import-test", appAuthority: "127.0.0.1:14070" });
   const response = await app.request(new Request("http://127.0.0.1:14070/api/projects/import", { method: "POST", headers: { host: "127.0.0.1:14070", origin: "http://127.0.0.1:14070" }, body: await zipForm({ "index.html": "ok" }) }));
   expect(response.status).toBe(403);
+  const allowed = await app.request(new Request("http://127.0.0.1:14070/api/projects/import", { method: "POST", headers: { host: "127.0.0.1:14070", origin: "http://127.0.0.1:14070", "x-burnguard-capability": "import-test" }, body: await zipForm({ "index.html": "<!doctype html><html><body>ok</body></html>" }) }));
+  const result = await allowed.json() as { data?: { id: string }; error?: unknown };
+  expect({ status: allowed.status, error: result.error }).toEqual({ status: 201, error: undefined });
+  const detail = await getProjectDetail(result.data!.id); created.push({ id: detail!.id, dir: detail!.dir_path });
 });
 
 test("Given symlinks or highly compressed oversized content When imported Then extraction is rejected", async () => {

--- a/packages/frontend/src/components/home/ProjectImportDialog.tsx
+++ b/packages/frontend/src/components/home/ProjectImportDialog.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+import { apiFetch, ApiError } from "@/api/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+export default function ProjectImportDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
+  const [name, setName] = useState("");
+  const [source, setSource] = useState<"zip" | "folder">("zip");
+  const [files, setFiles] = useState<File[]>([]);
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const body = new FormData(); body.set("name", name.trim()); body.set("source", source);
+      for (const file of files) { body.append("files", file); if (source === "folder") body.append("paths", file.webkitRelativePath || file.name); }
+      return apiFetch<{ id: string }>("/api/projects/import", { method: "POST", body });
+    },
+    onSuccess: async project => { await queryClient.invalidateQueries({ queryKey: ["projects"] }); onOpenChange(false); navigate(`/projects/${project.id}`); },
+  });
+  const oversized = files.reduce((sum, file) => sum + file.size, 0) > 48 * 1024 * 1024 || files.length > 10_000;
+  const code = mutation.error instanceof ApiError ? mutation.error.code : "";
+  return <Dialog open={open} onOpenChange={next => { if (!mutation.isPending) onOpenChange(next); }}>
+    <DialogContent><DialogHeader><DialogTitle>프로젝트 가져오기</DialogTitle><DialogDescription>내보낸 HTML ZIP 또는 압축을 푼 폴더를 선택하세요. HTML·CSS·이미지를 함께 복사해 새 프로젝트로 열어요. AI 연결이나 별도 승인은 필요 없어요.</DialogDescription></DialogHeader>
+      <form className="space-y-4" onSubmit={event => { event.preventDefault(); if (!oversized && files.length && name.trim()) mutation.mutate(); }}>
+        <label className="block space-y-2 text-sm">프로젝트 이름<Input value={name} maxLength={200} onChange={event => setName(event.target.value)} disabled={mutation.isPending} required /></label>
+        <label className="block space-y-2 text-sm">가져올 형식<select className="w-full rounded-md border border-border bg-background p-2" value={source} disabled={mutation.isPending} onChange={event => { setSource(event.target.value as "zip" | "folder"); setFiles([]); mutation.reset(); }}><option value="zip">HTML ZIP 파일</option><option value="folder">HTML 프로젝트 폴더</option></select></label>
+        <label className="block space-y-2 text-sm">{source === "zip" ? "ZIP 선택" : "폴더 선택"}<input key={source} type="file" className="block w-full" disabled={mutation.isPending} {...(source === "zip" ? { accept: ".zip" } : { webkitdirectory: "", directory: "", multiple: true })} onChange={event => { const next = Array.from(event.target.files ?? []); setFiles(next); mutation.reset(); if (!name && next[0]) setName((next[0].webkitRelativePath.split("/")[0] || next[0].name).replace(/\.zip$/i, "").slice(0, 200)); }} /></label>
+        <p className="text-xs text-muted-foreground">최대 48MB · 압축 해제 후 128MB · 10,000개 파일. 원본 폴더는 그대로 유지해요. 대화 기록과 AI 설정은 복원하지 않아요.</p>
+        {files.length > 0 && <p role="status" className="text-xs">{files.length}개 선택됨</p>}
+        {(oversized || mutation.isError) && <p role="alert" className="text-sm text-destructive">{oversized || code === "project_import_limit" || code === "payload_too_large" ? "파일 개수나 용량 제한을 초과했어요." : code === "project_import_entrypoint" ? "시작할 HTML을 찾지 못했어요. index.html 또는 내보내기 정보를 포함해 주세요." : "가져오지 못했어요. HTML·CSS·이미지만 포함한 ZIP 또는 폴더인지 확인해 주세요."}</p>}
+        <Button className="w-full" type="submit" disabled={mutation.isPending || oversized || !files.length || !name.trim()}>{mutation.isPending ? "프로젝트를 가져오고 있어요…" : "가져와서 열기"}</Button>
+      </form>
+    </DialogContent>
+  </Dialog>;
+}

--- a/packages/frontend/src/views/HomeView.tsx
+++ b/packages/frontend/src/views/HomeView.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/home/mappers";
 import ProjectCardSection from "@/components/home/ProjectCardSection";
 import ProjectCard from "@/components/home/ProjectCard";
+import ProjectImportDialog from "@/components/home/ProjectImportDialog";
 import NewProjectPanel from "@/components/home/NewProjectPanel";
 import PinterestImportDialog from "@/components/home/PinterestImportDialog";
 import DeleteDesignSystemDialog from "@/components/home/DeleteDesignSystemDialog";
@@ -71,6 +72,7 @@ export default function HomeView() {
   const creationType: ProjectType | null = requestedType === "other" || PROJECT_TYPES.some((type) => type.id === requestedType) ? requestedType as ProjectType : null;
   const createTriggerRef = useRef<HTMLButtonElement>(null);
   const [creatingProject, setCreatingProject] = useState(false);
+  const [projectImportOpen, setProjectImportOpen] = useState(false);
   const [projectQuery, setProjectQuery] = useState("");
   const [systemQuery, setSystemQuery] = useState("");
   const [systemStatus, setSystemStatus] = useState<"all" | "draft" | "review" | "published">("all");
@@ -305,6 +307,7 @@ export default function HomeView() {
 
   return (
     <>
+      <ProjectImportDialog open={projectImportOpen} onOpenChange={setProjectImportOpen} />
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
         <div className="mx-auto w-full max-w-[1440px] px-4 pb-8 pt-7 sm:px-8 sm:pt-10 lg:px-10">
         <div className="mb-8 flex flex-wrap items-start justify-between gap-5">
@@ -313,7 +316,7 @@ export default function HomeView() {
             <h1 className="text-2xl font-semibold tracking-tight sm:text-[32px] sm:leading-tight">{HOME_TITLES[activeTab].title}</h1>
             <p className="mt-2 text-sm leading-6 text-muted-foreground">{HOME_TITLES[activeTab].description}</p>
           </div>
-          <Button ref={createTriggerRef} variant="cta" className="h-11 gap-2 rounded-xl px-4" onClick={() => startProject()} aria-haspopup="dialog"><Plus className="h-4 w-4" aria-hidden="true" />새 프로젝트</Button>
+          <div className="flex gap-2"><Button variant="outline" className="h-11" onClick={() => setProjectImportOpen(true)}>프로젝트 가져오기</Button><Button ref={createTriggerRef} variant="cta" className="h-11 gap-2 rounded-xl px-4" onClick={() => startProject()} aria-haspopup="dialog"><Plus className="h-4 w-4" aria-hidden="true" />새 프로젝트</Button></div>
         </div>
         {detectionQuery.data?.backends.every((backend) => !backend.found) ? <div className="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border bg-card px-4 py-3"><p className="text-sm text-muted-foreground">AI와 작업하려면 Claude Code 또는 Codex를 연결해 주세요. 예제와 편집 기능은 먼저 살펴볼 수 있어요.</p><Button variant="outline" size="sm" onClick={() => setCliMissingOpen(true)}>AI 연결 안내</Button></div> : null}
         {activeTab === "recent" || activeTab === "mine" ? <section aria-label="빠른 시작" className="mb-10 grid grid-cols-1 gap-3 min-[430px]:grid-cols-2 xl:grid-cols-4">

--- a/scripts/qa/creation-canvas-fixtures.mjs
+++ b/scripts/qa/creation-canvas-fixtures.mjs
@@ -1,5 +1,6 @@
 // Run only against e2e-smoke's owned temporary profile. Provider POSTs are intercepted;
 // mock transcript assertions below are UI delivery checks, never provider execution proof.
+import JSZip from "jszip";
 import assert from "node:assert/strict";
 import { mkdir, realpath, writeFile } from "node:fs/promises";
 import path from "node:path";
@@ -19,6 +20,23 @@ export async function runCreationCanvasFixtures(page, base, scenario, { home, sh
   };
   await page.route(eventPattern, guard);
   try {
+    await scenario("creation-canvas-project-import", async () => {
+      await page.goto(base);
+      const zip = new JSZip();
+      zip.file("한국흑연/index.html", '<!doctype html><html><head><link rel="stylesheet" href="style.css"></head><body><h1 id="import-heading">한국흑연 가져오기</h1><img src="logo.svg"><a href="about.html">소개</a></body></html>');
+      zip.file("한국흑연/style.css", "h1{color:rgb(255, 0, 0)}");
+      zip.file("한국흑연/logo.svg", '<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40"><rect width="40" height="40" fill="blue"/></svg>');
+      zip.file("한국흑연/about.html", '<!doctype html><html><body><h1>회사 소개</h1></body></html>');
+      await page.getByRole("button", { name: "프로젝트 가져오기", exact: true }).click();
+      await page.getByLabel("ZIP 선택", { exact: true }).setInputFiles({ name: "한국흑연.zip", mimeType: "application/zip", buffer: await zip.generateAsync({ type: "nodebuffer" }) });
+      await page.getByRole("button", { name: "가져와서 열기", exact: true }).click();
+      await page.waitForURL(/\/projects\/[^/]+$/);
+      const frame = page.frameLocator('iframe[title="캔버스"]');
+      await frame.locator("#import-heading").waitFor();
+      assert.equal(await frame.locator("#import-heading").evaluate(el => getComputedStyle(el).color), "rgb(255, 0, 0)");
+      assert.ok(await frame.locator("img").evaluate(el => el.complete && el.naturalWidth > 0));
+      await shot(page, "creation-canvas-project-import");
+    });
     await scenario("creation-canvas-ctrl-wheel-zoom", async () => {
       await createFixture(page, base, ownedHome, "Zoom keyboard test");
       await page.frameLocator('iframe[title="캔버스"]').locator("#fixture-hero").waitFor();


### PR DESCRIPTION
Add Home > Project import for exported HTML ZIPs and extracted folders. The app imports HTML, CSS, images and relative subpages into a new canonical project, opens its preview, and detects slide decks without invoking AI or requiring agent approval. Original source files remain unchanged; chat history and AI settings are not restored.

Existing API authority remains enforced. Intake caps uploads/streamed expansion/files/depth, rejects path traversal, duplicate canonical paths, symlinks, private/agent paths and executable/key extensions, and reuses staged initialization/rollback. The lazy API dispatcher explicitly routes project import to its handler.

Validation: typecheck/lint; five integration/adversarial tests (17 assertions), including authorized API creation and Korean HTML/CSS/image/subpage export-import roundtrip; real-browser ZIP selection -> project navigation -> rendered CSS/image test PASS. Daybreak reviewed final source af5d82f/tree2d24aff with no unresolved security blocker; both security CI checks pass. Windows/macOS0.5.8 replacement packages are being reviewed before public publication.

Final release verification: Windows and macOS packages built from af5d82f (identical merged cb31efd tree). Daybreak static package checks and all14 uploaded asset hashes passed. Final compiled Windows startup/import/file-preview passed in119.128s on an initialized isolated profile; fresh-profile180s startup timed out and remains a documented performance limitation. No macOS interactive launch or live updater apply was tested.
