### PR TITLE
feat: choose image style presets and copy tone in design directions

### DIFF
--- a/packages/backend/src/harness/prompt-builder.ts
+++ b/packages/backend/src/harness/prompt-builder.ts
@@ -24,6 +24,7 @@ import { appendDesignBriefContext } from "./prompt-design-brief";
 import { appendDesignSystemContext } from "./prompt-design-system";
 import { appendGraphicOutputContext } from "./prompt-graphic-set";
 import { DESIGN_CRAFT_RULES } from "./design-craft";
+import { appendGenerationStyle } from "./prompt-generation-style";
 import { appendModelPromptContext } from "./prompt-model-context";
 import { appendReferenceLayoutContext } from "./prompt-reference-layout";
 import { appendVisualSourceContext } from "./prompt-visual-sources";
@@ -139,6 +140,7 @@ export async function buildPrompt(
     lines.push("");
   }
 
+  appendGenerationStyle(lines, directionState?.creative_preferences);
   lines.push("<burnguard-research-context-v1>");
   lines.push(JSON.stringify(buildResearchPromptContext({
     projectType: project.project_type,

--- a/packages/backend/src/harness/prompt-generation-style.ts
+++ b/packages/backend/src/harness/prompt-generation-style.ts
@@ -1,0 +1,12 @@
+import { COPY_TONE_PRESETS, IMAGE_STYLE_PRESETS, type GenerationStyle } from "@bg/shared";
+
+export function appendGenerationStyle(lines: string[], preferences: GenerationStyle | undefined): void {
+  if (preferences === undefined) return;
+  lines.push("<burnguard-generation-style-v1>", JSON.stringify(preferences), "</burnguard-generation-style-v1>");
+  lines.push("## Selected image style and copy tone");
+  lines.push(`- Image treatment: ${IMAGE_STYLE_PRESETS[preferences.image_style].prompt}`);
+  lines.push(`- Copy tone: ${COPY_TONE_PRESETS[preferences.copy_tone].prompt}`);
+  lines.push("- Apply this image treatment to every new image prompt, keeping lighting, materials and visual treatment coherent while using distinct relevant imagery for each placement. Keep Codex image generation and the image-uniqueness checks required by the project; this preset does not select a different image provider.");
+  lines.push("- Apply the tone to headings, body copy, captions and calls to action consistently in the requested language. Preserve names, facts, numbers, quotations and any wording the user requires verbatim; tone never authorizes inventing claims or changing meaning. Review tone consistency in the completion pass.");
+  lines.push("- These saved choices guide future generation and edits, without automatically regenerating existing assets or rewriting approved copy. Follow the user's explicit request for any exception, preserve the selected brand palette/fonts, and do not combine incompatible image styles unless requested.", "");
+}

--- a/packages/backend/src/routes/design-directions.ts
+++ b/packages/backend/src/routes/design-directions.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { Hono } from "hono";
-import type { ApiErrorBody, ApiSuccess, DesignBriefV1, ProjectType } from "@bg/shared";
+import { parseGenerationStyle, UpgradeContractError, type GenerationStyle, type ApiErrorBody, type ApiSuccess, type DesignBriefV1, type ProjectType } from "@bg/shared";
 import { getLatestProjectSession, getProjectDetail } from "../db/project-read-repository";
 import { projectsDir, resolveManagedPath } from "../lib/paths";
 import { PathBoundaryError, assertSafeName } from "../security/path-boundary";
@@ -68,7 +68,10 @@ designDirectionRoutes.post("/api/projects/:projectId/design-directions/generate"
   if (result.response !== undefined) return result.response;
   const value = result.value;
   if (value === undefined) return c.json(fail("project_session_not_found", "Project or session not found"), 404);
-  try { const started = await workflow.generate(value); void started.completion; return c.json(ok(started.state), 202); }
+  let preferences: GenerationStyle | undefined;
+  try { const text = await c.req.text(); if (text.trim() !== "") preferences = parseGenerationStyle(JSON.parse(text)); }
+  catch (error) { if (error instanceof SyntaxError || error instanceof UpgradeContractError) return c.json(fail("invalid_body", "Expected an image style and copy tone preset"), 400); throw error; }
+  try { const started = await workflow.generate(value, preferences); void started.completion; return c.json(ok(started.state), 202); }
   catch (error) { if (error instanceof DesignDirectionWorkflowError) return routeError(error); throw error; }
 });
 
@@ -98,6 +101,23 @@ designDirectionRoutes.post("/api/projects/:projectId/design-directions/select", 
   if (!isRecord(body) || !isText(body["generation_id"]) || !isRevision(body["expected_selection_revision"]) || !isText(body["direction_id"])) return c.json(fail("invalid_body", "Expected generation_id, expected_selection_revision, and direction_id"), 400);
   try { return c.json(ok(await workflow.select(value.sessionId, body["generation_id"], body["expected_selection_revision"], body["direction_id"]))); }
   catch (error) { if (error instanceof DesignDirectionWorkflowError) return routeError(error); throw error; }
+});
+
+designDirectionRoutes.post("/api/projects/:projectId/design-directions/preferences", async (c) => {
+  const result = await generationContext(c.req.param("projectId"));
+  if (result.response !== undefined) return result.response;
+  const value = result.value;
+  if (value === undefined) return c.json(fail("project_session_not_found", "Project or session not found"), 404);
+  const body = await c.req.json<unknown>().catch(() => null);
+  if (!isRecord(body) || Object.keys(body).some((key) => !["generation_id", "expected_selection_revision", "creative_preferences"].includes(key)) || !isText(body.generation_id) || !isRevision(body.expected_selection_revision)) return c.json(fail("invalid_body", "Expected generation identity and creative preferences"), 400);
+  try {
+    const preferences = parseGenerationStyle(body.creative_preferences);
+    return c.json(ok(await workflow.setPreferences(value.sessionId, body.generation_id, body.expected_selection_revision, preferences)));
+  } catch (error) {
+    if (error instanceof UpgradeContractError) return c.json(fail("invalid_body", "Unknown image style or copy tone preset"), 400);
+    if (error instanceof DesignDirectionWorkflowError) return routeError(error);
+    throw error;
+  }
 });
 
 designDirectionRoutes.post("/api/projects/:projectId/design-directions/undo-selection", async (c) => {

--- a/packages/backend/src/services/design-direction-workflow.ts
+++ b/packages/backend/src/services/design-direction-workflow.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { ulid } from "ulid";
-import type { DesignBriefV1, DesignDirectionSlot, DesignDirectionState, ProjectType } from "@bg/shared";
+import { DEFAULT_GENERATION_STYLE, parseGenerationStyle, type GenerationStyle, type DesignBriefV1, type DesignDirectionSlot, type DesignDirectionState, type ProjectType } from "@bg/shared";
 import { assertSafeName, resolveWithin } from "../security/path-boundary";
 import {
   activeDirectionGeneration,
@@ -31,9 +31,10 @@ export class DesignDirectionWorkflow {
 
   constructor(private readonly renderer: DesignDirectionRenderer = new SvgDesignDirectionRenderer(), private readonly now: () => number = Date.now, private readonly id: () => string = ulid) {}
 
-  async generate(input: ProjectSession): Promise<StartedGeneration> {
+  async generate(input: ProjectSession, preferences?: GenerationStyle): Promise<StartedGeneration> {
     const generationId = assertSafeName(this.id());
-    const state = this.initialState(input, generationId);
+    const prior = await getLatestDirectionState(input.sessionId);
+    const state = { ...this.initialState(input, generationId), creative_preferences: parseGenerationStyle(preferences ?? prior?.creative_preferences ?? DEFAULT_GENERATION_STYLE) };
     return this.start(input, state, state.directions.map((slot) => slot.id));
   }
 
@@ -73,6 +74,15 @@ export class DesignDirectionWorkflow {
     const selected = this.snapshot(current, { selected_id: directionId, selection_revision: current.selection_revision + 1, selection_history: [...current.selection_history, current.selected_id] });
     await this.publishSnapshot(sessionId, selected, current);
     return selected;
+  }
+
+  async setPreferences(sessionId: string, generationId: string, revision: number, preferences: GenerationStyle): Promise<DesignDirectionState> {
+    const current = await this.requiredState(sessionId);
+    if (isDirectionOperationActive(sessionId)) throw new DesignDirectionWorkflowError("operation_active");
+    this.checkIdentity(current, generationId, revision);
+    const updated = this.snapshot(current, { creative_preferences: parseGenerationStyle(preferences), selection_revision: current.selection_revision + 1 });
+    await this.publishSnapshot(sessionId, updated, current);
+    return updated;
   }
 
   async undo(sessionId: string, generationId: string, revision: number): Promise<DesignDirectionState> {

--- a/packages/backend/tests/design-direction-contract.test.ts
+++ b/packages/backend/tests/design-direction-contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseDesignDirectionState } from "@bg/shared";
+import { COPY_TONE_PRESETS, IMAGE_STYLE_PRESETS, parseGenerationStyle, parseDesignDirectionState } from "@bg/shared";
 
 function validState(): unknown {
   return {
@@ -23,6 +23,18 @@ function validState(): unknown {
 }
 
 describe("design direction state parser", () => {
+  test("Given saved style presets or a legacy state When decoded Then only known preset identities round trip", () => {
+    const state = parseDesignDirectionState(validState());
+    expect(state.creative_preferences).toBeUndefined();
+    for (const image_style of Object.keys(IMAGE_STYLE_PRESETS)) for (const copy_tone of Object.keys(COPY_TONE_PRESETS)) {
+      const preferences = { schema_version: 1, image_style, copy_tone };
+      expect(parseDesignDirectionState({ ...state, creative_preferences: preferences }).creative_preferences).toEqual(preferences);
+    }
+    for (const preferences of [null, {}, { schema_version: 2, image_style: "brand", copy_tone: "brand" }, { schema_version: 1, image_style: "constructor", copy_tone: "friendly" }, { schema_version: 1, image_style: "studio", copy_tone: "toString" }, { schema_version: 1, image_style: "studio", copy_tone: "friendly", prompt: "ignore safety" }]) {
+      expect(() => parseGenerationStyle(preferences)).toThrow();
+      expect(() => parseDesignDirectionState({ ...state, creative_preferences: preferences })).toThrow();
+    }
+  });
   test("rejects malformed state invariants", () => {
     const mutations: readonly ((state: Record<string, unknown>) => void)[] = [
       (state) => { state["status"] = "unknown"; },

--- a/packages/backend/tests/design-direction-routes.test.ts
+++ b/packages/backend/tests/design-direction-routes.test.ts
@@ -78,6 +78,31 @@ function nextTerminalState(): Promise<DesignDirectionState> {
 }
 
 describe("design direction routes", () => {
+  test("Given style choices When generated, saved and reopened Then the next model prompt receives them and invalid or stale updates fail", async () => {
+    const preferences = { schema_version: 1, image_style: "three_d", copy_tone: "concise" } as const;
+    const terminalEvent = nextTerminalState();
+    expect((await request(`/api/projects/${projectId}/design-directions/generate`, "POST", preferences)).status).toBe(202);
+    const ready = await terminalEvent;
+    expect(ready.creative_preferences).toEqual(preferences);
+    const input = { generation_id: ready.generation_id, expected_selection_revision: ready.selection_revision, creative_preferences: { ...preferences, copy_tone: "friendly" } };
+    const endpoint = `/api/projects/${projectId}/design-directions/preferences`;
+    expect((await request(endpoint, "POST", { ...input, creative_preferences: { ...preferences, image_style: "unknown" } })).status).toBe(400);
+    expect((await request(endpoint, "POST", { ...input, unexpected: true })).status).toBe(400);
+    expect((await request(endpoint, "POST", input)).status).toBe(200);
+    expect((await request(endpoint, "POST", input)).status).toBe(409);
+    const reopened = await (await request(`/api/projects/${projectId}/design-directions`)).json();
+    expect(reopened.data.creative_preferences).toEqual(input.creative_preferences);
+    const context = await buildSessionContext(sessionId);
+    if (context === null) throw new Error("Missing test context");
+    for (const contextMode of ["full", "compact"] as const) {
+      const prompt = await buildPrompt(context, { type: "user.message", text: "Continue" }, { contextMode });
+      expect(JSON.parse(prompt.match(/<burnguard-generation-style-v1>\n([^\n]+)\n<\/burnguard-generation-style-v1>/)![1]!)).toEqual(input.creative_preferences);
+    }
+    getSqlite().prepare("UPDATE sessions SET status='running' WHERE id=?").run(sessionId);
+    try { expect((await request(endpoint, "POST", { ...input, expected_selection_revision: 1 })).status).toBe(409); }
+    finally { getSqlite().prepare("UPDATE sessions SET status='idle' WHERE id=?").run(sessionId); }
+    expect((await request(`/api/projects/${projectId}/design-directions/generate`, "POST", { ...preferences, copy_tone: "invalid" })).status).toBe(400);
+  });
   test("generates state, selects, undoes, and serves validated SVG caching", async () => {
     expect((await request("/api/projects/missing/design-directions")).status).toBe(404);
     const terminalEvent = nextTerminalState();

--- a/packages/backend/tests/design-direction-workflow.test.ts
+++ b/packages/backend/tests/design-direction-workflow.test.ts
@@ -77,6 +77,20 @@ class GateRenderer implements DesignDirectionRenderer {
 }
 
 describe("design direction workflow", () => {
+  test("Given saved image style and tone When reopened, selected, undone and regenerated Then preferences persist and stale saves cannot overwrite them", async () => {
+    const input = session("creative-preferences");
+    const workflow = new DesignDirectionWorkflow();
+    const preferences = { schema_version: 1, image_style: "studio", copy_tone: "friendly" } as const;
+    const ready = await (await workflow.generate(input, preferences)).completion;
+    expect((await new DesignDirectionWorkflow().recover(input.sessionId))?.creative_preferences).toEqual(preferences);
+    const changed = { ...preferences, image_style: "collage", copy_tone: "professional" } as const;
+    const saved = await workflow.setPreferences(input.sessionId, ready.generation_id, ready.selection_revision, changed);
+    await expect(workflow.setPreferences(input.sessionId, ready.generation_id, ready.selection_revision, preferences)).rejects.toMatchObject({ code: "revision_conflict" });
+    const selected = await workflow.select(input.sessionId, saved.generation_id, saved.selection_revision, "editorial");
+    const undone = await workflow.undo(input.sessionId, selected.generation_id, selected.selection_revision);
+    expect(undone.creative_preferences).toEqual(changed);
+    expect((await (await workflow.generate(input)).completion).creative_preferences).toEqual(changed);
+  });
   test("Given initial persistence failure When generation is retried Then the session reservation is released", async () => {
     const input = session("initial-failure");
     const workflow = new DesignDirectionWorkflow(undefined, () => 10, () => "generation-initial-failure");
@@ -99,6 +113,7 @@ describe("design direction workflow", () => {
     try {
       await expect(workflow.select(input.sessionId, started.state.generation_id, 0, "editorial")).rejects.toMatchObject({ code: "operation_active" });
       await expect(workflow.undo(input.sessionId, started.state.generation_id, 0)).rejects.toMatchObject({ code: "operation_active" });
+      await expect(workflow.setPreferences(input.sessionId, started.state.generation_id, 0, { schema_version: 1, image_style: "studio", copy_tone: "calm" })).rejects.toMatchObject({ code: "operation_active" });
       expect((await getLatestDirectionState(input.sessionId))?.selection_revision).toBe(0);
     } finally { await workflow.cancel(input.sessionId); }
   });

--- a/packages/frontend/src/api/design-directions.ts
+++ b/packages/frontend/src/api/design-directions.ts
@@ -1,4 +1,4 @@
-import { parseDesignDirectionState, type DesignDirectionState } from "@bg/shared";
+import { parseDesignDirectionState, type DesignDirectionState, type GenerationStyle } from "@bg/shared";
 import { apiFetch } from "./client";
 
 /**
@@ -36,8 +36,13 @@ export async function getDesignDirectionState(
 
 export async function generateDesignDirections(
   projectId: string,
+  preferences?: GenerationStyle,
 ): Promise<DesignDirectionState> {
-  return parseState(await apiFetch<unknown>(`${base(projectId)}/generate`, { method: "POST" }));
+  return parseState(await apiFetch<unknown>(`${base(projectId)}/generate`, { method: "POST", ...(preferences === undefined ? {} : { body: JSON.stringify(preferences) }) }));
+}
+
+export async function saveDirectionPreferences(projectId: string, input: DirectionUndoInput & { readonly creative_preferences: GenerationStyle }): Promise<DesignDirectionState> {
+  return parseState(await apiFetch<unknown>(`${base(projectId)}/preferences`, { method: "POST", body: JSON.stringify(input) }));
 }
 
 /** Retries every failed or cancelled slot of the current generation. */

--- a/packages/frontend/src/components/directions/DirectionsView.tsx
+++ b/packages/frontend/src/components/directions/DirectionsView.tsx
@@ -1,8 +1,10 @@
-import type { DesignDirectionState } from "@bg/shared";
+import { useEffect, useState } from "react";
+import { DEFAULT_GENERATION_STYLE, type DesignDirectionState, type GenerationStyle } from "@bg/shared";
 import { Check, Compass, RotateCcw, StopCircle } from "lucide-react";
 import { ApiError } from "@/api/client";
 import { Button } from "@/components/ui/button";
 import { DirectionCard } from "./DirectionCard";
+import { GenerationStyleFields } from "./GenerationStyleFields";
 import { directionActions, directionProgress } from "@/lib/design-direction-state";
 
 type DirectionsViewProps = {
@@ -11,7 +13,9 @@ type DirectionsViewProps = {
   readonly actionPending: boolean;
   readonly cancelPending: boolean;
   readonly error: Error | null;
-  readonly onGenerate: () => void;
+  readonly onGenerate: (preferences: GenerationStyle) => void;
+  readonly onSavePreferences: (preferences: GenerationStyle) => void;
+  readonly preferencesSaving: boolean;
   readonly onCancel: () => void;
   readonly onRetry: () => void;
   readonly onSelect: (directionId: string) => void;
@@ -25,11 +29,17 @@ export function DirectionsView({
   cancelPending,
   error,
   onGenerate,
+  onSavePreferences,
+  preferencesSaving,
   onCancel,
   onRetry,
   onSelect,
   onUndo,
 }: DirectionsViewProps) {
+  const savedPreferences = state?.creative_preferences ?? DEFAULT_GENERATION_STYLE;
+  const [preferences, setPreferences] = useState(savedPreferences);
+  useEffect(() => { setPreferences(savedPreferences); }, [state?.generation_id, savedPreferences.image_style, savedPreferences.copy_tone]);
+  const preferencesChanged = preferences.image_style !== savedPreferences.image_style || preferences.copy_tone !== savedPreferences.copy_tone;
   const actions = directionActions(state);
   const selected =
     state?.directions.find((direction) => direction.id === state.selected_id) ?? null;
@@ -48,19 +58,21 @@ export function DirectionsView({
     return (
       <DirectionShell busy={actionPending}>
         <div className="grid min-h-full place-items-center px-4 py-12 text-center">
-          <div className="max-w-lg rounded-2xl border border-border bg-card px-6 py-10 shadow-sm sm:px-10">
+          <div className="w-full max-w-3xl rounded-2xl border border-border bg-card px-6 py-10 shadow-sm sm:px-10">
             <div className="mx-auto mb-5 grid h-14 w-14 place-items-center rounded-2xl bg-accent/10"><Compass className="h-7 w-7 text-accent" aria-hidden="true" /></div>
             <h1 className="text-xl font-semibold tracking-tight">프로젝트의 디자인 방향을 정해요</h1>
             <p className="mt-2 text-sm leading-relaxed text-muted-foreground [word-break:keep-all]">
               현재 콘텐츠를 바탕으로 서로 다른 구성과 스타일의 미리보기 3개를 만들어요.
             </p>
             <p className="mt-3 text-xs leading-6 text-muted-foreground">미리보기를 비교하고 원하는 방향을 선택하면 다음 AI 생성에 반영돼요.</p>
+            <GenerationStyleFields value={preferences} onChange={setPreferences} disabled={actionPending} />
+            <p className="mt-3 text-xs text-muted-foreground">방향을 만들 때 이미지 스타일과 어투도 함께 저장돼요. 아래 미리보기는 구성 예시예요.</p>
             <Button
               type="button"
               variant="cta"
               className="mt-6 min-h-11"
               disabled={actionPending}
-              onClick={onGenerate}
+              onClick={() => onGenerate(preferences)}
             >
               방향 3개 생성
             </Button>
@@ -109,6 +121,13 @@ export function DirectionsView({
           ) : null}
         </header>
 
+        <GenerationStyleFields value={preferences} onChange={setPreferences} disabled={loading || actionPending} />
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+          <p role="status" className="text-xs text-muted-foreground">{preferencesSaving ? "설정을 저장하고 있어요." : preferencesChanged ? "변경한 설정을 저장해 주세요." : "저장된 설정을 다음 생성·수정에 적용해요."} 아래 미리보기는 구성 예시예요.</p>
+          <Button type="button" variant="outline" disabled={loading || actionPending || !preferencesChanged} onClick={() => onSavePreferences(preferences)}>
+            {preferencesSaving ? "저장 중" : "이미지·어투 설정 저장"}
+          </Button>
+        </div>
         {!loading ? <ContentOutline items={state.content_outline} /> : null}
 
         <section

--- a/packages/frontend/src/components/directions/GenerationStyleFields.tsx
+++ b/packages/frontend/src/components/directions/GenerationStyleFields.tsx
@@ -1,0 +1,34 @@
+import { COPY_TONE_PRESETS, IMAGE_STYLE_PRESETS, parseGenerationStyle, type GenerationStyle } from "@bg/shared";
+
+export function GenerationStyleFields({ value, onChange, disabled }: {
+  readonly value: GenerationStyle;
+  readonly onChange: (value: GenerationStyle) => void;
+  readonly disabled: boolean;
+}) {
+  return (
+    <fieldset disabled={disabled} className="mt-6 rounded-xl border border-border bg-card p-4 text-left sm:p-5">
+      <legend className="px-2 text-sm font-semibold">이미지와 문안</legend>
+      <p className="mb-4 text-xs leading-relaxed text-muted-foreground">구성과 별개로 이미지의 표현 방식과 문안의 말투를 정해요. 저장한 설정은 다음 생성·수정부터 적용돼요.</p>
+      <div className="grid gap-5 sm:grid-cols-2">
+        <div>
+          <label htmlFor="direction-image-style" className="text-sm font-medium">이미지 스타일 프리셋</label>
+          <select id="direction-image-style" aria-describedby="direction-image-style-description" value={value.image_style}
+            onChange={(event) => onChange(parseGenerationStyle({ ...value, image_style: event.target.value }))}
+            className="mt-2 min-h-11 w-full rounded-md border border-border bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50">
+            {Object.entries(IMAGE_STYLE_PRESETS).map(([key, preset]) => <option key={key} value={key}>{preset.label}</option>)}
+          </select>
+          <p id="direction-image-style-description" className="mt-2 min-h-10 text-xs leading-relaxed text-muted-foreground">{IMAGE_STYLE_PRESETS[value.image_style].description}</p>
+        </div>
+        <div>
+          <label htmlFor="direction-copy-tone" className="text-sm font-medium">문안 어투</label>
+          <select id="direction-copy-tone" aria-describedby="direction-copy-tone-example" value={value.copy_tone}
+            onChange={(event) => onChange(parseGenerationStyle({ ...value, copy_tone: event.target.value }))}
+            className="mt-2 min-h-11 w-full rounded-md border border-border bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50">
+            {Object.entries(COPY_TONE_PRESETS).map(([key, preset]) => <option key={key} value={key}>{preset.label}</option>)}
+          </select>
+          <p id="direction-copy-tone-example" className="mt-2 min-h-10 text-xs leading-relaxed text-muted-foreground">예시 · {COPY_TONE_PRESETS[value.copy_tone].example}</p>
+        </div>
+      </div>
+    </fieldset>
+  );
+}

--- a/packages/frontend/src/views/ProjectView.tsx
+++ b/packages/frontend/src/views/ProjectView.tsx
@@ -18,6 +18,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
   ArtifactSummary,
   GenerationOptions,
+  GenerationStyle,
   Comment,
   DesignAuditFinding,
   DesignAuditResult,
@@ -54,6 +55,7 @@ import {
   getDesignDirectionState,
   retryDesignDirections,
   selectDesignDirection,
+  saveDirectionPreferences,
   undoDesignDirectionSelection,
 } from "@/api/design-directions";
 import {
@@ -263,7 +265,13 @@ export default function ProjectView() {
   );
 
   const generateDirectionsMutation = useMutation({
-    mutationFn: () => generateDesignDirections(id ?? ""),
+    mutationFn: (preferences: GenerationStyle) => generateDesignDirections(id ?? "", preferences),
+    onMutate: () => setDirectionActionError(null),
+    onSuccess: mergeDirectionCache,
+    onError: setDirectionActionError,
+  });
+  const saveDirectionPreferencesMutation = useMutation({
+    mutationFn: (input: Parameters<typeof saveDirectionPreferences>[1]) => saveDirectionPreferences(id ?? "", input),
     onMutate: () => setDirectionActionError(null),
     onSuccess: mergeDirectionCache,
     onError: setDirectionActionError,
@@ -801,6 +809,7 @@ export default function ProjectView() {
   }, [livePreview?.previewId, livePreview?.path]);
   const directionState = directionQuery.data ?? null;
   const directionActionPending =
+    sendPending || session?.status === "running" || saveDirectionPreferencesMutation.isPending ||
     generateDirectionsMutation.isPending ||
     cancelDirectionsMutation.isPending ||
     retryDirectionsMutation.isPending ||
@@ -1237,12 +1246,18 @@ export default function ProjectView() {
 
         {activeTab?.kind === "directions" && (
           <DirectionsView
+            key={id}
             state={directionState}
             recovering={directionQuery.isLoading}
             actionPending={directionActionPending}
             cancelPending={cancelDirectionsMutation.isPending}
             error={directionError}
-            onGenerate={() => generateDirectionsMutation.mutate()}
+            preferencesSaving={saveDirectionPreferencesMutation.isPending}
+            onGenerate={(preferences) => generateDirectionsMutation.mutate(preferences)}
+            onSavePreferences={(preferences) => {
+              if (directionState === null) return;
+              saveDirectionPreferencesMutation.mutate({ generation_id: directionState.generation_id, expected_selection_revision: directionState.selection_revision, creative_preferences: preferences });
+            }}
             onCancel={() => cancelDirectionsMutation.mutate()}
             onRetry={() => retryDirectionsMutation.mutate()}
             onSelect={(directionId) => {

--- a/packages/shared/src/design-direction.ts
+++ b/packages/shared/src/design-direction.ts
@@ -1,3 +1,4 @@
+import { parseGenerationStyle, type GenerationStyle } from "./generation-style";
 import {
   UpgradeContractError,
   decodeContract,
@@ -30,6 +31,7 @@ export type DesignDirectionSlot = {
 };
 
 export type DesignDirectionState = {
+  readonly creative_preferences?: GenerationStyle;
   readonly schema_version: 1;
   readonly project_id: string;
   readonly session_id: string;
@@ -46,7 +48,7 @@ export type DesignDirectionState = {
 
 export function parseDesignDirectionState(input: unknown): DesignDirectionState {
   const record = decodeContract(input);
-  exact(record, ["schema_version", "project_id", "session_id", "generation_id", "status", "content_outline", "directions", "selected_id", "selection_revision", "selection_history", "error", "updated_at"]);
+  exact(record, ["schema_version", "project_id", "session_id", "generation_id", "status", "content_outline", "directions", "selected_id", "selection_revision", "selection_history", "error", "updated_at"], ["creative_preferences"]);
   if (requiredNumber(record, "schema_version") !== 1) invalid("schema_version");
   const contentOutline = stringArray(record, "content_outline");
   if (contentOutline.length === 0 || contentOutline.length > 12 || contentOutline.some((entry) => entry.trim().length === 0)) invalid("content_outline");
@@ -68,6 +70,7 @@ export function parseDesignDirectionState(input: unknown): DesignDirectionState 
   const status = parseStatus(requiredString(record, "status"));
   validateAggregateStatus(status, directions);
   return {
+    ...(record.creative_preferences === undefined ? {} : { creative_preferences: parseGenerationStyle(record.creative_preferences) }),
     schema_version: 1,
     project_id: requiredString(record, "project_id"),
     session_id: requiredString(record, "session_id"),
@@ -114,5 +117,5 @@ function parseSlotStatus(value: string): DesignDirectionSlotStatus { switch (val
 function parseStatus(value: string): DesignDirectionStatus { switch (value) { case "loading": case "ready": case "partial": case "failed": case "cancelled": return value; default: return invalid("status"); } }
 function nullableString(record: UnknownRecord, key: string): string | null { const value = record[key]; if (value === null) return null; if (typeof value !== "string" || value.length === 0) invalid(key); return value; }
 function nonEmptyStrings(record: UnknownRecord, key: string): readonly string[] { const values = stringArray(record, key); if (values.length === 0 || values.length > 8) invalid(key); return values; }
-function exact(record: UnknownRecord, keys: readonly string[]): void { const allowed = new Set(keys); for (const key of Object.keys(record)) if (!allowed.has(key)) invalid(key); for (const key of keys) if (!(key in record)) throw new UpgradeContractError("missing_required_field", key); }
+function exact(record: UnknownRecord, keys: readonly string[], optional: readonly string[] = []): void { const allowed = new Set([...keys, ...optional]); for (const key of Object.keys(record)) if (!allowed.has(key)) invalid(key); for (const key of keys) if (!(key in record)) throw new UpgradeContractError("missing_required_field", key); }
 function invalid(path: string): never { throw new UpgradeContractError("invalid_field", path); }

--- a/packages/shared/src/generation-style.ts
+++ b/packages/shared/src/generation-style.ts
@@ -1,0 +1,39 @@
+import { decodeContract, UpgradeContractError } from "./contract-parser";
+
+export const IMAGE_STYLE_PRESETS = {
+  brand: { label: "브랜드 기준", description: "선택한 디자인 시스템과 자료에 어울리는 이미지", prompt: "Follow the selected brand and supplied visual references; keep a coherent photographic or illustration treatment." },
+  studio: { label: "스튜디오 제품사진", description: "정돈된 배경, 부드러운 조명, 선명한 제품 디테일", prompt: "Studio product photography with controlled soft lighting, uncluttered backgrounds, accurate materials and crisp product detail." },
+  lifestyle: { label: "라이프스타일 실사", description: "자연광과 실제 사용 장면이 있는 사진", prompt: "Natural-light lifestyle photography showing plausible real usage and environments, with candid compositions and realistic materials." },
+  cinematic: { label: "시네마틱", description: "영화 같은 구도, 깊이감 있는 빛과 분위기", prompt: "Cinematic photography with intentional framing, layered depth and motivated directional lighting; preserve the brand palette." },
+  three_d: { label: "3D 오브젝트", description: "입체적인 형태와 재질을 강조한 렌더 이미지", prompt: "Raster 3D-style object renders with coherent materials, readable silhouettes and physically plausible lighting; do not replace requested images with code-based scenes." },
+  illustration: { label: "에디토리얼 일러스트", description: "핵심 메시지를 설명하는 절제된 일러스트", prompt: "Editorial raster illustration with deliberate shapes, restrained detail and a consistent mark-making style that explains the content." },
+  collage: { label: "페이퍼 콜라주", description: "종이 질감과 오려 붙인 구성을 살린 이미지", prompt: "Paper collage imagery with tactile cut edges, layered paper textures and clear focal hierarchy; use distinct compositions rather than repeating a cutout." },
+} as const;
+
+export const COPY_TONE_PRESETS = {
+  brand: { label: "브랜드 기준", example: "기존 브랜드의 문장과 말투를 이어가요.", prompt: "Follow the supplied brand voice and existing approved wording consistently." },
+  professional: { label: "전문적인 합니다체", example: "필요한 정보를 정확하게 안내합니다.", prompt: "Use clear, precise professional language. In Korean, use consistent 합니다체 with evidence-based claims and no inflated jargon." },
+  friendly: { label: "친근한 해요체", example: "필요한 정보를 쉽게 찾아보세요.", prompt: "Use approachable, natural language. In Korean, use consistent polite 해요체; avoid childish expressions and unrequested slang." },
+  concise: { label: "간결한 브랜드 카피", example: "필요한 정보. 한눈에, 정확하게.", prompt: "Use concise, concrete brand copy with short headlines and direct calls to action. Keep necessary explanations complete rather than making every sentence a fragment." },
+  energetic: { label: "활기찬 제안형", example: "지금, 새로운 가능성을 만나보세요.", prompt: "Use energetic, action-oriented invitations with clear benefits; avoid excessive exclamation marks, fake urgency and unsupported promises." },
+  calm: { label: "차분한 설명형", example: "선택에 필요한 내용을 차근차근 살펴보세요.", prompt: "Use calm, measured explanations with a consistent polite register, concrete details and unhurried transitions; avoid pressure and ornate filler." },
+} as const;
+
+export type GenerationStyle = {
+  readonly schema_version: 1;
+  readonly image_style: keyof typeof IMAGE_STYLE_PRESETS;
+  readonly copy_tone: keyof typeof COPY_TONE_PRESETS;
+};
+
+export const DEFAULT_GENERATION_STYLE: GenerationStyle = { schema_version: 1, image_style: "brand", copy_tone: "brand" };
+
+export function parseGenerationStyle(input: unknown): GenerationStyle {
+  const record = decodeContract(input);
+  for (const key of Object.keys(record)) if (!["schema_version", "image_style", "copy_tone"].includes(key)) throw new UpgradeContractError("invalid_field", key);
+  if (record.schema_version !== 1) throw new UpgradeContractError("invalid_field", "schema_version");
+  const imageStyle = record.image_style;
+  const copyTone = record.copy_tone;
+  if (typeof imageStyle !== "string" || !Object.hasOwn(IMAGE_STYLE_PRESETS, imageStyle)) throw new UpgradeContractError("invalid_field", "image_style");
+  if (typeof copyTone !== "string" || !Object.hasOwn(COPY_TONE_PRESETS, copyTone)) throw new UpgradeContractError("invalid_field", "copy_tone");
+  return { schema_version: 1, image_style: imageStyle as GenerationStyle["image_style"], copy_tone: copyTone as GenerationStyle["copy_tone"] };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -33,3 +33,4 @@ export * from "./ux-review";
 export * from "./security";
 export * from "./updates";
 export type { VercelDeployment } from "./vercel";
+export * from "./generation-style";

--- a/scripts/qa/creation-canvas-fixtures.mjs
+++ b/scripts/qa/creation-canvas-fixtures.mjs
@@ -20,6 +20,37 @@ export async function runCreationCanvasFixtures(page, base, scenario, { home, sh
   };
   await page.route(eventPattern, guard);
   try {
+    await scenario("creation-canvas-generation-style", async () => {
+      const fixture = await createFixture(page, base, ownedHome, "Generation style fixture");
+      await page.getByRole("button", { name: "방향 정하기", exact: true }).click();
+      const imageStyle = page.getByLabel("이미지 스타일 프리셋", { exact: true });
+      const copyTone = page.getByLabel("문안 어투", { exact: true });
+      await imageStyle.selectOption("studio");
+      await copyTone.selectOption("friendly");
+      const generated = page.waitForResponse(response => response.url().endsWith("/design-directions/generate") && response.request().method() === "POST");
+      await page.getByRole("button", { name: "방향 3개 생성", exact: true }).click();
+      const response = await generated;
+      assert.equal(response.status(), 202);
+      assert.deepEqual(response.request().postDataJSON(), { schema_version: 1, image_style: "studio", copy_tone: "friendly" });
+      await page.getByText("3개 방향이 모두 준비됐어요. 비교한 뒤 하나를 선택하세요.", { exact: true }).waitFor();
+      await imageStyle.selectOption("collage");
+      await copyTone.selectOption("professional");
+      const saved = page.waitForResponse(item => item.url().endsWith("/design-directions/preferences") && item.request().method() === "POST");
+      await page.getByRole("button", { name: "이미지·어투 설정 저장", exact: true }).click();
+      assert.equal((await saved).status(), 200);
+      await page.reload({ waitUntil: "domcontentloaded" });
+      await page.getByRole("button", { name: "방향 정하기", exact: true }).click();
+      await imageStyle.waitFor();
+      assert.equal(await imageStyle.inputValue(), "collage");
+      assert.equal(await copyTone.inputValue(), "professional");
+      const persisted = await page.request.get(`${base}/api/projects/${fixture.id}/design-directions`);
+      assert.deepEqual((await persisted.json()).data.creative_preferences, { schema_version: 1, image_style: "collage", copy_tone: "professional" });
+      await page.setViewportSize({ width: 680, height: 900 });
+      assert.ok(await imageStyle.isVisible());
+      assert.ok(await copyTone.isVisible());
+      await shot(page, "creation-canvas-generation-style");
+    });
+
     await scenario("creation-canvas-live-preview", async () => {
       await page.addInitScript(() => {
         const Native = window.EventSource;


### PR DESCRIPTION
## Changes
The Design Direction screen now lets users choose an image style preset and copy tone independently of the three layout directions. Image styles include brand default, studio product photography, lifestyle, cinematic, 3D objects, editorial illustration and paper collage. Tone choices include brand default, professional, friendly, concise, energetic and calm, with Korean examples.

Choices are saved with direction generation, can be updated afterward, and survive reopening, selection/undo and regeneration. The existing durable direction event and revision checks prevent stale saves. Full and compact generation prompts receive the selected treatment and tone, while preserving facts, verbatim copy, brand tokens and the existing Codex image-generation rules. Existing files change only when the user requests generation or editing. Direction thumbnails remain layout examples.

## Validation
- 53 focused tests passed; one Windows symlink case skipped because this host cannot create symlinks.
- Root typecheck, frontend production build and lint passed.
- Browser smoke passed against an isolated real backend: select presets, generate directions, save changed preferences, reload and verify persisted choices. The 680px layout was visually inspected. Provider turns were guarded against execution; this verifies settings delivery and persistence, not a live image-generation result.

No new provider integration or dependency. This PR does not publish a release.
