### PR TITLE
fix: align token usage footer with the chat scroll edge

### DIFF
--- a/packages/frontend/src/components/chat/MessageStream.tsx
+++ b/packages/frontend/src/components/chat/MessageStream.tsx
@@ -67,7 +67,7 @@ export default function MessageStream({
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className="chat-scroll absolute inset-0 space-y-4 overflow-y-auto px-4 py-5"
+        className="chat-scroll absolute inset-0 space-y-4 overflow-y-auto px-4 pt-5"
       >
         {groups.length === 0 && (
           <div className="py-4">

--- a/packages/frontend/src/components/chat/blocks/UsageFooter.tsx
+++ b/packages/frontend/src/components/chat/blocks/UsageFooter.tsx
@@ -16,7 +16,7 @@ export default function UsageFooter({
     <div
       data-qa="usage-footer"
       title={`입력 ${exact(usage.input)} · 출력 ${exact(usage.output)} · 캐시 ${exact(usage.cached)} 토큰`}
-      className="sticky bottom-0 -mx-4 -mb-5 flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-border bg-background/95 px-4 py-2 text-[10px] text-muted-foreground backdrop-blur"
+      className="sticky bottom-0 -mx-4 flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-border bg-background/95 px-4 py-2 text-[10px] text-muted-foreground backdrop-blur"
     >
       <span>입력 {compact(usage.input)}</span>
       <span>출력 {compact(usage.output)}</span>


### PR DESCRIPTION
## Summary

The token usage footer (`입력 / 출력 / 캐시`) in the chat pane sat 20px above the bottom edge of the message scroll area, and scrolled messages showed through the strip beneath it, so it looked detached from the composer overlay.

**Root cause.** `UsageFooter` is `sticky bottom-0` and relied on `-mb-5` to bleed into the scroll container's bottom padding (`py-5`). The container's `space-y-4` utility (`> :not([hidden]) ~ :not([hidden])`, specificity 0,3,0) also sets `margin-bottom`, which overrides the footer's `-mb-5` (0,1,0). Sticky positioning then pins the footer to the padding-excluded content edge, leaving the 20px padding strip visible below it with content scrolling through.

**Fix.** Two class-name changes, nothing else:

- `MessageStream.tsx`: scroll container `py-5` → `pt-5` (bottom padding is no longer needed; the footer's own `space-y-4` margin-top keeps the last message separated from it).
- `UsageFooter.tsx`: drop the dead `-mb-5`.

## Verification

- Reproduced the layout in a standalone page with the same Tailwind v3 class structure. Before the fix: footer computed `margin-bottom: 0px` and a 20px gap to the scrollport bottom while scrolled. After the fix: gap 0px at top, mid-scroll, and bottom; left/right edges aligned with the scroll container.
- `bun run --cwd packages/frontend typecheck` passes.

## Test plan

- [ ] Open a project with a running session and scroll the chat; the usage footer should stay flush with the bottom edge of the message area, directly above the design-direction status bar.
- [ ] Confirm no message content is visible beneath the footer while scrolling.
- [ ] Empty session (no messages): footer still sits at the bottom of the message area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
